### PR TITLE
BUILD-8317 Create a new GitHub action to support building MAVEN workloads

### DIFF
--- a/.shellspec
+++ b/.shellspec
@@ -1,5 +1,5 @@
 # kcov (coverage) options
---kcov-options "--include-pattern=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-npm"
+--kcov-options "--include-pattern=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-npm,build-maven"
 # --kcov-options "--exclude-pattern=.github,.idea,.git"
 
 # define minimum coverage (fail otherwise)

--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -15,6 +15,7 @@
 # - DEPLOY_PULL_REQUEST: whether to deploy pull request artifacts (default: false)
 # - SKIP_TESTS: whether to skip running tests (default: false)
 # - GRADLE_ARGS: additional arguments to pass to Gradle
+# - GITHUB_RUN_ID: GitHub workflow run ID. Unique per workflow run, but unchanged on re-runs.
 
 set -euo pipefail
 

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -1,0 +1,111 @@
+---
+name: Build Maven
+description: GitHub Action to build, analyze, and deploy a Maven project
+inputs:
+  public:
+    description: Whether to build and deploy with/to public repositories. Defaults to `true` for public repositories (OSS), and `false` for
+      private repositories.
+    default: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}
+  artifactory-reader-role:
+    description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories, and `public-reader`
+      for public repositories.
+    default: ''
+  artifactory-deployer-role:
+    description: Suffix for the Artifactory deployer role in Vault. Defaults to `qa-deployer` for private repositories, and
+      `public-deployer` for public repositories.
+    default: ''
+  deploy-pull-request:
+    description: Whether to deploy pull request artifacts. Set to `false` if not using the promote action.
+    default: 'false'
+  maven-local-repository-path:
+    description: Path to the Maven cache directory, relative to the user home directory.
+    default: .m2/repository
+  maven-opts:
+    description: Additional Maven options to pass to the build script (`MAVEN_OPTS`).
+    default: -Xmx1536m -Xms128m
+  scanner-java-opts:
+    description: Additional Java options for the Sonar scanner (`SONAR_SCANNER_JAVA_OPTS`).
+    default: -Xmx512m
+  use-develocity:
+    description: Whether to use Develocity for build tracking.
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Set build parameters
+      shell: bash
+      env:
+        ARTIFACTORY_READER_ROLE: ${{ inputs.artifactory-reader-role != '' && inputs.artifactory-reader-role ||
+          (inputs.public == 'true' && 'public-reader' || 'private-reader') }}
+        ARTIFACTORY_DEPLOYER_ROLE: ${{ inputs.artifactory-deployer-role != '' && inputs.artifactory-deployer-role ||
+          (inputs.public == 'true' && 'public-deployer' || 'qa-deployer') }}
+      run: |
+        echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
+        echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
+    - name: Cache local Maven repository
+      uses: SonarSource/ci-github-actions/cache@master
+      with:
+        path: ~/${{ inputs.maven-local-repository-path }}
+        key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: maven-${{ runner.os }}-
+    - name: Vault
+      # yamllint disable rule:line-length
+      id: secrets
+      uses: SonarSource/vault-action-wrapper@d6d745ffdbc82b040df839b903bc33b5592cd6b0 # 3.0.2
+      with:
+        secrets: |
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} access_token | ARTIFACTORY_ACCESS_TOKEN;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} username | ARTIFACTORY_DEPLOY_USERNAME;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} access_token | ARTIFACTORY_DEPLOY_PASSWORD;
+          development/kv/data/next url | SONAR_HOST_URL;
+          development/kv/data/next token | SONAR_TOKEN;
+          development/kv/data/sign key | SIGN_KEY;
+          development/kv/data/sign passphrase | PGP_PASSPHRASE;
+          development/kv/data/develocity token | DEVELOCITY_TOKEN;
+          ${{ inputs.use-develocity == 'true' && 'development/kv/data/develocity token | DEVELOCITY_TOKEN;' || '' }}
+      # yamllint enable rule:line-length
+    - name: Maven configuration
+      shell: bash
+      env:
+        PUBLIC_BUILD: ${{ inputs.public }}
+      run: |
+        MAVEN_CONFIG="$HOME/.m2"
+        mkdir -p "$MAVEN_CONFIG"
+        if [[ "${PUBLIC_BUILD}" == "true" ]]; then
+          echo "Setting up public Maven settings"
+          cp "${GITHUB_ACTION_PATH}/resources/settings-public-auth.xml" "$MAVEN_CONFIG/settings.xml"
+        else
+          echo "Setting up private Maven settings"
+          cp "${GITHUB_ACTION_PATH}/resources/settings-private.xml" "$MAVEN_CONFIG/settings.xml"
+        fi
+        MAVEN_LOCAL_REPOSITORY="$HOME/${{ inputs.maven-local-repository-path }}"
+        mkdir -p "$MAVEN_LOCAL_REPOSITORY"
+        echo "MAVEN_LOCAL_REPOSITORY=${MAVEN_LOCAL_REPOSITORY}" >> "$GITHUB_ENV"
+    - name: Build, Analyze and deploy
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.public == 'true' && 'sonarsource-public-qa' || 'sonarsource-private-qa' }}
+        ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
+        ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
+        SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_HOST_URL }}
+        SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
+        SIGN_KEY: ${{ fromJSON(steps.secrets.outputs.vault).SIGN_KEY }}
+        PGP_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).PGP_PASSPHRASE }}
+        DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
+        PULL_REQUEST: ${{ github.event.pull_request.number || '' }}
+        DEVELOCITY_ACCESS_KEY: ${{ inputs.use-develocity == 'true' &&
+          format('develocity.sonar.build={0}', fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN) || '' }}
+        MAVEN_OPTS: ${{ inputs.maven-opts }}
+        SONAR_SCANNER_JAVA_OPTS: ${{ inputs.scanner-java-opts }}
+      run: |
+        ${GITHUB_ACTION_PATH}/build.sh
+    - name: Cleanup Maven repository before caching
+      shell: bash
+      run: |
+        rm -rf "$MAVEN_LOCAL_REPOSITORY/org/sonarsource/"
+        rm -rf "$MAVEN_LOCAL_REPOSITORY/repository/com/sonarsource/"
+        /usr/bin/find "$MAVEN_LOCAL_REPOSITORY" -name resolver-status.properties -delete

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# Build and deploy a Maven project.
+# Environment variables:
+# - ARTIFACTORY_URL: Repox URL.
+# - ARTIFACTORY_DEPLOY_REPO: Deployment repository (sonarsource-public-qa or sonarsource-private-qa)
+# - ARTIFACTORY_DEPLOY_PASSWORD: Access token to deploy to the repository
+# - ARTIFACTORY_ACCESS_TOKEN: Access token to access the private repository
+# - ARTIFACTORY_DEPLOY_USERNAME: used by artifactory-maven-plugin
+# - DEFAULT_BRANCH: Default branch (e.g. main)
+# - PULL_REQUEST: Pull request number (e.g. 1234), if applicable.
+# - GITHUB_REF_NAME: Short ref name of the branch or tag (e.g. main, branch-123, dogfood-on-123)
+# - GITHUB_BASE_REF: Base branch of the pull request (e.g. main, branch-123), if applicable.
+# - BUILD_NUMBER: Build number (e.g. 42)
+# - GITHUB_RUN_ID: GitHub workflow run ID. Unique per workflow run, but unchanged on re-runs.
+# - GITHUB_EVENT_NAME: Event name (e.g. push, pull_request)
+# - GITHUB_REPOSITORY: Repository name (e.g. sonarsource/sonar-dummy-maven)
+# - MAVEN_OPTS: Optional JVM options for Maven (e.g. -Xmx1536m -Xms128m)
+# - SONAR_SCANNER_JAVA_OPTS: Optional JVM options for SonarQube scanner (e.g. -Xmx512m)
+# - DEPLOY_PULL_REQUEST: whether to deploy pull request artifacts (default: false)
+# - SONAR_HOST_URL: URL of SonarQube server
+# - SONAR_TOKEN: access token to send analysis reports to SonarQube
+# - ARTIFACTORY_PUBLISH_ARTIFACTS: NOT IMPLEMENTED
+# shellcheck source-path=SCRIPTDIR
+
+set -euo pipefail
+
+: "${ARTIFACTORY_URL:="https://repox.jfrog.io/artifactory"}"
+# Required by maven-enforcer-plugin in SonarSource parent POM
+: "${ARTIFACTORY_DEPLOY_REPO:?}" "${ARTIFACTORY_DEPLOY_USERNAME:?}" "${ARTIFACTORY_DEPLOY_PASSWORD:?}" "${ARTIFACTORY_ACCESS_TOKEN:?}"
+: "${GITHUB_REF_NAME:?}" "${BUILD_NUMBER:?}" "${GITHUB_RUN_ID:?}" "${GITHUB_REPOSITORY:?}" "${GITHUB_EVENT_NAME:?}"
+: "${PULL_REQUEST?}" "${DEFAULT_BRANCH:?}"
+: "${SONAR_HOST_URL:?}" "${SONAR_TOKEN:?}"
+: "${DEPLOY_PULL_REQUEST:=false}"
+export ARTIFACTORY_URL DEPLOY_PULL_REQUEST
+
+# FIXME Workaround for SonarSource parent POM; it can be removed after releases of parent 73+ and parent-oss 84+
+export BUILD_ID=$BUILD_NUMBER
+
+# SonarQube parameters
+: "${SCANNER_VERSION:=5.1.0.4751}"
+readonly SONAR_GOAL="org.sonarsource.scanner.maven:sonar-maven-plugin:${SCANNER_VERSION}:sonar"
+
+# Check if a command is available and runs it, typically: 'some_tool --version'
+check_tool() {
+  if ! command -v "$1"; then
+    echo "$1 is not installed." >&2
+    return 1
+  fi
+  "$@"
+}
+
+is_main_branch() {
+  [[ "$GITHUB_REF_NAME" == "$DEFAULT_BRANCH" ]]
+}
+
+is_maintenance_branch() {
+  [[ "${GITHUB_REF_NAME}" == branch-* ]]
+}
+
+is_pull_request() {
+  [[ "$GITHUB_EVENT_NAME" == pull_request ]]
+}
+
+is_dogfood_branch() {
+  [[ "${GITHUB_REF_NAME}" == dogfood-on-* ]]
+}
+
+is_feature_branch() {
+  [[ "${GITHUB_REF_NAME}" == feature/long/* ]]
+}
+
+# Unshallow and fetch all commit history for SonarQube analysis and issue assignment
+git_fetch_unshallow() {
+  # The --filter=blob:none flag significantly speeds up the download
+  if git rev-parse --is-shallow-repository --quiet >/dev/null 2>&1; then
+    echo "Fetch Git references for SonarQube analysis..."
+    git fetch --unshallow --filter=blob:none
+  elif is_pull_request; then
+    echo "Fetch ${GITHUB_BASE_REF:?} for SonarQube analysis..."
+    git fetch --filter=blob:none origin "${GITHUB_BASE_REF}"
+  fi
+}
+
+# Evaluate a Maven property/expression with org.codehaus.mojo:exec-maven-plugin
+maven_expression() {
+  mvn -q -Dexec.executable="echo" -Dexec.args="\${$1}" --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec
+}
+
+# Set the project version as <MAJOR>.<MINOR>.<PATCH>.<BUILD_NUMBER>
+# Update current_version variable with the current project version.
+# Then remove the -SNAPSHOT suffix if present, complete with '.0' if needed, and append the build number at the end.
+set_project_version() {
+  local current_version
+  if ! current_version=$(maven_expression "project.version" 2>&1); then
+    echo -e "::error file=pom.xml,title=Maven project version::Could not get 'project.version' from Maven project\nERROR: $current_version"
+    return 1
+  fi
+
+  local release_version="${current_version%"-SNAPSHOT"}"
+  local digits="${release_version//[^.]/}"
+  local digit_count="${#digits}"
+
+  # shellcheck disable=SC2035
+  if is_maintenance_branch && [[ "$current_version" != *"-SNAPSHOT" ]]; then
+    echo "Found RELEASE version on maintenance branch: $current_version"
+    if [[ "$digit_count" -ne 3 ]]; then
+      echo "::error file=pom.xml,title=Maven project version::Unsupported version '$current_version' with $((digit_count+1)) digits."
+      return 1
+    fi
+    echo "Skipping version update."
+    export PROJECT_VERSION=$current_version
+    return 0
+  fi
+
+  if [[ "$digit_count" -eq 0 ]]; then
+    release_version="${release_version}.0.0"
+  elif [[ "$digit_count" -eq 1 ]]; then
+    release_version="${release_version}.0"
+  elif [[ "$digit_count" -ne 2 ]]; then
+    echo "::error file=pom.xml,title=Maven project version::Unsupported version '$current_version' with $((digit_count+1)) digits."
+    return 1
+  fi
+  local new_version="${release_version}.${BUILD_NUMBER}"
+
+  echo "Replacing version $current_version with $new_version"
+  mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion="$new_version" -DgenerateBackupPoms=false -B -e
+  export PROJECT_VERSION=$new_version
+}
+
+build_maven() {
+  check_tool mvn --version
+  git_fetch_unshallow
+
+  set_project_version
+
+  local maven_command_args
+  local sonar_props=("-Dsonar.host.url=${SONAR_HOST_URL}" "-Dsonar.token=${SONAR_TOKEN}")
+  sonar_props+=("-Dsonar.projectVersion=$PROJECT_VERSION" "-Dsonar.scm.revision=$GITHUB_SHA")
+
+  if is_main_branch || is_maintenance_branch; then
+    echo "======= Build, deploy and analyze $GITHUB_REF_NAME ======="
+    maven_command_args=("deploy" "$SONAR_GOAL" "-Pcoverage,deploy-sonarsource,release,sign" "${sonar_props[@]}")
+
+  elif is_pull_request; then
+    echo "======= Build and analyze pull request $PULL_REQUEST ($GITHUB_HEAD_REF) ======="
+    sonar_props+=("-Dsonar.pullrequest.key=$PULL_REQUEST")
+    sonar_props+=("-Dsonar.pullrequest.branch=$GITHUB_HEAD_REF")
+    sonar_props+=("-Dsonar.pullrequest.base=$GITHUB_BASE_REF")
+
+    if [[ "$DEPLOY_PULL_REQUEST" == "true" ]]; then
+      echo "======= with deploy ======="
+      maven_command_args=("deploy" "$SONAR_GOAL" "-Pcoverage,deploy-sonarsource" "${sonar_props[@]}")
+    else
+      echo "======= no deploy ======="
+      maven_command_args=("verify" "$SONAR_GOAL" "-Pcoverage" "${sonar_props[@]}")
+    fi
+
+  elif is_dogfood_branch; then
+    echo "======= Build, and deploy dogfood branch $GITHUB_REF_NAME ======="
+    maven_command_args=("deploy" "-Pdeploy-sonarsource,release")
+
+  elif is_feature_branch; then
+    echo "======= Build and analyze long lived feature branch $GITHUB_REF_NAME ======="
+    maven_command_args=("verify" "$SONAR_GOAL" "-Pcoverage" "${sonar_props[@]}")
+
+  else
+    echo "======= Build, no analysis, no deploy $GITHUB_REF_NAME ======="
+    maven_command_args=("verify")
+  fi
+
+  readonly COMMON_MVN_FLAGS=("-Dmaven.test.redirectTestOutputToFile=false" "-B" "-e" "-V")
+  echo "Maven command: mvn ${maven_command_args[*]} ${COMMON_MVN_FLAGS[*]} $*"
+  mvn "${maven_command_args[@]}" "${COMMON_MVN_FLAGS[@]}" "$@"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  build_maven "$@"
+fi

--- a/build-maven/resources/settings-private.xml
+++ b/build-maven/resources/settings-private.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <localRepository>${env.MAVEN_LOCAL_REPOSITORY}</localRepository>
+  <servers>
+    <server>
+      <id>sonarsource</id>
+      <configuration>
+        <httpHeaders>
+          <property>
+            <name>Authorization</name>
+            <value>Bearer ${env.ARTIFACTORY_ACCESS_TOKEN}</value>
+          </property>
+        </httpHeaders>
+      </configuration>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>sonarsource-repo</id>
+      <activation>
+        <property>
+          <name>!skip-sonarsource-repo</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>sonarsource</id>
+          <name>SonarSource Central Repository</name>
+          <url>https://repox.jfrog.io/artifactory/sonarsource-qa</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>interval:60</updatePolicy>
+            <checksumPolicy>fail</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>sonarsource</id>
+          <name>SonarSource Central Repository</name>
+          <url>https://repox.jfrog.io/artifactory/sonarsource-qa</url>
+          <releases>
+            <enabled>true</enabled>
+            <!-- no need to always check if new versions are available when executing a Maven plugin without specifying the version -->
+            <updatePolicy>interval:60</updatePolicy>
+            <checksumPolicy>fail</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/build-maven/resources/settings-public-auth.xml
+++ b/build-maven/resources/settings-public-auth.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <localRepository>${env.MAVEN_LOCAL_REPOSITORY}</localRepository>
+  <servers>
+    <server>
+      <id>sonarsource</id>
+      <configuration>
+        <httpHeaders>
+          <property>
+            <name>Authorization</name>
+            <value>Bearer ${env.ARTIFACTORY_ACCESS_TOKEN}</value>
+          </property>
+        </httpHeaders>
+      </configuration>
+    </server>
+  </servers>
+  <profiles>
+    <profile>
+      <id>sonarsource-repo</id>
+      <activation>
+        <property>
+          <name>!skip-sonarsource-repo</name>
+        </property>
+      </activation>
+      <repositories>
+        <repository>
+          <id>sonarsource</id>
+          <name>SonarSource Central Repository</name>
+          <url>https://repox.jfrog.io/artifactory/sonarsource</url>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>interval:60</updatePolicy>
+            <checksumPolicy>fail</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>sonarsource</id>
+          <name>SonarSource Central Repository</name>
+          <url>https://repox.jfrog.io/artifactory/sonarsource</url>
+          <releases>
+            <enabled>true</enabled>
+            <!-- no need to always check if new versions are available when executing a Maven plugin without specifying the version -->
+            <updatePolicy>interval:60</updatePolicy>
+            <checksumPolicy>fail</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: ''
   deploy-pull-request:
     description: Whether to deploy pull request artifacts. Set to `false` if not using the promote action.
-    default: 'true'
+    default: 'false'
   poetry-virtualenvs-path:
     description: Path to the Poetry virtual environments, relative to GitHub workspace. The folder is cached only if it is a subdirectory of
       `poetry-cache-dir`.

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -21,8 +21,8 @@ set -euo pipefail
 : "${GITHUB_REF_NAME:?}" "${BUILD_NUMBER:?}" "${GITHUB_REPOSITORY:?}" "${GITHUB_EVENT_NAME:?}" "${GITHUB_EVENT_PATH:?}"
 : "${GITHUB_ENV:?}" # "${GITHUB_OUTPUT:?}"
 
+# Check if a command is available and runs it, typically: 'some_tool --version'
 check_tool() {
-  # Check if a command is available and runs it, typically: 'some_tool --version'
   if ! command -v "$1"; then
     echo "$1 is not installed." >&2
     return 1
@@ -38,6 +38,7 @@ set_build_env() {
 
   if [[ "$GITHUB_EVENT_NAME" = "pull_request" ]]; then
     PULL_REQUEST=$(jq --raw-output .number "$GITHUB_EVENT_PATH")
+    # FIXME Unused? otherwise, it should be '.pull_request.head.sha' (not base.sha)
     PULL_REQUEST_SHA=$(jq --raw-output .pull_request.base.sha "$GITHUB_EVENT_PATH")
   else
     PULL_REQUEST=false
@@ -91,7 +92,7 @@ jfrog_poetry_publish() {
     --overwrite # avoid duplicate builds on re-runs
 }
 
-build-poetry() {
+build_poetry() {
   check_tool jq --version
   check_tool python --version
   check_tool poetry --version
@@ -124,5 +125,5 @@ build-poetry() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  build-poetry
+  build_poetry
 fi

--- a/promote/promote.sh
+++ b/promote/promote.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 : "${GITHUB_REF_NAME:?}" "${BUILD_NUMBER:?}" "${GITHUB_REPOSITORY:?}" "${GITHUB_EVENT_NAME:?}" "${GITHUB_EVENT_PATH:?}" "${GITHUB_TOKEN:?}"
 : "${GITHUB_SHA:?}"
 GH_API_VERSION_HEADER="X-GitHub-Api-Version: 2022-11-28"
-BUILD_INFO_FILE=".build-info"
+BUILD_INFO_FILE=$(mktemp)
 rm -f "$BUILD_INFO_FILE"
 
 : "${MULTI_REPO_PROMOTE:=false}"
@@ -179,6 +179,7 @@ jfrog_promote() {
 }
 
 promote() {
+  check_tool gh --version
   check_tool jq --version
   check_tool jf --version
   set_build_env

--- a/run_shell_tests.sh
+++ b/run_shell_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 LANG=
-shellspec --kcov "**/spec"
+shellspec --kcov spec "$@"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.projectName=ci-github-actions
 
 sonar.sourceEncoding=UTF-8
 
-sonar.sources=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-npm
+sonar.sources=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-npm,build-maven
 sonar.tests=spec
 
 sonar.coverageReportPaths=coverage/coverage_data/sonar_coverage.xml

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -36,7 +36,7 @@ export GITHUB_OUTPUT=/dev/null
 export ARTIFACTORY_DEPLOY_REPO="test-repo"
 export ARTIFACTORY_DEPLOY_USERNAME="test-user"
 export ARTIFACTORY_DEPLOY_PASSWORD="test-pass"
-export SONAR_HOST_URL="https://sonar.example.com"
+export SONAR_HOST_URL="https://sonar.dummy"
 export SONAR_TOKEN="test-token"
 export ORG_GRADLE_PROJECT_signingKey="test-key"
 export ORG_GRADLE_PROJECT_signingPassword="test-pass"
@@ -234,7 +234,7 @@ Describe 'build_gradle_args'
 
   It 'should add sonar arguments when SONAR_HOST_URL and SONAR_TOKEN are set'
     export SKIP_TESTS="false"
-    export SONAR_HOST_URL="https://sonar.example.com"
+    export SONAR_HOST_URL="https://sonar.dummy"
     export SONAR_TOKEN="sonar-token"
     export GRADLE_ARGS=""
     export PULL_REQUEST="false"
@@ -242,7 +242,7 @@ Describe 'build_gradle_args'
 
     When call build_gradle_args
     The line 1 should include "sonar"
-    The line 1 should include "-Dsonar.host.url=https://sonar.example.com"
+    The line 1 should include "-Dsonar.host.url=https://sonar.dummy"
     The line 1 should include "-Dsonar.token=sonar-token"
     The line 1 should include "-Dsonar.analysis.buildNumber=42"
     The line 1 should include "-Dsonar.analysis.pipeline=12345"

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+eval "$(shellspec - -c) exit 1"
+
+Mock mvn
+  case "$*" in
+    *"project.version"*) echo "1.2.3-SNAPSHOT" ;;
+    *"versions:set"*) echo "mvn $*" ;;
+    *) echo "mvn $*" ;;
+  esac
+End
+
+Mock git
+  echo "git $*"
+End
+
+Mock gh
+  echo "gh $*"
+End
+
+# Set required environment variables
+export GITHUB_ENV=/dev/null
+export ARTIFACTORY_URL="https://dummy.repox"
+export ARTIFACTORY_DEPLOY_REPO="deploy-repo-qa"
+export ARTIFACTORY_DEPLOY_USERNAME="deploy-user"
+export ARTIFACTORY_DEPLOY_PASSWORD="deploy-password"
+export ARTIFACTORY_ACCESS_TOKEN="access-token"
+export GITHUB_REPOSITORY="sonarsource/test-repo"
+export DEFAULT_BRANCH="def_main"
+export GITHUB_REF_NAME="a-branch"
+export GITHUB_EVENT_NAME="push"
+export BUILD_NUMBER="42"
+export PULL_REQUEST=""
+export SONAR_HOST_URL="https://sonarqube"
+export SONAR_TOKEN="sonar-token"
+export GITHUB_SHA="abc123def456"
+export GITHUB_RUN_ID="123456789"
+
+Describe 'build.sh'
+  It 'does not run build_maven() if the script is sourced'
+    When run source build-maven/build.sh
+    The status should be success
+    The output should equal ""
+  End
+
+  It 'runs build_maven()'
+    When run script build-maven/build.sh
+    The status should be success
+      The lines of stdout should equal 9
+      The line 1 should include "mvn"
+      The line 2 should include "mvn"
+      The line 3 should include "Fetch Git references"
+      The line 4 should include "git fetch"
+      The line 5 should include "Replacing version 1.2.3-SNAPSHOT with 1.2.3.42"
+      The line 6 should match pattern "mvn org.codehaus.mojo:versions-maven-plugin*newVersion=1.2.3.42*"
+      The line 7 should include "Build, no analysis, no deploy"
+      The line 8 should include "Maven command: mvn verify"
+      The line 9 should include "mvn verify -Dmaven.test.redirectTestOutputToFile=false -B -e -V"
+  End
+End
+
+Include build-maven/build.sh
+
+Describe 'check_tool()'
+  It 'reports not installed tool'
+    When call check_tool some_tool
+    The status should be failure
+    The error should equal "some_tool is not installed."
+  End
+End
+
+Describe 'git_fetch_unshallow()'
+  It 'fetches unshallow repository'
+    When call git_fetch_unshallow
+    The lines of stdout should equal 2
+    The line 1 should start with "Fetch Git references"
+    The line 2 should equal "git fetch --unshallow --filter=blob:none"
+  End
+
+  It 'fallbacks and fetches base branch for pull request'
+    export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_BASE_REF="def_main"
+    Mock git
+      case "$*" in
+        *"rev-parse --is-shallow-repository"*) return 0;;
+        *) echo "git $*" ;;
+      esac
+    End
+    When call git_fetch_unshallow
+    The lines of stdout should equal 2
+    The line 1 should start with "Fetch def_main"
+    The line 2 should equal "git fetch --filter=blob:none origin def_main"
+  End
+End
+
+Describe 'maven_expression()'
+  It 'extracts project version'
+    When call maven_expression "project.version"
+    The output should equal "1.2.3-SNAPSHOT"
+  End
+End
+
+Describe 'set_project_version()'
+  export GITHUB_REF_NAME="branch-1"
+
+  It 'converts SNAPSHOT version to build version'
+    When call set_project_version
+    The lines of stdout should equal 2
+    The line 1 should include "Replacing version 1.2.3-SNAPSHOT with 1.2.3.42"
+    The line 2 should match pattern "mvn org.codehaus.mojo:versions-maven-plugin*newVersion=1.2.3.42*"
+    The variable PROJECT_VERSION should equal "1.2.3.42"
+  End
+
+  It 'handles 1-digit version by adding .0.0'
+    Mock mvn
+      case "$*" in
+        *"project.version"*) echo "1-SNAPSHOT" ;;
+        *) echo "mvn $*" ;;
+      esac
+    End
+    When call set_project_version
+    The lines of stdout should equal 2
+    The line 1 should include "Replacing version 1-SNAPSHOT with 1.0.0.42"
+    The variable PROJECT_VERSION should equal "1.0.0.42"
+  End
+
+  It 'handles 2-digit version by adding .0'
+    Mock mvn
+      case "$*" in
+        *"project.version"*) echo "1.2-SNAPSHOT" ;;
+        *) echo "mvn $*" ;;
+      esac
+    End
+    When call set_project_version
+    The lines of stdout should equal 2
+    The line 1 should include "Replacing version 1.2-SNAPSHOT with 1.2.0.42"
+    The variable PROJECT_VERSION should equal "1.2.0.42"
+  End
+
+  It 'fails on not compliant version'
+    Mock mvn
+      case "$*" in
+        *"project.version"*) echo "1.2.3.4-SNAPSHOT" ;;
+        *) echo "mvn $*" ;;
+      esac
+    End
+    When call set_project_version
+    The status should be failure
+    The lines of stdout should equal 1
+    The line 1 should include "Unsupported version '1.2.3.4-SNAPSHOT' with 4 digits"
+    The variable PROJECT_VERSION should be undefined
+  End
+
+  It 'handles non-SNAPSHOT version'
+    Mock mvn
+      case "$*" in
+        *"project.version"*) echo "1.2.3.42" ;;
+        *) echo "mvn $*" ;;
+      esac
+    End
+    When call set_project_version
+    The lines of stdout should equal 2
+    The line 1 should include "Found RELEASE version on maintenance branch"
+    The line 2 should include "Skipping version update"
+    The variable PROJECT_VERSION should equal "1.2.3.42"
+  End
+
+  It 'fails on not compliant non-SNAPSHOT version'
+    Mock mvn
+      case "$*" in
+        *"project.version"*) echo "1.2.3" ;;
+        *) echo "mvn $*" ;;
+      esac
+    End
+    When call set_project_version
+    The status should be failure
+    The lines of stdout should equal 2
+    The line 1 should include "Found RELEASE version on maintenance branch"
+    The line 2 should include "Unsupported version '1.2.3' with 3 digits"
+    The variable PROJECT_VERSION should be undefined
+  End
+
+  It 'fails when maven expression fails'
+    Mock mvn
+      case "$*" in
+        *"project.version"*) echo "Something went wrong" >&2; exit 1 ;;
+        *) echo "mvn $*" ;;
+      esac
+    End
+    When call set_project_version
+    The status should be failure
+    The lines of stdout should equal 2
+    The line 1 should include "Could not get 'project.version' from Maven project"
+    The line 2 should equal "ERROR: Something went wrong"
+  End
+End
+
+Describe 'build_maven()'
+  Mock check_tool
+  End
+  Mock git_fetch_unshallow
+  End
+  Mock set_project_version
+  End
+  export PROJECT_VERSION="1.2.3.42"
+
+  Describe 'is_main_branch'
+    export GITHUB_REF_NAME="def_main"
+
+    It 'builds, deploys and analyzes main branch'
+      When call build_maven
+      The lines of stdout should equal 3
+      The line 1 should include "Build, deploy and analyze def_main"
+      The line 2 should start with "Maven command: mvn deploy"
+      The line 3 should start with "mvn deploy"
+      The line 3 should include "-Pcoverage,deploy-sonarsource,release,sign"
+      The line 3 should include "-Dsonar.host.url=https://sonarqube"
+      The line 3 should include "-Dsonar.token=sonar-token"
+      The line 3 should include "-Dsonar.projectVersion=1.2.3.42"
+      The line 3 should include "-Dsonar.scm.revision=abc123def456"
+    End
+  End
+
+  Describe 'is_maintenance_branch'
+    export GITHUB_REF_NAME="branch-1.2"
+
+    It 'builds, deploys and analyzes maintenance branch'
+      When call build_maven
+      The lines of stdout should equal 3
+      The line 1 should include "Build, deploy and analyze branch-1.2"
+      The line 3 should start with "mvn deploy"
+    End
+  End
+
+  Describe 'is_pull_request'
+    export GITHUB_EVENT_NAME="pull_request"
+    export PULL_REQUEST="123"
+    export GITHUB_REF_NAME="123/merge"
+    export GITHUB_HEAD_REF="fix/jdoe/JIRA-1234-aFix"
+    export GITHUB_BASE_REF="def_main"
+
+    It 'builds, analyzes pull request with no deploy by default'
+      When call build_maven
+      The lines of stdout should equal 4
+      The line 1 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
+      The line 2 should include "no deploy"
+      The line 3 should start with "Maven command: mvn verify"
+      The line 4 should start with "mvn verify"
+      The line 4 should include "-Pcoverage"
+      The line 4 should include "-Dsonar.host.url=https://sonarqube"
+      The line 4 should include "-Dsonar.pullrequest.key=123"
+      The line 4 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
+      The line 4 should include "-Dsonar.pullrequest.base=def_main"
+    End
+
+    It 'builds, analyzes pull request with deploy when DEPLOY_PULL_REQUEST is true'
+      export DEPLOY_PULL_REQUEST="true"
+      When call build_maven
+      The lines of stdout should equal 4
+      The line 1 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
+      The line 2 should include "with deploy"
+      The line 3 should start with "Maven command: mvn deploy"
+      The line 4 should start with "mvn deploy"
+      The line 4 should include "-Pcoverage,deploy-sonarsource"
+      The line 4 should include "-Dsonar.host.url=https://sonarqube"
+      The line 4 should include "-Dsonar.pullrequest.key=123"
+      The line 4 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
+      The line 4 should include "-Dsonar.pullrequest.base=def_main"
+    End
+  End
+
+  Describe 'is_dogfood_branch'
+    export GITHUB_REF_NAME="dogfood-on-something"
+
+    It 'builds'
+      When call build_maven
+      The lines of stdout should equal 3
+      The line 1 should include "Build, and deploy dogfood branch dogfood-on-something"
+      The line 2 should start with "Maven command: mvn deploy"
+      The line 3 should start with "mvn deploy"
+      The line 3 should include "-Pdeploy-sonarsource,release"
+    End
+  End
+
+  Describe 'is_feature_branch'
+    export GITHUB_REF_NAME="feature/long/some-feature"
+
+    It 'builds and analyzes long lived feature branch'
+      When call build_maven
+      The lines of stdout should equal 3
+      The line 1 should include "Build and analyze long lived feature branch feature/long/some-feature"
+      The line 2 should start with "Maven command: mvn verify"
+      The line 3 should start with "mvn verify"
+      The line 3 should include "-Pcoverage"
+      The line 3 should include "-Dsonar.host.url=https://sonarqube"
+    End
+  End
+
+  Describe 'other branches'
+    export GITHUB_REF_NAME="some-branch"
+
+    It 'builds only'
+      When call build_maven
+      The lines of stdout should equal 3
+      The line 1 should include "Build, no analysis, no deploy some-branch"
+      The line 2 should start with "Maven command: mvn verify"
+      The line 3 should start with "mvn verify"
+    End
+  End
+End

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -68,7 +68,7 @@ export ARTIFACTORY_URL="https://repox.jfrog.io/artifactory"
 export ARTIFACTORY_ACCESS_TOKEN="reader-token"
 export ARTIFACTORY_DEPLOY_REPO="test-repo"
 export ARTIFACTORY_DEPLOY_ACCESS_TOKEN="deploy-token"
