### PR TITLE
BUILD-8643 Improve build-gradle action

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ jobs:
           gradle-wrapper-validation: true                           # Validate Gradle wrapper
           develocity-url: https://develocity.sonar.build/           # Develocity URL
           repox-url: https://repox.jfrog.io                         # Repox URL
-          primary-sonar-platform: next                             # SonarQube platform (next, sqc-eu, or sqc-us)
+          sonar-platform: next                             # SonarQube platform (next, sqc-eu, or sqc-us)
 ```
 
 ⚠️ Required GitHub permissions:
@@ -231,7 +231,7 @@ jobs:
 
 ⚠️ Required Vault permissions:
 
-- `development/kv/data/next`, `development/kv/data/sonarcloud`, or `development/kv/data/sonarqube-us`: SonarQube credentials (based on primary-sonar-platform)
+- `development/kv/data/next`, `development/kv/data/sonarcloud`, or `development/kv/data/sonarqube-us`: SonarQube credentials (based on sonar-platform)
 - `development/kv/data/sign`: Artifact signing credentials
 - `development/kv/data/develocity`: Develocity access token
 - `public-reader` or `private-reader` Artifactory roles for the build
@@ -239,13 +239,14 @@ jobs:
 
 ### Inputs
 
-- `public`: Whether to build and deploy with/to public repositories - automatically detected 
+- `public`: Whether to build and deploy with/to public repositories - automatically detected
 from repository visibility (optional)
-- `artifactory-deploy-repo`: Name of deployment repository - defaults to `sonarsource-public-qa` 
+- `artifactory-deploy-repo`: Name of deployment repository - defaults to `sonarsource-public-qa`
 or `sonarsource-private-qa` based on repository visibility (optional)
 - `artifactory-reader-role`: Suffix for the Artifactory reader role in Vault - defaults to `public-reader`
 or `private-reader` based on repository visibility (optional)
-- `artifactory-deployer-role`: Suffix for the Artifactory deployer role in Vault - defaults to `public-deployer` or `qa-deployer` based on repository visibility (optional)
+- `artifactory-deployer-role`: Suffix for the Artifactory deployer role in Vault -
+defaults to `public-deployer` or `qa-deployer` based on repository visibility (optional)
 - `deploy-pull-request`: Whether to deploy pull request artifacts (default: `false`)
 - `skip-tests`: Whether to skip running tests (default: `false`)
 - `gradle-args`: Additional arguments to pass to Gradle (optional)
@@ -253,7 +254,7 @@ or `private-reader` based on repository visibility (optional)
 - `gradle-wrapper-validation`: Whether to validate Gradle wrapper (default: `true`)
 - `develocity-url`: URL for Develocity (default: `https://develocity.sonar.build/`)
 - `repox-url`: URL for Repox (default: `https://repox.jfrog.io`)
-- `primary-sonar-platform`: SonarQube platform - 'next', 'sqc-eu', or 'sqc-us' (default: `next`)
+- `sonar-platform`: SonarQube platform - 'next', 'sqc-eu', or 'sqc-us' (default: `next`)
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -209,9 +209,10 @@ jobs:
       - uses: SonarSource/ci-github-actions/get-build-number@v1
       - uses: SonarSource/ci-github-actions/build-gradle@v1
         with:
+          public: false                                             # Defaults to `true` if the repository is public
           artifactory-deploy-repo: ""                               # Artifactory repository name
-          artifactory-deploy-username: ""                           # Artifactory username
-          artifactory-deploy-password: ""                           # Artifactory password
+          artifactory-reader-role: private-reader                   # or public-reader if `public` is `true`
+          artifactory-deployer-role: qa-deployer                    # or public-deployer if `public` is `true`
           deploy-pull-request: false                                # Deploy pull request artifacts
           skip-tests: false                                         # Skip running tests
           gradle-args: ""                                           # Additional Gradle arguments
@@ -220,6 +221,7 @@ jobs:
           gradle-wrapper-validation: true                           # Validate Gradle wrapper
           develocity-url: https://develocity.sonar.build/           # Develocity URL
           repox-url: https://repox.jfrog.io                         # Repox URL
