### PR TITLE
BUILD-8776 Improve AI migration guidelines

### DIFF
--- a/.cursor/cirrus-github-migration.md
+++ b/.cursor/cirrus-github-migration.md
@@ -588,6 +588,63 @@ env:
 2. **Configure Build Action**: Add `deploy-pull-request: true` to your build action
 3. **Configure Promote Action**: Add `promote-pull-request: true` to your promote action
 
+##### Overriding SonarQube Platform
+
+The SonarQube platform used for analysis is based on the `SONAR_HOST_URL` in your Cirrus CI configuration.
+
+**🔍 Detection Steps - Follow These Exactly**:
+
+1. **Examine `.cirrus.yml` for SONAR_HOST_URL pattern**:
+   Look for: `SONAR_HOST_URL: VAULT[development/kv/data/... data.url]`
+
+2. **Check the vault path to determine platform**:
+   - `development/kv/data/next` → **No action needed** (default platform)
+   - `development/kv/data/sonarcloud` → Set `sonar-platform: sqc-eu`
+   - `development/kv/data/sonarqube-us` → Set `sonar-platform: sqc-us`
+
+**🎯 Decision Matrix**:
+
+| Vault Path in .cirrus.yml                    | SONAR_HOST_URL Contains | Action Required                    |
+|----------------------------------------------|-------------------------|-----------------------------------|
+| `development/kv/data/next`                   | `next`                  | **No override needed** (default)  |
+| `development/kv/data/sonarcloud`             | `sonarcloud`            | **Set `sonar-platform: sqc-eu`**  |
+| `development/kv/data/sonarqube-us`           | `sonarqube-us`          | **Set `sonar-platform: sqc-us`**  |
+
+**🛠️ Implementation Examples**:
+
+```yaml
+# Example 1: Using sonarcloud platform (EU)
+# Found in .cirrus.yml: SONAR_HOST_URL: VAULT[development/kv/data/sonarcloud data.url]
+- uses: SonarSource/ci-github-actions/build-maven@v1
+  with:
+    sonar-platform: sqc-eu    # Override default next platform
+
+# Example 2: Using sonarqube-us platform (US)
+# Found in .cirrus.yml: SONAR_HOST_URL: VAULT[development/kv/data/sonarqube-us data.url]
+- uses: SonarSource/ci-github-actions/build-maven@v1
+  with:
+    sonar-platform: sqc-us    # Override default next platform
+
+# Example 3: Using next platform (default)
+# Found in .cirrus.yml: SONAR_HOST_URL: VAULT[development/kv/data/next data.url]
+- uses: SonarSource/ci-github-actions/build-maven@v1
+  with:
+    # sonar-platform auto-detected (next) - no override needed
+```
+
+**Available platform options**:
+
+- **`next`**: Default SonarQube platform (auto-detected)
+- **`sqc-eu`**: SonarCloud EU platform
+- **`sqc-us`**: SonarCloud US platform
+
+**Migration Steps**:
+
+1. **Check Cirrus CI**: Look for `SONAR_HOST_URL` in your `.cirrus.yml`
+2. **Identify vault path**: Determine which vault path is used for the SonarQube URL
+3. **Configure platform**: Add `sonar-platform` parameter if needed (see decision matrix above)
+4. **Test analysis**: Verify that SonarQube analysis works with the correct platform
+
 ### Additional Actions
 
 #### cache
@@ -967,6 +1024,11 @@ Only override if you have specific requirements.
   - [ ] If public repo + no patterns found → Use default auto-detection (no override needed)
   - [ ] If private repo → Use default auto-detection (no override needed)
 - [ ] Verify Overriding Pull Request Deployment and Promotion
+- [ ] **Verify Overriding SonarQube Platform**:
+  - [ ] Search `.cirrus.yml` for `SONAR_HOST_URL` vault pattern
+  - [ ] If vault path contains `sonarcloud` → Add `sonar-platform: sqc-eu`
+  - [ ] If vault path contains `sonarqube-us` → Add `sonar-platform: sqc-us`
+  - [ ] If vault path contains `next` → Use default auto-detection (no override needed)
 - [ ] **If using cirrus-modules**: Verify all features are covered by SonarSource custom actions
 - [ ] Test build job functionality
 

--- a/.cursor/cirrus-github-migration.md
+++ b/.cursor/cirrus-github-migration.md
@@ -305,7 +305,6 @@ jobs:
       - uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
         with:
           version: 2025.7.12
-      - uses: SonarSource/ci-github-actions/get-build-number@v1
       - uses: SonarSource/ci-github-actions/build-maven@v1
         with:
           deploy-pull-request: true