-export SONAR_HOST_URL="https://sonar.example.com"
+export SONAR_HOST_URL="https://sonar.dummy"
 export SONAR_TOKEN="sonar-token"
 export DEPLOY_PULL_REQUEST="false"
 export SKIP_TESTS="false"
@@ -288,7 +288,7 @@ Describe 'build-npm/build.sh'
     End
 
     It 'builds pull request without deploy'
-      export GITHUB_REF_NAME="feature/test"
+      export GITHUB_REF_NAME="123/merge"
       export GITHUB_EVENT_NAME="pull_request"
       export DEPLOY_PULL_REQUEST="false"
       export PULL_REQUEST="123"
@@ -304,7 +304,7 @@ Describe 'build-npm/build.sh'
     End
 
     It 'builds pull request with deploy when enabled'
-      export GITHUB_REF_NAME="feature/test"
+      export GITHUB_REF_NAME="123/merge"
       export GITHUB_EVENT_NAME="pull_request"
       export DEPLOY_PULL_REQUEST="true"
       export PULL_REQUEST="123"

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -32,13 +32,13 @@ export GITHUB_EVENT_PATH
 #export GITHUB_OUTPUT
 
 Describe 'build-poetry/build.sh'
-  It 'does not run build-poetry() if the script is sourced'
+  It 'does not run build_poetry() if the script is sourced'
     When run source build-poetry/build.sh
     The status should be success
     The output should equal ""
   End
 