+          primary-sonar-platform: next                             # SonarQube platform (next, sqc-eu, or sqc-us)
 ```
 
 ⚠️ Required GitHub permissions:
@@ -229,15 +231,18 @@ jobs:
 
 ⚠️ Required Vault permissions:
 
-- `development/kv/data/next`: SonarQube credentials
+- `development/kv/data/next`, `development/kv/data/sonarcloud`, or `development/kv/data/sonarqube-us`: SonarQube credentials (based on primary-sonar-platform)
 - `development/kv/data/sign`: Artifact signing credentials
 - `development/kv/data/develocity`: Develocity access token
+- `public-reader` or `private-reader` Artifactory roles for the build
+- `public-deployer` or `qa-deployer` Artifactory roles for the deployment
 
 ### Inputs
 
-- `artifactory-deploy-repo`: Name of deployment repository (optional)
-- `artifactory-deploy-username`: Username to deploy to Artifactory (optional)
-- `artifactory-deploy-password`: Password to deploy to Artifactory (optional)
+- `public`: Whether to build and deploy with/to public repositories - automatically detected from repository visibility (optional)
+- `artifactory-deploy-repo`: Name of deployment repository - defaults to `sonarsource-public-qa` or `sonarsource-private-qa` based on repository visibility (optional)
+- `artifactory-reader-role`: Suffix for the Artifactory reader role in Vault - defaults to `public-reader` or `private-reader` based on repository visibility (optional)
+- `artifactory-deployer-role`: Suffix for the Artifactory deployer role in Vault - defaults to `public-deployer` or `qa-deployer` based on repository visibility (optional)
 - `deploy-pull-request`: Whether to deploy pull request artifacts (default: `false`)
 - `skip-tests`: Whether to skip running tests (default: `false`)
 - `gradle-args`: Additional arguments to pass to Gradle (optional)
@@ -245,6 +250,7 @@ jobs:
 - `gradle-wrapper-validation`: Whether to validate Gradle wrapper (default: `true`)
 - `develocity-url`: URL for Develocity (default: `https://develocity.sonar.build/`)
 - `repox-url`: URL for Repox (default: `https://repox.jfrog.io`)
+- `primary-sonar-platform`: SonarQube platform - 'next', 'sqc-eu', or 'sqc-us' (default: `next`)
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -239,9 +239,12 @@ jobs:
 
 ### Inputs
 
-- `public`: Whether to build and deploy with/to public repositories - automatically detected from repository visibility (optional)
-- `artifactory-deploy-repo`: Name of deployment repository - defaults to `sonarsource-public-qa` or `sonarsource-private-qa` based on repository visibility (optional)
-- `artifactory-reader-role`: Suffix for the Artifactory reader role in Vault - defaults to `public-reader` or `private-reader` based on repository visibility (optional)
+- `public`: Whether to build and deploy with/to public repositories - automatically detected 
+from repository visibility (optional)
+- `artifactory-deploy-repo`: Name of deployment repository - defaults to `sonarsource-public-qa` 
+or `sonarsource-private-qa` based on repository visibility (optional)
+- `artifactory-reader-role`: Suffix for the Artifactory reader role in Vault - defaults to `public-reader`
+or `private-reader` based on repository visibility (optional)
 - `artifactory-deployer-role`: Suffix for the Artifactory deployer role in Vault - defaults to `public-deployer` or `qa-deployer` based on repository visibility (optional)
 - `deploy-pull-request`: Whether to deploy pull request artifacts (default: `false`)
 - `skip-tests`: Whether to skip running tests (default: `false`)

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -43,7 +43,7 @@ inputs:
     description: URL for Repox
     required: false
     default: https://repox.jfrog.io
-  primary-sonar-platform:
+  sonar-platform:
     description: SonarQube variant (next, sqc-eu, or sqc-us)
     required: false
     default: next
@@ -73,8 +73,8 @@ runs:
       with:
         # yamllint disable rule:line-length
         secrets: |
-          development/kv/data/${{ inputs.primary-sonar-platform == 'sqc-eu' && 'sonarcloud' || (inputs.primary-sonar-platform == 'sqc-us' && 'sonarqube-us' || 'next') }} url | SONAR_HOST_URL;
-          development/kv/data/${{ inputs.primary-sonar-platform == 'sqc-eu' && 'sonarcloud' || (inputs.primary-sonar-platform == 'sqc-us' && 'sonarqube-us' || 'next') }} token | SONAR_TOKEN;
+          development/kv/data/${{ inputs.sonar-platform == 'sqc-eu' && 'sonarcloud' || (inputs.sonar-platform == 'sqc-us' && 'sonarqube-us' || 'next') }} url | SONAR_HOST_URL;
+          development/kv/data/${{ inputs.sonar-platform == 'sqc-eu' && 'sonarcloud' || (inputs.sonar-platform == 'sqc-us' && 'sonarqube-us' || 'next') }} token | SONAR_TOKEN;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} username | ARTIFACTORY_DEPLOY_USERNAME;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} access_token | ARTIFACTORY_DEPLOY_PASSWORD;
           development/kv/data/sign key | SIGN_KEY;

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -2,30 +2,31 @@
 name: Build Gradle
 description: GitHub Action to build, analyze, and deploy a Gradle project with SonarQube integration
 inputs:
