### PR TITLE
BUILD-8568: Fix file path interpretation in windows

### DIFF
--- a/get-build-number/get_build_number.sh
+++ b/get-build-number/get_build_number.sh
@@ -8,7 +8,7 @@ GH_API_VERSION_HEADER="X-GitHub-Api-Version: 2022-11-28"
 CACHE_FILE="build_number.txt"
 
 echo "Fetching build number from repository properties..."
-PROPERTIES_API_URL="/repos/${GITHUB_REPOSITORY}/properties/values"
+PROPERTIES_API_URL="repos/${GITHUB_REPOSITORY}/properties/values"
 BUILD_NUMBER=$(gh api -H "$GH_API_VERSION_HEADER" "$PROPERTIES_API_URL" --jq '.[] | select(.property_name == "build_number") | .value')
 echo "Current build number from repo: ${BUILD_NUMBER:=0}"
 if ! [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
[BUILD-8568](https://sonarsource.atlassian.net/browse/BUILD-8568)

BUILD-8568: Fix file path interpretation in windows

The API path was getting intrepreted as file path in windows and causing issues with windows builds

[BUILD-8568]: https://sonarsource.atlassian.net/browse/BUILD-8568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