### PR TITLE
BUILD-8716 Add working-directory parameter to build-maven action

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=SonarSource_ci-github-actions&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=SonarSource_ci-github-actions)
 
-CI/CD GitHub Actions
+## Using AI for Cirrus CI to GitHub Actions Migration
+
+It is recommended to use AI tools like Cursor or Claude code to assist with Cirrus CI to GitHub actions migration.
+This repository contains a comprehensive guide to be passed as a context to AI. The guide is shared with Sonar developers using Cursor,
+accessible using `@Doc` tag.
+
+See the [documentation](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/4232970266/Migration+From+Cirrus+CI+-+GitHub)
+for details on how to use it.
 
 ---
 
@@ -642,12 +649,3 @@ jobs:
 - Seamless API compatibility with standard GitHub Actions cache
 - Supports all standard cache inputs and outputs
 - Automatic repository visibility detection
-
-## Using AI for Cirrus CI to GitHub Actions Migration
-
-It is recommended to use AI tools like Cursor or Claude code to assist with Cirrus CI to GitHub actions migration.
-This repository contains a comprehensive guide to be passed as a context to AI. The guide is shared with Sonar developers using Cursor,
-accessible using `@Doc` tag.
-
-See the [documentation](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/2639560710/Migration+From+Cirrus+CI+-+GitHub)
-for details on how to use it.

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -99,6 +99,7 @@ runs:
         echo "MAVEN_SETTINGS=${MAVEN_CONFIG}/settings.xml" >> "$GITHUB_ENV"
     - name: Build, Analyze and deploy
       shell: bash
+      id: build
       env:
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
@@ -127,3 +128,23 @@ runs:
         rm -rf "$MAVEN_LOCAL_REPOSITORY/org/sonarsource/"
         rm -rf "$MAVEN_LOCAL_REPOSITORY/repository/com/sonarsource/"
         /usr/bin/find "$MAVEN_LOCAL_REPOSITORY" -name resolver-status.properties -delete
+    - name: Generate workflow summary
+      if: always()
+      shell: bash
+      run: |
+        if [[ "${{ steps.build.conclusion }}" == "success" ]]; then
+          echo "# ✅ Build & Deployment Successful" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "# ❌ Build & Deployment Failed" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "## **Details**" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "* **Project**: \`${GITHUB_REPOSITORY#*/}\`" >> $GITHUB_STEP_SUMMARY
+        echo "* **Version**: \`${{ steps.build.outputs.project-version || 'Unknown' }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "* **Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+        ARTIFACTORY_BROWSE_URL="https://repox.jfrog.io/ui/builds/${GITHUB_REPOSITORY#*/}/$BUILD_NUMBER"
+        echo "* **Build**: [View in Artifactory](${ARTIFACTORY_BROWSE_URL})" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "---" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -38,6 +38,9 @@ inputs:
   sonar-platform:
     description: SonarQube primary platform (next, sqc-eu, or sqc-us)
     default: next
+  working-directory:
+    description: Relative path under github.workspace to execute the build in
+    default: .
 
 runs:
   using: composite
@@ -116,6 +119,7 @@ runs:
         SONAR_SCANNER_JAVA_OPTS: ${{ inputs.scanner-java-opts }}
       run: |
         export MAVEN_OPTS="$USER_MAVEN_OPTS -Duser.home=$HOME"
+        cd "${{ inputs.working-directory }}"
         ${GITHUB_ACTION_PATH}/build.sh
     - name: Cleanup Maven repository before caching
       shell: bash

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -156,6 +156,7 @@ set_project_version() {
   echo "Replacing version $current_version with $new_version"
   mvn --settings "$MAVEN_SETTINGS" org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion="$new_version" -DgenerateBackupPoms=false -B -e
   export PROJECT_VERSION=$new_version
+  echo "project-version=$PROJECT_VERSION" >> "$GITHUB_OUTPUT"
 }
 
 build_maven() {


### PR DESCRIPTION
[BUILD-8716](https://sonarsource.atlassian.net/browse/BUILD-8716)

- Add working-directory parameter to build-maven action
  - This is required for the sonar-dummy-maven-enterprise project, where the maven project resides in the private directory
- Generate build summary in build-maven action
- Fix link to docs

[BUILD-8716]: https://sonarsource.atlassian.net/browse/BUILD-8716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