+  public:
+    description: Whether to build and deploy with/to public repositories. Set to `true` for public repositories (OSS), `false` for private.
+    default: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}
   artifactory-deploy-repo:
     description: Name of deployment repository
     required: false
     default: ''
-  artifactory-deploy-username:
-    description: Username to deploy to Artifactory
-    required: false
+  artifactory-reader-role:
+    description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories,
+      and `public-reader` for public repositories.
     default: ''
-  artifactory-deploy-password:
-    description: Password to deploy to Artifactory
-    required: false
+  artifactory-deployer-role:
+    description: Suffix for the Artifactory deployer role in Vault. Defaults to `qa-deployer` for private repositories, and
+      `public-deployer` for public repositories.
     default: ''
   gradle-args:
     description: Additional arguments to pass to Gradle
     required: false
-    default: ''
   gradle-version:
     description: Gradle version to use for setup-gradle action
     required: false
-    default: ''
   deploy-pull-request:
     description: Whether to deploy pull request artifacts
     required: false
-    default: 'false'
+    default: 'true'
   skip-tests:
     description: Whether to skip running tests
     required: false
@@ -42,6 +43,10 @@ inputs:
     description: URL for Repox
     required: false
     default: https://repox.jfrog.io
+  primary-sonar-platform:
+    description: SonarQube variant (next, sqc-eu, or sqc-us)
+    required: false
+    default: next
 
 outputs:
   project-version:
@@ -51,17 +56,32 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set build parameters
+      shell: bash
+      env:
+        ARTIFACTORY_READER_ROLE: ${{ inputs.artifactory-reader-role != '' && inputs.artifactory-reader-role ||
+          (inputs.public == 'true' && 'public-reader' || 'private-reader') }}
+        ARTIFACTORY_DEPLOYER_ROLE: ${{ inputs.artifactory-deployer-role != '' && inputs.artifactory-deployer-role ||
+          (inputs.public == 'true' && 'public-deployer' || 'qa-deployer') }}
+      run: |
+        echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
+        echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
+
     - name: Vault
       id: secrets
       uses: SonarSource/vault-action-wrapper@d6d745ffdbc82b040df839b903bc33b5592cd6b0 # 3.0.2
       with:
+        # yamllint disable rule:line-length
         secrets: |
-          development/kv/data/next url | SONAR_HOST_URL;
-          development/kv/data/next token | SONAR_TOKEN;
+          development/kv/data/${{ inputs.primary-sonar-platform == 'sqc-eu' && 'sonarcloud' || (inputs.primary-sonar-platform == 'sqc-us' && 'sonarqube-us' || 'next') }} url | SONAR_HOST_URL;
+          development/kv/data/${{ inputs.primary-sonar-platform == 'sqc-eu' && 'sonarcloud' || (inputs.primary-sonar-platform == 'sqc-us' && 'sonarqube-us' || 'next') }} token | SONAR_TOKEN;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} username | ARTIFACTORY_DEPLOY_USERNAME;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} access_token | ARTIFACTORY_DEPLOY_PASSWORD;
           development/kv/data/sign key | SIGN_KEY;
           development/kv/data/sign passphrase | PGP_PASSPHRASE;
           development/kv/data/sign key_id | SIGN_KEY_ID;
           development/kv/data/develocity token | DEVELOCITY_TOKEN;
+        # yamllint enable rule:line-length
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
@@ -82,9 +102,10 @@ runs:
 
         # Action inputs
         ARTIFACTORY_URL: ${{ inputs.repox-url }}/artifactory
-        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo }}
-        ARTIFACTORY_DEPLOY_USERNAME: ${{ inputs.artifactory-deploy-username }}
-        ARTIFACTORY_DEPLOY_PASSWORD: ${{ inputs.artifactory-deploy-password }}
+        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
+          (inputs.public == 'true' && 'sonarsource-public-qa' || 'sonarsource-private-qa') }}
+        ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
+        ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
         SKIP_TESTS: ${{ inputs.skip-tests }}
         GRADLE_ARGS: ${{ inputs.gradle-args }}


### PR DESCRIPTION
• Added public parameter that auto-detects repository visibility and configures appropriate deployment settings
• Replaced hardcoded Artifactory credentials with role-based authentication using configurable reader/deployer roles
• Added sonar-platform parameter to support next/sqc-eu/sqc-us SonarQube instances with dynamic Vault path resolution
• Changed deploy-pull-request default from false to true
• Added .DS_Store to gitignore for macOS compatibility