### PR TITLE
BUILD-8573 Use master version of s3 cache action

### DIFF
--- a/cache/action.yml
+++ b/cache/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Cache with S3 (private/internal repos)
       if: steps.repo-visibility.outputs.cache-backend == 's3'
-      uses: SonarSource/gh-action_cache@b65bddcb4ecd1c9fffa3a777366cba94577b5a3e # 1.0.0
+      uses: SonarSource/gh-action_cache@master # 1.0.0
       id: s3-cache
       with:
         path: ${{ inputs.path }}


### PR DESCRIPTION
Required to accurately get the latest changes from cache action