### PR TITLE
BUILD-8842 Use the gradle-wrapper by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Build and publish a Gradle project with SonarQube analysis and Artifactory deplo
 
 - `development/kv/data/next`, `development/kv/data/sonarcloud`, or `development/kv/data/sonarqube-us`: SonarQube credentials (based on sonar-platform)
 - `development/kv/data/sign`: Artifact signing credentials (key, passphrase, and key_id)
-- `development/kv/data/develocity`: Develocity access token
+- `development/kv/data/develocity`: Develocity access token if `use-develocity: true`
 - `public-reader` or `private-reader`: Artifactory role for reading dependencies
 - `public-deployer` or `qa-deployer`: Artifactory role for deployment
 
@@ -296,8 +296,6 @@ jobs:
 | `deploy-pull-request` | Whether to deploy pull request artifacts | `false` |
 | `skip-tests` | Whether to skip running tests | `false` |
 | `gradle-args` | Additional arguments to pass to Gradle | (optional) |
-| `gradle-version` | Gradle version to use for setup-gradle action | (optional) |
-| `gradle-wrapper-validation` | Whether to validate Gradle wrapper | `true` |
 | `develocity-url` | URL for Develocity | `https://develocity.sonar.build/` |
 | `repox-url` | URL for Repox | `https://repox.jfrog.io` |
 | `sonar-platform` | SonarQube variant - 'next', 'sqc-eu', or 'sqc-us' | `next` |
@@ -310,13 +308,13 @@ jobs:
 
 ### Features
 
+- Uses the gradle wrapper (`./gradlew`) by default and falls back to the `gradle` binary in case it is not found
 - Automated version management with build numbers
 - SonarQube analysis for code quality
 - Conditional deployment based on branch patterns
 - Automatic artifact signing with credentials from Vault
 - Pull request support with optional deployment
-- Develocity integration for build optimization
-- Gradle wrapper validation
+- Develocity integration for build scans
 - Comprehensive build logging and error handling
 
 ## `build-npm`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ for details on how to use it.
 
 ---
 
+## Actions provided in this repository
+
+- [`get-build-number`](#get-build-number)
+- [`build-maven`](#build-maven)
+- [`build-poetry`](#build-poetry)
+- [`build-gradle`](#build-gradle)
+- [`build-npm`](#build-npm)
+- [`build-yarn`](#build-yarn)
+- [`promote`](#promote)
+- [`pr-cleanup`](#pr-cleanup)
+- [`cache`](#cache)
+
 ## `get-build-number`
 
 Manage the build number in GitHub Actions.
@@ -253,9 +265,12 @@ Build and publish a Gradle project with SonarQube analysis and Artifactory deplo
 
 #### Other Dependencies
 
-The Java and Gradle tools must be pre-installed. Use of `mise` is recommended.
+**Java**: Not pre-installed in the runner image. We recommend using `mise` to install and manage Java versions.
 
-Gradle Artifactory plugin configuration is required in your `build.gradle` file.
+**Gradle**: Not pre-installed in the runner image. We recommend including the Gradle wrapper (`gradlew`) in your repository, which will be
+used automatically. If the Gradle wrapper is not available, you can install Gradle using `mise` in your pipeline.
+
+**Additional Configuration**: The Gradle Artifactory plugin configuration is required in your `build.gradle` file.
 
 ### Usage
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -18,17 +18,12 @@ inputs:
     default: ''
   gradle-args:
     description: Additional arguments to pass to Gradle
-  gradle-version:
-    description: Gradle version to use for setup-gradle action
   deploy-pull-request:
     description: Whether to deploy pull request artifacts
     default: 'false'
   skip-tests:
     description: Whether to skip running tests
     default: 'false'
-  gradle-wrapper-validation:
-    description: Whether to validate Gradle wrapper
-    default: 'true'
   use-develocity:
     description: Whether to use Develocity for build tracking.
     default: 'false'
@@ -79,10 +74,10 @@ runs:
           ${{ inputs.use-develocity == 'true' && 'development/kv/data/develocity token | DEVELOCITY_TOKEN;' || '' }}
         # yamllint enable rule:line-length
 
-    - name: Setup Gradle
+    # Configure Gradle for comprehensive caching and build summary reporting. It does not install Gradle.
+    - name: Configure Gradle
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
       with:
-        gradle-version: ${{ inputs.gradle-version }}
         develocity-access-key: >-
          ${{ inputs.use-develocity == 'true' &&
          fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN || '' }}


### PR DESCRIPTION
[BUILD-8842](https://sonarsource.atlassian.net/browse/BUILD-8842)

- Use the gradle wrapper (`./gradlew`) by default and fall back to the `gradle` binary in case it is not found.
- Remove unused parameter `gradle-wrapper-validation`
- Remove `gradle-version` parameter to set conventions on the wrapper

[BUILD-8842]: https://sonarsource.atlassian.net/browse/BUILD-8842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