### PR TITLE
BUILD-8317 use the workflow name in the cache key

### DIFF
--- a/.github/workflows/test-shell-scripts.yml
+++ b/.github/workflows/test-shell-scripts.yml
@@ -24,7 +24,7 @@ jobs:
         # FIXME BUILD-8337: improve setup of kcov
         run: |
           curl -L -O https://archive.ubuntu.com/ubuntu/pool/universe/k/kcov/kcov_38+dfsg-1_amd64.deb
-          sudo dpkg -i kcov_38+dfsg-1_amd64.deb
+          sudo dpkg -i --path-exclude=/usr/share/doc/* --path-exclude=/usr/share/man/* kcov_38+dfsg-1_amd64.deb
           rm kcov_38+dfsg-1_amd64.deb
 
           ./run_shell_tests.sh

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -47,8 +47,8 @@ runs:
       uses: SonarSource/ci-github-actions/cache@master
       with:
         path: ~/${{ inputs.maven-local-repository-path }}
-        key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
-        restore-keys: maven-${{ runner.os }}-
+        key: maven-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: maven-${{ runner.os }}-${{ github.workflow }}-
     - name: Vault
       # yamllint disable rule:line-length
       id: secrets
@@ -71,11 +71,12 @@ runs:
       run: |
         MAVEN_CONFIG="$HOME/.m2"
         mkdir -p "$MAVEN_CONFIG"
+        echo "MAVEN_CONFIG=${MAVEN_CONFIG}" >> "$GITHUB_ENV"
         if [[ "${PUBLIC_BUILD}" == "true" ]]; then
-          echo "Setting up public Maven settings"
+          echo "Setting up public Maven settings $MAVEN_CONFIG/settings.xml"
           cp "${GITHUB_ACTION_PATH}/resources/settings-public-auth.xml" "$MAVEN_CONFIG/settings.xml"
         else
-          echo "Setting up private Maven settings"
+          echo "Setting up private Maven settings $MAVEN_CONFIG/settings.xml"
           cp "${GITHUB_ACTION_PATH}/resources/settings-private.xml" "$MAVEN_CONFIG/settings.xml"
         fi
         MAVEN_LOCAL_REPOSITORY="$HOME/${{ inputs.maven-local-repository-path }}"
@@ -83,7 +84,6 @@ runs:
         echo "MAVEN_LOCAL_REPOSITORY=${MAVEN_LOCAL_REPOSITORY}" >> "$GITHUB_ENV"
     - name: Build, Analyze and deploy
       shell: bash
-      working-directory: ${{ github.workspace }}
       env:
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
@@ -98,9 +98,10 @@ runs:
         PULL_REQUEST: ${{ github.event.pull_request.number || '' }}
         DEVELOCITY_ACCESS_KEY: ${{ inputs.use-develocity == 'true' &&
           format('develocity.sonar.build={0}', fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN) || '' }}
-        MAVEN_OPTS: ${{ inputs.maven-opts }}
+        USER_MAVEN_OPTS: ${{ inputs.maven-opts }}
         SONAR_SCANNER_JAVA_OPTS: ${{ inputs.scanner-java-opts }}
       run: |
+        export MAVEN_OPTS="$USER_MAVEN_OPTS -Duser.home=$HOME"
         ${GITHUB_ACTION_PATH}/build.sh
     - name: Cleanup Maven repository before caching
       shell: bash

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -34,6 +34,9 @@ export SONAR_HOST_URL="https://sonarqube"
 export SONAR_TOKEN="sonar-token"
 export GITHUB_SHA="abc123def456"
 export GITHUB_RUN_ID="123456789"
+MAVEN_SETTINGS="$(mktemp)"
+touch "$MAVEN_SETTINGS"
+export MAVEN_SETTINGS
 
 Describe 'build.sh'
   It 'does not run build_maven() if the script is sourced'
@@ -188,9 +191,21 @@ Describe 'set_project_version()'
     End
     When call set_project_version
     The status should be failure
-    The lines of stdout should equal 2
+    The lines of stdout should equal 4
     The line 1 should include "Could not get 'project.version' from Maven project"
     The line 2 should equal "ERROR: Something went wrong"
+    The line 3 should equal "Failed to evaluate Maven expression 'project.version'"
+    The line 4 should equal "Something went wrong"
+  End
+
+  It 'fails when Maven settings.xml is missing'
+    export MAVEN_SETTINGS="missing-settings.xml"
+    When call set_project_version
+    The status should be failure
+    The lines of stdout should equal 1
+    The line 1 should include "Maven settings.xml file not found at $MAVEN_SETTINGS"
+    The variable PROJECT_VERSION should be undefined
+    unset MAVEN_SETTINGS
   End
 End
 


### PR DESCRIPTION
BUILD-8317 sonar-dummy integration tests are failing due to differences between standard runner and runner container.

```
    runs-on: sonar-runner-large
    container: ...
```

- Do not use the same cache key for different workflows (not working due to relative path `../../...` being included in the cache archive).
- Maven was not using Shell HOME variable, but Java user.home which was not consistent with the environment. 
- Speed up kcov install with skipping docs and man pages

Tested with https://github.com/SonarSource/sonar-dummy/actions/runs/16566665765?pr=464