@@ -326,7 +325,6 @@ jobs:
         with:
           cache_save: false
           version: 2025.7.12
-      - uses: SonarSource/ci-github-actions/get-build-number@v1
       - uses: SonarSource/ci-github-actions/promote@v1
         with:
           promote-pull-request: true
@@ -340,21 +338,6 @@ repository is public and contains the most up-to-date documentation, examples, a
 instructions for all custom actions.
 
 ### Required Actions for All Projects
-
-#### get-build-number
-
-Generates unique build numbers stored in GitHub repository properties. **Always include this before build actions**.
-
-```yaml
-- uses: SonarSource/ci-github-actions/get-build-number@v1
-```
-
-**Features:**
-
-- Stores build number in repository property `build_number`
-- Sets `BUILD_NUMBER` environment variable and output
-- Unique per workflow run ID (unchanged on reruns)
-- **Required permissions:** `id-token: write`, `contents: read`
 
 #### promote
 
@@ -839,9 +822,8 @@ Standard order:
 
 1. `actions/checkout@v4`
 2. `jdx/mise-action` (tool setup)
-3. `get-build-number@v1`
-4. Build action (`build-maven@v1`, etc.)
-5. `promote@v1` (promote job only)
+3. Build action (`build-maven@v1`, etc.)
+4. `promote@v1` (promote job only)
 
 ### 7. Avoid Unnecessary Environment Variables
 
@@ -893,7 +875,7 @@ Only override if you have specific requirements.
 - [ ] Add standard triggers (push, PR, merge_group, workflow_dispatch)
 - [ ] Select appropriate runner type (sonar-xs for private repos)
 - [ ] Configure concurrency control
-- [ ] Add checkout, mise, get-build-number steps
+- [ ] Add checkout, mise steps
 - [ ] Add appropriate build action (maven/gradle/poetry)
 - [ ] **If using cirrus-modules**: Verify all features are covered by SonarSource custom actions
 - [ ] Test build job functionality
@@ -902,7 +884,7 @@ Only override if you have specific requirements.
 
 - [ ] Add promote job with proper dependencies
 - [ ] Configure same concurrency control
-- [ ] Add checkout, mise (with cache_save: false), get-build-number
+- [ ] Add checkout, mise (with cache_save: false)
 - [ ] Add promote action
 - [ ] Test promotion functionality
 
@@ -1087,7 +1069,6 @@ This workflow automatically:
 
 ### ✅ DO These
 
-- Get build number before promotion (always include `get-build-number@v1`)
 - Move `DEPLOY_PULL_REQUEST` to global environment variable
 - Use Maven cache key format: `maven-${{ runner.os }}` (better UI filtering)
 - Include `pr-cleanup.yml` for automatic PR resource cleanup
@@ -1119,12 +1100,11 @@ This workflow automatically:
 ### Common Issues
 
 1. **Missing permissions**: Ensure `id-token: write` and `contents: write` are set
-2. **Build numbers**: Always include `get-build-number@v1` before build actions
-3. **Tool versions**: Use mise.toml instead of manual setup actions
-4. **Cache conflicts**: Use `cache_save: false` in promote jobs
-5. **Branch conditions**: Let custom actions handle most conditional logic
-6. **Build number continuity**: Set custom property > latest Cirrus CI build
-7. **Artifactory role mismatch**: If your Cirrus CI uses different roles than auto-detected, override them:
+2. **Tool versions**: Use mise.toml instead of manual setup actions
+3. **Cache conflicts**: Use `cache_save: false` in promote jobs
+4. **Branch conditions**: Let custom actions handle most conditional logic
+5. **Build number continuity**: Set custom property > latest Cirrus CI build
+6. **Artifactory role mismatch**: If your Cirrus CI uses different roles than auto-detected, override them:
    ```yaml
    # Check .cirrus.yml for actual roles used and override if needed
    - uses: SonarSource/ci-github-actions/build-maven@v1
@@ -1132,10 +1112,10 @@ This workflow automatically:
        artifactory-reader-role: private-reader    # Match Cirrus CI config
        artifactory-deployer-role: qa-deployer     # Match Cirrus CI config
    ```
-8. **Cirrus-modules migration**: If migrating from cirrus-modules, don't try to recreate individual features
+7. **Cirrus-modules migration**: If migrating from cirrus-modules, don't try to recreate individual features
    manually - use the comprehensive SonarSource custom actions instead
-9. **Security**: Ensure third-party actions are pinned to commit SHA
-10. **Script injection**: Never use untrusted input directly in shell commands
+8. **Security**: Ensure third-party actions are pinned to commit SHA
+9. **Script injection**: Never use untrusted input directly in shell commands
 
 ### Security Troubleshooting
 
