### PR TITLE
BUILD-8700: Add sonarqube support for poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,18 +222,7 @@ jobs:
 
 ### Outputs
 
-- `project-version`: The project version from pyproject.toml with build number
-
-### Features
-
-- Automated version management with build numbers and .dev suffix handling
-- SonarQube analysis for code quality using pysonar (credentials from Vault)
-- Conditional deployment based on branch patterns (default, maintenance, dogfood branches)
-- Poetry dependency management and virtual environment isolation
-- Pull request support with optional deployment
-- Comprehensive build logging and error handling
-- Support for different branch types (default, maintenance, PR, dogfood, long-lived feature)
-- Multi-platform SonarQube support (SonarCloud EU/US, SonarQube Next)
+- `project-version`: The project version from pyproject.toml with build number. The same is also exposed as `PROJECT_VERSION` environment variable.
 
 ## `build-gradle`
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ No outputs are provided by this action.
 
 ## `build-poetry`
 
-Build and publish a Python project using Poetry.
+Build, analyze, and publish a Python project using Poetry with SonarQube integration and Artifactory deployment.
 
 ### Requirements
 
@@ -196,6 +196,15 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: SonarSource/ci-github-actions/build-poetry@v1
+        with:
+          public: false                                        # Defaults to `true` if the repository is public
+          artifactory-reader-role: private-reader              # or public-reader if `public` is `true`
+          artifactory-deployer-role: qa-deployer               # or public-deployer if `public` is `true`
+          deploy-pull-request: false                           # Deploy pull request artifacts
+          poetry-virtualenvs-path: .cache/pypoetry/virtualenvs # Poetry virtual environment path
+          poetry-cache-dir: .cache/pypoetry                    # Poetry cache directory
+          repox-url: https://repox.jfrog.io                    # Repox URL
+          sonar-platform: next                                 # SonarQube platform (next, sqc-eu, or sqc-us)
 ```
 
 ### Inputs
@@ -213,15 +222,18 @@ jobs:
 
 ### Outputs
 
-No outputs are provided by this action.
+- `project-version`: The project version from pyproject.toml with build number
 
 ### Features
 
-- Automated dependency management with Poetry
-- Conditional deployment based on branch patterns
-- Python virtual environment caching for faster builds
-- SonarQube analysis integration (configurable)
+- Automated version management with build numbers and .dev suffix handling
+- SonarQube analysis for code quality using pysonar (credentials from Vault)
+- Conditional deployment based on branch patterns (default, maintenance, dogfood branches)
+- Poetry dependency management and virtual environment isolation
+- Pull request support with optional deployment
 - Comprehensive build logging and error handling
+- Support for different branch types (default, maintenance, PR, dogfood, long-lived feature)
+- Multi-platform SonarQube support (SonarCloud EU/US, SonarQube Next)
 
 ## `build-gradle`
 

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -32,7 +32,7 @@ inputs:
 
 outputs:
   project-version:
-    description: The project version from pyproject.toml
+    description: The project version from pyproject.toml with BUILD_NUMBER
     value: ${{ env.PROJECT_VERSION }}
 
 runs:

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -1,6 +1,6 @@
 ---
 name: Build Poetry
-description: GitHub Action to build, analyze, and deploy a Python project using Poetry
+description: GitHub Action to build, analyze, and deploy a Python project using Poetry with SonarQube integration
 inputs:
   public:
     description: Whether to build and deploy with/to public repositories. Set to `true` for public repositories (OSS), `false` for private.
@@ -27,8 +27,13 @@ inputs:
     description: URL for Repox
     default: https://repox.jfrog.io
   sonar-platform:
-    description: SonarQube primary platform (next, sqc-eu, or sqc-us) - currently not enabled in build script
+    description: SonarQube primary platform (next, sqc-eu, or sqc-us)
     default: next
+
+outputs:
+  project-version:
+    description: The project version from pyproject.toml
+    value: ${{ env.PROJECT_VERSION }}
 
 runs:
   using: composite
@@ -77,14 +82,15 @@ runs:
         # Action inputs
         ARTIFACTORY_URL: ${{ inputs.repox-url }}/artifactory
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
-        # SonarQube integration (currently disabled in build script)
-        SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_HOST_URL }}
-        SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
         ARTIFACTORY_PYPI_REPO: ${{ inputs.public == 'true' && 'sonarsource-pypi' || 'sonarsource-pypi' }} # FIXME: sonarsource-pypi-public
         ARTIFACTORY_DEPLOY_REPO: ${{ inputs.public == 'true' && 'sonarsource-pypi-public-qa' || 'sonarsource-pypi-private-qa' }}
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
         POETRY_VIRTUALENVS_PATH: ${{ github.workspace }}/${{ inputs.poetry-virtualenvs-path }}
         POETRY_CACHE_DIR: ${{ github.workspace }}/${{ inputs.poetry-cache-dir }}
+
+        # Vault secrets
+        SONAR_HOST_URL: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_HOST_URL }}
+        SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
       run: |
         ${GITHUB_ACTION_PATH}/build.sh

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 # Build script for SonarSource Poetry projects.
-# Supports building, testing, and JFrog Artifactory deployment.
+# Supports building, testing, SonarQube analysis, and JFrog Artifactory deployment.
 #
 # Required inputs (must be explicitly provided):
 # - BUILD_NUMBER: Build number for versioning
+# - SONAR_HOST_URL: URL of SonarQube server
+# - SONAR_TOKEN: Access token to send analysis reports to SonarQube
 # - ARTIFACTORY_URL: URL to Artifactory repository
 # - ARTIFACTORY_PYPI_REPO: Repository to install dependencies from
 # - ARTIFACTORY_ACCESS_TOKEN: Access token to access the repository
@@ -15,11 +17,14 @@
 #
 # GitHub Actions auto-provided:
 # - GITHUB_REF_NAME: Git branch name
+# - GITHUB_SHA: Git commit SHA
 # - GITHUB_REPOSITORY: Repository name (e.g. sonarsource/sonar-dummy-poetry)
+# - GITHUB_RUN_ID: GitHub Actions run ID
 # - GITHUB_EVENT_NAME: Event name (e.g. push, pull_request)
 # - GITHUB_EVENT_PATH: Path to the event webhook payload file
 # - GITHUB_ENV: Path to GitHub Actions environment file
 # - GITHUB_OUTPUT: Path to GitHub Actions output file
+# - GITHUB_BASE_REF: Base branch for pull requests (only during pull_request events)
 #
 # Optional user customization:
 # - DEPLOY_PULL_REQUEST: Whether to deploy pull request artifacts (default: false)
@@ -34,7 +39,8 @@ set -euo pipefail
 : "${ARTIFACTORY_PYPI_REPO:?}" "${ARTIFACTORY_ACCESS_TOKEN:?}" "${ARTIFACTORY_DEPLOY_REPO:?}" "${ARTIFACTORY_DEPLOY_ACCESS_TOKEN:?}"
 : "${GITHUB_REF_NAME:?}" "${BUILD_NUMBER:?}" "${GITHUB_REPOSITORY:?}" "${GITHUB_EVENT_NAME:?}" "${GITHUB_EVENT_PATH:?}"
 : "${PULL_REQUEST?}" "${DEFAULT_BRANCH:?}"
-: "${GITHUB_ENV:?}" "${GITHUB_OUTPUT:?}"
+: "${GITHUB_ENV:?}" "${GITHUB_OUTPUT:?}" "${GITHUB_SHA:?}" "${GITHUB_RUN_ID:?}"
+: "${SONAR_HOST_URL:?}" "${SONAR_TOKEN:?}"
 : "${DEPLOY_PULL_REQUEST:=false}"
 export ARTIFACTORY_URL DEPLOY_PULL_REQUEST
 
@@ -47,13 +53,42 @@ check_tool() {
   "$@"
 }
 
+git_fetch_unshallow() {
+  # The --filter=blob:none flag significantly speeds up the download
+  if git rev-parse --is-shallow-repository --quiet >/dev/null 2>&1; then
+    echo "Fetch Git references for SonarQube analysis..."
+    git fetch --unshallow --filter=blob:none
+  elif [ -n "${GITHUB_BASE_REF:-}" ]; then
+    echo "Fetch ${GITHUB_BASE_REF} for SonarQube analysis..."
+    git fetch --filter=blob:none origin "${GITHUB_BASE_REF}"
+  fi
+}
+
+run_sonar_scanner() {
+    local additional_params=("$@")
+
+    # Install pysonar into Poetry's virtual environment without modifying project files
+    if ! poetry run pysonar --help >/dev/null 2>&1; then
+        echo "Installing pysonar into Poetry virtual environment..."
+        poetry run pip install pysonar
+    fi
+
+    poetry run pysonar \
+        -Dsonar.host.url="${SONAR_HOST_URL}" \
+        -Dsonar.token="${SONAR_TOKEN}" \
+        -Dsonar.analysis.buildNumber="${BUILD_NUMBER}" \
+        -Dsonar.analysis.pipeline="${GITHUB_RUN_ID}" \
+        -Dsonar.analysis.sha1="${GITHUB_SHA}" \
+        -Dsonar.analysis.repository="${GITHUB_REPOSITORY}" \
+        "${additional_params[@]}"
+    echo "SonarQube scanner finished"
+}
+
 # FIXME BUILD-8337? this is similar to source github-env <BUILD|BUILD-PRIVATE>
 set_build_env() {
-  DEFAULT_BRANCH=${DEFAULT_BRANCH:=$(gh repo view --json defaultBranchRef --jq ".defaultBranchRef.name")}
   export PROJECT=${GITHUB_REPOSITORY#*/}
   echo "PROJECT: $PROJECT"
-  echo "PULL_REQUEST: $PULL_REQUEST"
-  export DEFAULT_BRANCH PULL_REQUEST PULL_REQUEST_SHA
+  git_fetch_unshallow
 }
 
 is_default_branch() {
@@ -72,16 +107,25 @@ is_dogfood_branch() {
   [[ "${GITHUB_REF_NAME}" == "dogfood-on-"* ]]
 }
 
-# is_long_lived_feature_branch() {
-#   [[ "${GITHUB_REF_NAME}" == "feature/long/"* ]]
-# }
+is_long_lived_feature_branch() {
+  [[ "${GITHUB_REF_NAME}" == "feature/long/"* ]]
+}
+
+is_merge_queue_branch() {
+  [[ "${GITHUB_REF_NAME}" == "gh-readonly-queue/"* ]]
+}
 
 set_project_version() {
+  local current_version release_version digit_count
+
   if ! current_version=$(poetry version -s); then
     echo "Could not get version from Poetry project ('poetry version -s')" >&2
     echo "$current_version" >&2
     return 1
   fi
+
+  export CURRENT_VERSION="${current_version}"
+
   release_version=${current_version%".dev"*}
   # In case of 2 digits, we need to add a '0' as the 3rd digit.
   digit_count=$(echo "${release_version//./ }" | wc -w)
@@ -98,6 +142,63 @@ set_project_version() {
   poetry version "$new_version"
   export PROJECT_VERSION=$new_version
   echo "PROJECT_VERSION=$PROJECT_VERSION" >> "$GITHUB_ENV"
+}
+
+# Determine build configuration based on branch type
+get_build_config() {
+  local enable_sonar enable_deploy
+  local sonar_args=()
+
+  if is_default_branch && ! is_pull_request; then
+    echo "======= Building main branch ======="
+    echo "Current version: ${CURRENT_VERSION}"
+
+    enable_sonar=true
+    enable_deploy=true
+    sonar_args=("-Dsonar.projectVersion=${CURRENT_VERSION}")
+
+  elif is_maintenance_branch && ! is_pull_request; then
+    echo "======= Building maintenance branch ======="
+
+    enable_sonar=true
+    enable_deploy=true
+    sonar_args=("-Dsonar.branch.name=${GITHUB_REF_NAME}")
+
+  elif is_pull_request; then
+    echo "======= Building pull request ======="
+
+    enable_sonar=true
+    sonar_args=("-Dsonar.analysis.prNumber=${PULL_REQUEST}")
+
+    if [ "${DEPLOY_PULL_REQUEST:-false}" == "true" ]; then
+      echo "======= with deploy ======="
+      enable_deploy=true
+    else
+      echo "======= no deploy ======="
+      enable_deploy=false
+    fi
+
+  elif is_dogfood_branch && ! is_pull_request; then
+    echo "======= Build dogfood branch ======="
+    enable_sonar=false
+    enable_deploy=true
+
+  elif is_long_lived_feature_branch && ! is_pull_request; then
+    echo "======= Build long-lived feature branch ======="
+    enable_sonar=true
+    enable_deploy=false
+    sonar_args=("-Dsonar.branch.name=${GITHUB_REF_NAME}")
+
+  else
+    echo "======= Build other branch ======="
+    enable_sonar=false
+    enable_deploy=false
+  fi
+
+  # Export the configuration for use by build_poetry
+  export BUILD_ENABLE_SONAR="$enable_sonar"
+  export BUILD_ENABLE_DEPLOY="$enable_deploy"
+  export BUILD_SONAR_ARGS="${sonar_args[*]:-}"
 }
 
 jfrog_poetry_install() {
@@ -122,36 +223,42 @@ jfrog_poetry_publish() {
 }
 
 build_poetry() {
+  echo "=== Poetry Build, Deploy, and Analyze ==="
+  echo "Branch: ${GITHUB_REF_NAME}"
+  echo "Pull Request: ${PULL_REQUEST}"
+  echo "Deploy Pull Request: ${DEPLOY_PULL_REQUEST}"
+
+  set_project_version
+  get_build_config
+
+  echo "Installing dependencies..."
+  jfrog_poetry_install
+
+  echo "Building project..."
+  poetry build
+
+  if [ "${BUILD_ENABLE_SONAR}" = "true" ]; then
+    read -ra sonar_args <<< "$BUILD_SONAR_ARGS"
+    run_sonar_scanner "${sonar_args[@]}"
+  fi
+
+  if [ "${BUILD_ENABLE_DEPLOY}" = "true" ]; then
+    jfrog_poetry_publish
+  fi
+
+  echo "=== Build completed successfully ==="
+}
+
+main() {
   check_tool jq --version
   check_tool python --version
   check_tool poetry --version
   check_tool jf --version
+
   set_build_env
-  set_project_version
-  jfrog_poetry_install
-  poetry build
-  if (is_pull_request && [[ "${DEPLOY_PULL_REQUEST:-}" == "true" ]]) || \
-     (! is_pull_request && (is_default_branch || is_maintenance_branch || is_dogfood_branch)); then
-    jfrog_poetry_publish
-  fi
-
-  # run scanner?
-  #if is_main_branch && ! is_pull_request; then
-  #  run_sonar_scanner \
-  #  -Dsonar.projectVersion="$CURRENT_VERSION"
-  #elif is_maintenance_branch && ! is_pull_request; then
-  #  run_sonar_scanner \
-  #  -Dsonar.branch.name="$GITHUB_REF_NAME"
-  #elif is_pull_request; then
-  #  run_sonar_scanner \
-  #  -Dsonar.analysis.prNumber="$PULL_REQUEST"
-  #elif is_long_lived_feature_branch && ! is_pull_request; then
-  #  run_sonar_scanner \
-  #  -Dsonar.branch.name="$GITHUB_REF_NAME"
-
-  # run_sonar_scanner
+  build_poetry
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  build_poetry
+  main "$@"
 fi

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -13,7 +13,6 @@
 # - ARTIFACTORY_DEPLOY_ACCESS_TOKEN: Access token to deploy to the repository
 # - DEFAULT_BRANCH: Default branch name (e.g. main)
 # - PULL_REQUEST: Pull request number (e.g. 1234) or empty string
-# - PULL_REQUEST_SHA: Pull request base SHA or empty string
 #
 # GitHub Actions auto-provided:
 # - GITHUB_REF_NAME: Git branch name
@@ -68,10 +67,7 @@ run_sonar_scanner() {
     local additional_params=("$@")
 
     # Install pysonar into Poetry's virtual environment without modifying project files
-    if ! poetry run pysonar --help >/dev/null 2>&1; then
-        echo "Installing pysonar into Poetry virtual environment..."
-        poetry run pip install pysonar
-    fi
+    poetry run pip install pysonar
 
     poetry run pysonar \
         -Dsonar.host.url="${SONAR_HOST_URL}" \
@@ -124,8 +120,6 @@ set_project_version() {
     return 1
   fi
 
-  export CURRENT_VERSION="${current_version}"
-
   release_version=${current_version%".dev"*}
   # In case of 2 digits, we need to add a '0' as the 3rd digit.
   digit_count=$(echo "${release_version//./ }" | wc -w)
@@ -151,11 +145,9 @@ get_build_config() {
 
   if is_default_branch && ! is_pull_request; then
     echo "======= Building main branch ======="
-    echo "Current version: ${CURRENT_VERSION}"
 
     enable_sonar=true
     enable_deploy=true
-    sonar_args=("-Dsonar.projectVersion=${CURRENT_VERSION}")
 
   elif is_maintenance_branch && ! is_pull_request; then
     echo "======= Building maintenance branch ======="

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -10,9 +10,6 @@ End
 Mock jf
   echo "jf $*"
 End
-Mock gh
-  echo "gh $*"
-End
 
 # Minimal environment variables
 export GITHUB_ENV=/dev/null
@@ -27,10 +24,13 @@ export GITHUB_REF_NAME="any-branch"
 export GITHUB_EVENT_NAME="push"
 export BUILD_NUMBER="42"
 export PULL_REQUEST=""
-export PULL_REQUEST_SHA=""
 GITHUB_EVENT_PATH=$(mktemp)
 export GITHUB_EVENT_PATH
 export GITHUB_OUTPUT=/dev/null
+export SONAR_HOST_URL="https://sonarqube.test"
+export SONAR_TOKEN="dummy-sonar-token"
+export GITHUB_SHA="dummy-sha"
+export GITHUB_RUN_ID="dummy-run-id"
 
 Describe 'build-poetry/build.sh'
   It 'does not run build_poetry() if the script is sourced'
@@ -47,9 +47,12 @@ Describe 'build-poetry/build.sh'
         echo "poetry $*"
       fi
     End
+    Mock git
+      echo "git $*"
+    End
     When run script build-poetry/build.sh
       The status should be success
-      The lines of stdout should equal 16
+      The lines of stdout should equal 25
       The line 1 should include "jq"
       The line 2 should include "jq"
       The line 3 should include "python"
@@ -59,13 +62,21 @@ Describe 'build-poetry/build.sh'
       The line 7 should include "jf"
       The line 8 should include "jf"
       The line 9 should equal "PROJECT: my-repo"
-      The line 10 should equal "PULL_REQUEST: "
-      The line 11 should equal "Replacing version 1.2 with 1.2.0.42"
-      The line 12 should equal "poetry version 1.2.0.42"
-      The line 13 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token dummy access token"
-      The line 14 should equal "jf poetry-config --server-id-resolve repox --repo-resolve <repox pypi repo>"
-      The line 15 should equal "jf poetry install --build-name=my-repo --build-number=42"
-      The line 16 should equal "poetry build"
+      The line 10 should equal "Fetch Git references for SonarQube analysis..."
+      The line 11 should equal "git fetch --unshallow --filter=blob:none"
+      The line 12 should equal "=== Poetry Build, Deploy, and Analyze ==="
+      The line 13 should equal "Branch: any-branch"
+      The line 14 should equal "Pull Request: "
+      The line 15 should equal "Deploy Pull Request: false"
+      The line 16 should equal "Replacing version 1.2 with 1.2.0.42"
+      The line 17 should equal "poetry version 1.2.0.42"
+      The line 18 should equal "======= Build other branch ======="
+
+      The line 20 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token dummy access token"
+      The line 21 should equal "jf poetry-config --server-id-resolve repox --repo-resolve <repox pypi repo>"
+      The line 22 should equal "jf poetry install --build-name=my-repo --build-number=42"
+      The line 24 should equal "poetry build"
+      The line 25 should equal "=== Build completed successfully ==="
     End
 End
 
@@ -87,29 +98,30 @@ Describe 'check_tool()'
 End
 
 Describe 'set_build_env()'
-  It 'sets the default branch and project name'
-    export PULL_REQUEST=""
-    export PULL_REQUEST_SHA=""
+  It 'sets the project name and do git fetch'
+    Mock git
+      echo "git $*"
+    End
     When call set_build_env
+    The status should be success
     The line 1 should equal "PROJECT: my-repo"
-    The line 2 should equal "PULL_REQUEST: "
-    The variable DEFAULT_BRANCH should equal "main"
+    The line 2 should equal "Fetch Git references for SonarQube analysis..."
     The variable PROJECT should equal "my-repo"
-    The variable PULL_REQUEST should equal ""
-    The variable PULL_REQUEST_SHA should equal ""
   End
-
-  It 'sets PULL_REQUEST and PULL_REQUEST_SHA for pull requests'
-    export GITHUB_EVENT_NAME="pull_request"
-    export PULL_REQUEST="123"
-    export PULL_REQUEST_SHA="abc123"
-    echo '{"number": 123, "pull_request": {"base": {"sha": "abc123"}}}' > "$GITHUB_EVENT_PATH"
-
+  It 'Fetches base branch for SonarQube analysis'
+    Mock git
+      if [[ "$*" == "rev-parse --is-shallow-repository --quiet" ]]; then
+        return 1
+      else
+        echo "git $*"
+      fi
+    End
+    export GITHUB_BASE_REF="main"
     When call set_build_env
+    The status should be success
     The line 1 should equal "PROJECT: my-repo"
-    The line 2 should equal "PULL_REQUEST: 123"
-    The variable PULL_REQUEST should equal "123"
-    The variable PULL_REQUEST_SHA should equal "abc123"
+    The line 2 should equal "Fetch main for SonarQube analysis..."
+    The variable PROJECT should equal "my-repo"
   End
 End
 
@@ -138,6 +150,20 @@ Describe 'helper functions'
     It 'returns false for non-dogfood branch'
       export GITHUB_REF_NAME="main"
       When call is_dogfood_branch
+      The status should be failure
+    End
+  End
+
+  Describe 'is_merge_queue_branch()'
+    It 'returns true for gh-readonly-queue/* pattern'
+      export GITHUB_REF_NAME="gh-readonly-queue/123"
+      When call is_merge_queue_branch
+      The status should be success
+    End
+
+    It 'returns false for non-mergequeue branch'
+      export GITHUB_REF_NAME="main"
+      When call is_merge_queue_branch
       The status should be failure
     End
   End
@@ -247,29 +273,45 @@ Describe 'build_poetry()'
   End
 
   It 'builds and publishes when on the default branch (main) and not a PR'
-    unset PULL_REQUEST
+    export PULL_REQUEST=""
     export GITHUB_REF_NAME="main"
 
     When call build_poetry
-    The line 1 should equal 'poetry build'
-    The line 2 should equal "jf config remove repox"
-    The line 3 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>"
-    The line 4 should include "/dist"
-    The line 5 should equal "jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42"
-    # ignore line 6 with popd output
-    The line 7 should equal "jf rt build-collect-env my-repo 42"
-    The line 8 should include "jf rt build-publish my-repo 42"
-    The line 9 should be undefined
+    The line 1 should equal '=== Poetry Build, Deploy, and Analyze ==='
+    The line 2 should equal 'Branch: main'
+    The line 3 should equal 'Pull Request: '
+    The line 4 should equal 'Deploy Pull Request: false'
+    The line 5 should equal '======= Building main branch ======='
+    The line 8 should equal 'poetry build'
+    The line 9 should equal 'poetry run pip install pysonar'
+    The line 10 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarqube.test -Dsonar.token=dummy-sonar-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
+    The line 11 should equal 'SonarQube scanner finished'
+    The line 12 should equal 'jf config remove repox'
+    The line 13 should equal 'jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>'
+    The line 14 should include '/dist'
+    The line 15 should equal 'jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42'
+    The line 17 should equal 'jf rt build-collect-env my-repo 42'
+    The line 18 should include 'jf rt build-publish my-repo 42'
+    The line 19 should include '=== Build completed successfully ==='
     The status should be success
   End
 
-  It 'skips when on a PR and DEPLOY_PULL_REQUEST is not true'
+  It 'skips deploy when on a PR and DEPLOY_PULL_REQUEST is not true'
     export GITHUB_EVENT_NAME="pull_request"
     export PULL_REQUEST="123"
     export GITHUB_REF_NAME="123/merge"
 
     When call build_poetry
-    The output should equal 'poetry build'
+    The line 1 should equal '=== Poetry Build, Deploy, and Analyze ==='
+    The line 2 should equal 'Branch: 123/merge'
+    The line 3 should equal 'Pull Request: 123'
+    The line 4 should equal 'Deploy Pull Request: false'
+    The line 5 should equal '======= Building pull request ======='
+    The line 6 should equal '======= no deploy ======='
+    The line 9 should equal 'poetry build'
+    The line 11 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarqube.test -Dsonar.token=dummy-sonar-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
+    The line 12 should equal 'SonarQube scanner finished'
+    The line 13 should equal '=== Build completed successfully ==='
     The status should be success
   End
 
@@ -280,15 +322,75 @@ Describe 'build_poetry()'
     export DEPLOY_PULL_REQUEST="true"
 
     When call build_poetry
-    The line 1 should equal 'poetry build'
-    The line 2 should equal "jf config remove repox"
-    The line 3 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>"
-    The line 4 should include "/dist"
-    The line 5 should equal "jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42"
-    # ignore line 6 with popd output
-    The line 7 should equal "jf rt build-collect-env my-repo 42"
-    The line 8 should include "jf rt build-publish my-repo 42"
-    The line 9 should be undefined
+    The line 1 should equal '=== Poetry Build, Deploy, and Analyze ==='
+    The line 2 should equal 'Branch: 123/merge'
+    The line 3 should equal 'Pull Request: 123'
+    The line 4 should equal 'Deploy Pull Request: true'
+    The line 5 should equal '======= Building pull request ======='
+    The line 6 should equal '======= with deploy ======='
+    The line 9 should equal 'poetry build'
+    The line 11 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarqube.test -Dsonar.token=dummy-sonar-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
+    The line 12 should equal 'SonarQube scanner finished'
+    The line 13 should equal "jf config remove repox"
+    The line 14 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>"
+    The line 15 should include "/dist"
+    The line 16 should equal "jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42"
+    The line 18 should equal "jf rt build-collect-env my-repo 42"
+    The line 19 should include "jf rt build-publish my-repo 42"
     The status should be success
+  End
+
+  It 'disables sonarqube on dogfood branch'
+    export GITHUB_REF_NAME="dogfood-on-test"
+
+    When call build_poetry
+    The line 1 should equal '=== Poetry Build, Deploy, and Analyze ==='
+    The line 2 should equal 'Branch: dogfood-on-test'
+    The line 3 should equal 'Pull Request: '
+    The line 4 should equal 'Deploy Pull Request: false'
+    The line 5 should equal '======= Build dogfood branch ======='
+    The status should be success
+    The variable BUILD_ENABLE_SONAR should equal "false"
+  End
+
+  It 'disables deploy on long-lived branch'
+    export GITHUB_REF_NAME="feature/long/test"
+
+    When call build_poetry
+    The line 1 should equal '=== Poetry Build, Deploy, and Analyze ==='
+    The line 2 should equal 'Branch: feature/long/test'
+    The line 3 should equal 'Pull Request: '
+    The line 4 should equal 'Deploy Pull Request: false'
+    The line 5 should equal '======= Build long-lived feature branch ======='
+    The status should be success
+    The variable BUILD_ENABLE_SONAR should equal "true"
+    The variable BUILD_SONAR_ARGS should equal "-Dsonar.branch.name=feature/long/test"
+  End
+
+  It 'enables deploy and scan on maintenance branch'
+    export GITHUB_REF_NAME="branch-1.2"
+
+    When call build_poetry
+    The line 1 should equal '=== Poetry Build, Deploy, and Analyze ==='
+    The line 2 should equal 'Branch: branch-1.2'
+    The line 3 should equal 'Pull Request: '
+    The line 4 should equal 'Deploy Pull Request: false'
+    The line 5 should equal '======= Building maintenance branch ======='
+    The status should be success
+    The variable BUILD_ENABLE_SONAR should equal "true"
+  End
+
+  It 'disables deploy and scan on merge queue branch'
+    export GITHUB_REF_NAME="gh-readonly-queue/123"
+
+    When call build_poetry
+    The line 1 should equal '=== Poetry Build, Deploy, and Analyze ==='
+    The line 2 should equal 'Branch: gh-readonly-queue/123'
+    The line 3 should equal 'Pull Request: '
+    The line 4 should equal 'Deploy Pull Request: false'
+    The line 5 should equal '======= Build other branch ======='
+    The status should be success
+    The variable BUILD_ENABLE_SONAR should equal "false"
+    The variable BUILD_ENABLE_DEPLOY should equal "false"
   End
 End


### PR DESCRIPTION
[BUILD-8700](https://sonarsource.atlassian.net/browse/BUILD-8700)

Adds sonarqube support in build-poetry action

Tested in https://github.com/SonarSource/sonar-dummy-python-oss/pull/50



[BUILD-8700]: https://sonarsource.atlassian.net/browse/BUILD-8700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


* Add support for sonar-platform parameter
* Run sonar scan using pysonar
* Make code consistent with build-npm