-  It 'runs build-poetry()'
+  It 'runs build_poetry()'
     Mock poetry
       if [[ "$*" == "version -s" ]]; then
         echo "1.2"
@@ -182,7 +182,7 @@ Describe 'jfrog_poetry_install()'
   End
 End
 
-Describe 'build-poetry()'
+Describe 'build_poetry()'
   setup() {
     mkdir -p dist
   }
@@ -208,7 +208,7 @@ Describe 'build-poetry()'
     unset PULL_REQUEST
     export GITHUB_REF_NAME="main"
 
-    When call build-poetry
+    When call build_poetry
     The line 1 should equal 'poetry build'
     The line 2 should equal "jf config remove repox"
     The line 3 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>"
@@ -223,19 +223,19 @@ Describe 'build-poetry()'
 
   It 'skips when on a PR and DEPLOY_PULL_REQUEST is not true'
     export PULL_REQUEST="123"
-    export GITHUB_REF_NAME="test/pull-request/123"
+    export GITHUB_REF_NAME="123/merge"
 
-    When call build-poetry
+    When call build_poetry
     The output should equal 'poetry build'
     The status should be success
   End
 
   It 'builds and publishes when on a PR and DEPLOY_PULL_REQUEST is true'
     export PULL_REQUEST="123"
-    export GITHUB_REF_NAME="test/pull-request/123"
+    export GITHUB_REF_NAME="123/merge"
     export DEPLOY_PULL_REQUEST="true"
 