@@ -1395,7 +1375,6 @@ jobs:
       - uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
         with:
           version: 2025.7.12
-      - uses: SonarSource/ci-github-actions/get-build-number@v1
       - uses: SonarSource/ci-github-actions/build-maven@v1
         with:
           deploy-pull-request: true
@@ -1416,7 +1395,6 @@ jobs:
         with:
           cache_save: false
           version: 2025.7.12
-      - uses: SonarSource/ci-github-actions/get-build-number@v1
       - uses: SonarSource/ci-github-actions/promote@v1
         with:
           promote-pull-request: true
@@ -1515,7 +1493,6 @@ maven = "3.9"
 
 - Keep it simple - trust the custom actions
 - Use standard triggers and let actions handle the rest
-- Always include `get-build-number@v1`
 - Use `mise.toml` for tool versions
 - Let parameters auto-detect from repository settings (public/private, Artifactory roles)
 - **Leave `.cirrus.yml` unchanged during migration**

--- a/.cursor/cirrus-github-migration.md
+++ b/.cursor/cirrus-github-migration.md
@@ -32,7 +32,7 @@ When updating this migration guide:
 - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
 # Mise Setup - INCLUDES REQUIRED VERSION PARAMETER
-- uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
+- uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
   with:
     version: 2025.7.12
 
@@ -199,7 +199,7 @@ Follow these security principles during migration:
 
 ```yaml
 # ✅ CORRECT - Pinned to commit SHA
-- uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
 # ❌ WRONG - Unpinned versions
 - uses: actions/checkout@v4  # Can be modified
@@ -258,7 +258,7 @@ maven = "3.9"
 ### GitHub Workflow Integration
 
 ```yaml
-      - uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           version: 2025.7.12
 ```
@@ -266,7 +266,7 @@ maven = "3.9"
 **For promote jobs**, disable cache saving:
 
 ```yaml
-- uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
+- uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
   with:
     cache_save: false
     version: 2025.7.12
@@ -276,7 +276,7 @@ maven = "3.9"
 
 ### Basic Template
 
-⚠️ **First, check your repository visibility** (Settings → General → Repository visibility) to select the correct runner.
+⚠️ **First, check your repository visibility** to select the correct runner.
 
 ```yaml
 name: Build
@@ -301,8 +301,8 @@ jobs:
       id-token: write  # Required for Vault OIDC authentication
       contents: write  # Required for repository access and tagging
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           version: 2025.7.12
       - uses: SonarSource/ci-github-actions/build-maven@v1
@@ -320,8 +320,8 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           cache_save: false
           version: 2025.7.12
@@ -874,8 +874,8 @@ by the custom actions. No need to specify cache folders or cleanup scripts.
 
 ```yaml
 # ✅ Pin third-party actions to commit SHA
-- uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-- uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+- uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
   with:
     version: 2025.7.12
 
@@ -1520,8 +1520,8 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           version: 2025.7.12
       - uses: SonarSource/ci-github-actions/build-maven@v1
@@ -1539,8 +1539,8 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           cache_save: false
           version: 2025.7.12
@@ -1612,7 +1612,7 @@ maven = "3.9"
      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
    # ❌ WRONG - GITHUB_TOKEN is already available by default
-   - uses: jdx/mise-action@bfb9fa0b029db830a8c570757cee683df207a6c5 # v2.4.0
+   - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
      env:
        GITHUB_TOKEN: ${{ github.token }}  # Not needed!
    ```


### PR DESCRIPTION
# Changes

- Remove references to get-build-number since it's bundled with the build and promote actions
- Improve documentation on build and promotion parameters
- Configure the sonar-platform parameter for build actions
- Update dependency versions


# Validation

Outputs verified with VSCode and Claude Sonnet 4

> ## Phase 2-3: Create Build and Promote Workflows
> 
> Now I'll create the main build workflow. Based on the migration guide and the Cirrus CI configuration analysis:
> 
> 1.  **Repository visibility**: This is a public repository
> 2.  **Runner selection**: For public repository with auth actions → `ubuntu-24.04-large`
> 3.  **Artifactory roles**: I found `private-reader` and `qa-deployer` patterns in the Cirrus CI config, so I need to override the default roles
> 4.  **SonarQube platform**: Uses `next` platform (default), no override needed
> 5.  **Pull request deployment**: `DEPLOY_PULL_REQUEST: true` is set, so I need `deploy-pull-request: true` and `promote-pull-request: true`
>

[BUILD-8776]: https://sonarsource.atlassian.net/browse/BUILD-8776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