-    When call build-poetry
+    When call build_poetry
     The line 1 should equal 'poetry build'
     The line 2 should equal "jf config remove repox"
     The line 3 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>"

--- a/spec/promote_spec.sh
+++ b/spec/promote_spec.sh
@@ -78,17 +78,19 @@ Describe 'promote/promote.sh'
     export GITHUB_EVENT_NAME="pull_request"
     When run script promote/promote.sh
     The status should be success
-    The lines of stdout should equal 10
-    The line 1 should include "jq"
-    The line 2 should include "jq"
-    The line 3 should include "jf"
-    The line 4 should include "jf"
-    The line 5 should equal "PROJECT: $PROJECT"
-    The line 6 should equal "jf config remove repox"
-    The line 7 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token dummy promote token"
-    The line 8 should equal "Promote $PROJECT/$BUILD_NUMBER build artifacts to $ARTIFACTORY_TARGET"
-    The line 9 should equal "jf rt bpr --status it-passed-pr $PROJECT $BUILD_NUMBER $ARTIFACTORY_TARGET"
-    The line 10 should include "gh api -X POST"
+    The lines of stdout should equal 12
+    The line 1 should include "gh"
+    The line 2 should include "gh"
+    The line 3 should include "jq"
+    The line 4 should include "jq"
+    The line 5 should include "jf"
+    The line 6 should include "jf"
+    The line 7 should equal "PROJECT: $PROJECT"
+    The line 8 should equal "jf config remove repox"
+    The line 9 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token dummy promote token"
+    The line 10 should equal "Promote $PROJECT/$BUILD_NUMBER build artifacts to $ARTIFACTORY_TARGET"
+    The line 11 should equal "jf rt bpr --status it-passed-pr $PROJECT $BUILD_NUMBER $ARTIFACTORY_TARGET"
+    The line 12 should include "gh api -X POST"
   End
 End
 


### PR DESCRIPTION
BUILD-8317
This PR migrates our Maven-related CI scripts from the ci-common-scripts repository into a new, self-contained GitHub Action.

The primary goal is to improve maintainability and simplify our workflows by centralizing the build and analysis logic within a versioned Action.

Tested with:
- https://github.com/SonarSource/sonar-dummy/pull/463
https://github.com/SonarSource/sonar-dummy/actions/runs/16524805308/job/46735258021?pr=463

Use ARTIFACTORY_ACCESS_TOKEN, not ARTIFACTORY_PRIVATE_PASSWORD
Options for MAVEN_OPTS and SONAR_SCANNER_JAVA_OPTS
Develocity is optional
Cleanup M2 repo before cache

Remove development/github/token/licenses-ro which is optional

Rework build.sh:
- align with other actions
- simplify and shorten
- validate all required environment variables at the beginning
- maintenance branches are built the same as main branch (no more separated analysis)
- improved unshallow

mise: no need for jfrog CLI

set deploy-pull-request to false by default

Format: Shell functions documentation should be ahead, not after the function name
Shell function names with underscore separator, not dash

Use temp file in promote build info (was local .build-info)
Check for gh in promote

README: build-maven
- no optional with parameter in the snippet
- Configuration Options (`with` Parameters), Required GitHub permissions, Required Vault permissions are described after

Improved test coverage to 100% (except build-gradle and build-npm)

