### PR TITLE
BUILD-8714 authenticate Gradle with Repox

### DIFF
--- a/.cursor/cirrus-github-migration.md
+++ b/.cursor/cirrus-github-migration.md
@@ -39,7 +39,7 @@ When updating this migration guide:
 # Upload Artifacts
 - name: Upload coverage reports
   if: always() && ! canceled()
-  uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+  uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
   with:
     name: coverage-reports
     path: path/to/coverage.xml
@@ -72,7 +72,7 @@ Update this section when newer versions are released:
 #### Core GitHub Actions
 
 - [ ] `actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0`
-- [ ] `actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0`
+- [ ] `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
 - [ ] `actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8`
 
 #### Build Tools

--- a/.github/workflows/test-pr-cleanup.yml
+++ b/.github/workflows/test-pr-cleanup.yml
@@ -22,7 +22,7 @@ jobs:
           key: test-cache-${{ github.event.pull_request.number }}
 
       - name: Create and upload test artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: test-artifact-${{ github.event.pull_request.number }}
           path: test-cache/test.txt

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ No inputs are required for this action.
 
 ### Outputs
 
-| Output | Description |
-|--------|-------------|
+| Output         | Description              |
+|----------------|--------------------------|
 | `BUILD_NUMBER` | The current build number |
 
 ### Features
@@ -134,21 +134,21 @@ jobs:
 
 ### Inputs
 
-| Input | Description | Default |
-|-------|-------------|---------|
-| `public` | Whether to build and deploy with/to public repositories | Auto-detected from repository visibility |
-| `artifactory-reader-role` | Suffix for the Artifactory reader role in Vault | `private-reader` for private repos, `public-reader` for public repos |
-| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault | `qa-deployer` for private repos, `public-deployer` for public repos |
-| `deploy-pull-request` | Whether to deploy pull request artifacts | `false` |
-| `maven-local-repository-path` | Path to the Maven cache directory, relative to the user home directory | `.m2/repository` |
-| `maven-opts` | Additional Maven options to pass to the build script (`MAVEN_OPTS`) | `-Xmx1536m -Xms128m` |
-| `scanner-java-opts` | Additional Java options for the Sonar scanner (`SONAR_SCANNER_JAVA_OPTS`) | `-Xmx512m` |
-| `use-develocity` | Whether to use Develocity for build tracking | `false` |
-| `repox-url` | URL for Repox | `https://repox.jfrog.io` |
-| `develocity-url` | URL for Develocity | `https://develocity.sonar.build/` |
-| `sonar-platform` | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us' | `next` |
-| `working-directory` | Relative path under github.workspace to execute the build in | `.` |
-| `run-shadow-scans` | If true, run SonarQube analysis on all 3 platforms (next, sqc-eu, sqc-us); if false, only on the selected `sonar-platform` | `false` |
+| Input                         | Description                                                                                                                | Default                                                              |
+|-------------------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| `public`                      | Whether to build and deploy with/to public repositories                                                                    | Auto-detected from repository visibility                             |
+| `artifactory-reader-role`     | Suffix for the Artifactory reader role in Vault                                                                            | `private-reader` for private repos, `public-reader` for public repos |
+| `artifactory-deployer-role`   | Suffix for the Artifactory deployer role in Vault                                                                          | `qa-deployer` for private repos, `public-deployer` for public repos  |
+| `deploy-pull-request`         | Whether to deploy pull request artifacts                                                                                   | `false`                                                              |
+| `maven-local-repository-path` | Path to the Maven cache directory, relative to the user home directory                                                     | `.m2/repository`                                                     |
+| `maven-opts`                  | Additional Maven options to pass to the build script (`MAVEN_OPTS`)                                                        | `-Xmx1536m -Xms128m`                                                 |
+| `scanner-java-opts`           | Additional Java options for the Sonar scanner (`SONAR_SCANNER_JAVA_OPTS`)                                                  | `-Xmx512m`                                                           |
+| `use-develocity`              | Whether to use Develocity for build tracking                                                                               | `false`                                                              |
+| `repox-url`                   | URL for Repox                                                                                                              | `https://repox.jfrog.io`                                             |
+| `develocity-url`              | URL for Develocity                                                                                                         | `https://develocity.sonar.build/`                                    |
+| `sonar-platform`              | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us'                                                                 | `next`                                                               |
+| `working-directory`           | Relative path under github.workspace to execute the build in                                                               | `.`                                                                  |
+| `run-shadow-scans`            | If true, run SonarQube analysis on all 3 platforms (next, sqc-eu, sqc-us); if false, only on the selected `sonar-platform` | `false`                                                              |
 
 ### Outputs
 
@@ -231,18 +231,18 @@ jobs:
 
 ### Inputs
 
-| Input | Description | Default |
-|-------|-------------|---------|
-| `public` | Whether to build and deploy with/to public repositories | Auto-detected from repository visibility |
-| `artifactory-reader-role` | Suffix for the Artifactory reader role in Vault | `private-reader` for private repos, `public-reader` for public repos |
-| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault | `qa-deployer` for private repos, `public-deployer` for public repos |
-| `deploy-pull-request` | Whether to deploy pull request artifacts | `false` |
-| `poetry-virtualenvs-path` | Path to the Poetry virtual environments, relative to GitHub workspace | `.cache/pypoetry/virtualenvs` |
-| `poetry-cache-dir` | Path to the Poetry cache directory, relative to GitHub workspace | `.cache/pypoetry` |
-| `repox-url` | URL for Repox | `https://repox.jfrog.io` |
-| `sonar-platform` | SonarQube primary platform - 'next', 'sqc-eu', sqc-us, or 'none'. Use 'none' to skip sonar scans | `next` |
-| `run-shadow-scans` | If true, run sonar scanner on all 3 platforms using the provided URL and token. If false, run on the platform provided by sonar-platform. When enabled, the sonar-platform setting is ignored | `false` |
-| `working-directory` | Relative path under github.workspace to execute the build in | `.` |
+| Input                       | Description                                                                                                                                                                                   | Default                                                              |
+|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| `public`                    | Whether to build and deploy with/to public repositories                                                                                                                                       | Auto-detected from repository visibility                             |
+| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                                                                                                                               | `private-reader` for private repos, `public-reader` for public repos |
+| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                                                                                                                             | `qa-deployer` for private repos, `public-deployer` for public repos  |
+| `deploy-pull-request`       | Whether to deploy pull request artifacts                                                                                                                                                      | `false`                                                              |
+| `poetry-virtualenvs-path`   | Path to the Poetry virtual environments, relative to GitHub workspace                                                                                                                         | `.cache/pypoetry/virtualenvs`                                        |
+| `poetry-cache-dir`          | Path to the Poetry cache directory, relative to GitHub workspace                                                                                                                              | `.cache/pypoetry`                                                    |
+| `repox-url`                 | URL for Repox                                                                                                                                                                                 | `https://repox.jfrog.io`                                             |
+| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', sqc-us, or 'none'. Use 'none' to skip sonar scans                                                                                              | `next`                                                               |
+| `run-shadow-scans`          | If true, run sonar scanner on all 3 platforms using the provided URL and token. If false, run on the platform provided by sonar-platform. When enabled, the sonar-platform setting is ignored | `false`                                                              |
+| `working-directory`         | Relative path under github.workspace to execute the build in                                                                                                                                  | `.`                                                                  |
 
 ### Outputs
 
@@ -315,25 +315,25 @@ jobs:
 
 ### Inputs
 
-| Input | Description | Default |
-|-------|-------------|---------|
-| `public` | Whether to build and deploy with/to public repositories | Auto-detected from repository visibility |
-| `artifactory-deploy-repo` | Name of deployment repository | Auto-detected based on repository visibility |
-| `artifactory-reader-role` | Suffix for the Artifactory reader role in Vault | `private-reader` for private repos, `public-reader` for public repos |
-| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault | `qa-deployer` for private repos, `public-deployer` for public repos |
-| `deploy-pull-request` | Whether to deploy pull request artifacts | `false` |
-| `skip-tests` | Whether to skip running tests | `false` |
-| `use-develocity` | Whether to use Develocity for build tracking | `false` |
-| `gradle-args` | Additional arguments to pass to Gradle | (optional) |
-| `develocity-url` | URL for Develocity | `https://develocity.sonar.build/` |
-| `repox-url` | URL for Repox | `https://repox.jfrog.io` |
-| `sonar-platform` | SonarQube variant - 'next', 'sqc-eu', or 'sqc-us' | `next` |
-| `run-shadow-scans` | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false` |
+| Input                       | Description                                                                    | Default                                                              |
+|-----------------------------|--------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| `public`                    | Whether to build and deploy with/to public repositories                        | Auto-detected from repository visibility                             |
+| `artifactory-deploy-repo`   | Name of deployment repository                                                  | Auto-detected based on repository visibility                         |
+| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                | `private-reader` for private repos, `public-reader` for public repos |
+| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                              | `qa-deployer` for private repos, `public-deployer` for public repos  |
+| `deploy-pull-request`       | Whether to deploy pull request artifacts                                       | `false`                                                              |
+| `skip-tests`                | Whether to skip running tests                                                  | `false`                                                              |
+| `use-develocity`            | Whether to use Develocity for build tracking                                   | `false`                                                              |
+| `gradle-args`               | Additional arguments to pass to Gradle                                         | (optional)                                                           |
+| `develocity-url`            | URL for Develocity                                                             | `https://develocity.sonar.build/`                                    |
+| `repox-url`                 | URL for Repox                                                                  | `https://repox.jfrog.io`                                             |
+| `sonar-platform`            | SonarQube variant - 'next', 'sqc-eu', or 'sqc-us'                              | `next`                                                               |
+| `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                              |
 
 ### Outputs
 
-| Output | Description |
-|--------|-------------|
+| Output            | Description                                |
+|-------------------|--------------------------------------------|
 | `project-version` | The project version from gradle.properties |
 
 ### Features
@@ -409,26 +409,26 @@ jobs:
 
 ### Inputs
 
-| Input | Description | Default |
-|-------|-------------|---------|
-| `public` | Whether to build and deploy with/to public repositories | Auto-detected from repository visibility |
-| `artifactory-reader-role` | Suffix for the Artifactory reader role in Vault | `private-reader` for private repos, `public-reader` for public repos |
-| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault | `qa-deployer` for private repos, `public-deployer` for public repos |
-| `artifactory-deploy-repo` | Name of deployment repository | (optional) |
-| `artifactory-deploy-access-token` | Access token to deploy to Artifactory | (optional) |
-| `deploy-pull-request` | Whether to deploy pull request artifacts | `false` |
-| `skip-tests` | Whether to skip running tests | `false` |
-| `cache-npm` | Whether to cache NPM dependencies | `true` |
-| `repox-url` | URL for Repox | `https://repox.jfrog.io` |
-| `sonar-platform` | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us' | `next` |
-| `run-shadow-scans` | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false` |
+| Input                             | Description                                                                    | Default                                                              |
+|-----------------------------------|--------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| `public`                          | Whether to build and deploy with/to public repositories                        | Auto-detected from repository visibility                             |
+| `artifactory-reader-role`         | Suffix for the Artifactory reader role in Vault                                | `private-reader` for private repos, `public-reader` for public repos |
+| `artifactory-deployer-role`       | Suffix for the Artifactory deployer role in Vault                              | `qa-deployer` for private repos, `public-deployer` for public repos  |
+| `artifactory-deploy-repo`         | Name of deployment repository                                                  | (optional)                                                           |
+| `artifactory-deploy-access-token` | Access token to deploy to Artifactory                                          | (optional)                                                           |
+| `deploy-pull-request`             | Whether to deploy pull request artifacts                                       | `false`                                                              |
+| `skip-tests`                      | Whether to skip running tests                                                  | `false`                                                              |
+| `cache-npm`                       | Whether to cache NPM dependencies                                              | `true`                                                               |
+| `repox-url`                       | URL for Repox                                                                  | `https://repox.jfrog.io`                                             |
+| `sonar-platform`                  | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us'                     | `next`                                                               |
+| `run-shadow-scans`                | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                              |
 
 ### Outputs
 
-| Output | Description |
-|--------|-------------|
+| Output            | Description                           |
+|-------------------|---------------------------------------|
 | `project-version` | The project version from package.json |
-| `build-info-url` | The JFrog build info UI URL |
+| `build-info-url`  | The JFrog build info UI URL           |
 
 ### Features
 
@@ -503,25 +503,25 @@ jobs:
 
 ### Inputs
 
-| Input | Description | Default |
-|-------|-------------|---------|
-| `public` | Whether to build and deploy with/to public repositories | Auto-detected from repository visibility |
-| `artifactory-reader-role` | Suffix for the Artifactory reader role in Vault | `private-reader` for private repos, `public-reader` for public repos |
-| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault | `qa-deployer` for private repos, `public-deployer` for public repos |
-| `artifactory-deploy-repo` | Name of deployment repository | (optional) |
-| `deploy-pull-request` | Whether to deploy pull request artifacts | `false` |
-| `skip-tests` | Whether to skip running tests | `false` |
-| `cache-yarn` | Whether to cache Yarn dependencies | `true` |
-| `repox-url` | URL for Repox | `https://repox.jfrog.io` |
-| `sonar-platform` | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us' | `next` |
-| `run-shadow-scans` | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false` |
+| Input                       | Description                                                                    | Default                                                              |
+|-----------------------------|--------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| `public`                    | Whether to build and deploy with/to public repositories                        | Auto-detected from repository visibility                             |
+| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                | `private-reader` for private repos, `public-reader` for public repos |
+| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                              | `qa-deployer` for private repos, `public-deployer` for public repos  |
+| `artifactory-deploy-repo`   | Name of deployment repository                                                  | (optional)                                                           |
+| `deploy-pull-request`       | Whether to deploy pull request artifacts                                       | `false`                                                              |
+| `skip-tests`                | Whether to skip running tests                                                  | `false`                                                              |
+| `cache-yarn`                | Whether to cache Yarn dependencies                                             | `true`                                                               |
+| `repox-url`                 | URL for Repox                                                                  | `https://repox.jfrog.io`                                             |
+| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us'                     | `next`                                                               |
+| `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                              |
 
 ### Outputs
 
-| Output | Description |
-|--------|-------------|
+| Output            | Description                           |
+|-------------------|---------------------------------------|
 | `project-version` | The project version from package.json |
-| `build-info-url` | The JFrog build info UI URL |
+| `build-info-url`  | The JFrog build info UI URL           |
 
 ### Features
 
@@ -583,11 +583,11 @@ promote:
 
 ### Inputs
 
-| Input | Description | Default |
-|-------|-------------|---------|
-| `promote-pull-request` | Whether to promote pull request artifacts. Requires `deploy-pull-request` input to be set to `true` in the build action | `false` |
-| `multi-repo` | If true, promotes to public and private repositories. For projects with both public and private artifacts | (optional) |
-| `artifactory-deploy-repo` | Repository to deploy to. If not set, it will be retrieved from the build info | (optional) |
+| Input                     | Description                                                                                                               | Default    |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------|------------|
+| `promote-pull-request`    | Whether to promote pull request artifacts. Requires `deploy-pull-request` input to be set to `true` in the build action   | `false`    |
+| `multi-repo`              | If true, promotes to public and private repositories. For projects with both public and private artifacts                 | (optional) |
+| `artifactory-deploy-repo` | Repository to deploy to. If not set, it will be retrieved from the build info                                             | (optional) |
 | `artifactory-target-repo` | Target repository for the promotion. If not set, it will be determined based on the branch type and the deploy repository | (optional) |
 
 ### Outputs
@@ -681,20 +681,20 @@ jobs:
 
 ### Inputs
 
-| Input | Description | Default |
-|-------|-------------|---------|
-| `path` | A list of files, directories, and wildcard patterns to cache and restore | (required) |
-| `key` | An explicit key for restoring and saving the cache | (required) |
-| `restore-keys` | An ordered list of prefix-matched keys to use for restoring stale cache if no cache hit occurred for key | (optional) |
-| `upload-chunk-size` | The chunk size used to split up large files during upload, in bytes | (optional) |
-| `enableCrossOsArchive` | When enabled, allows to save or restore caches that can be restored or saved respectively on other platforms | `false` |
-| `fail-on-cache-miss` | Fail the workflow if cache entry is not found | `false` |
-| `lookup-only` | Check if a cache entry exists for the given input(s) without downloading the cache | `false` |
+| Input                  | Description                                                                                                  | Default    |
+|------------------------|--------------------------------------------------------------------------------------------------------------|------------|
+| `path`                 | A list of files, directories, and wildcard patterns to cache and restore                                     | (required) |
+| `key`                  | An explicit key for restoring and saving the cache                                                           | (required) |
+| `restore-keys`         | An ordered list of prefix-matched keys to use for restoring stale cache if no cache hit occurred for key     | (optional) |
+| `upload-chunk-size`    | The chunk size used to split up large files during upload, in bytes                                          | (optional) |
+| `enableCrossOsArchive` | When enabled, allows to save or restore caches that can be restored or saved respectively on other platforms | `false`    |
+| `fail-on-cache-miss`   | Fail the workflow if cache entry is not found                                                                | `false`    |
+| `lookup-only`          | Check if a cache entry exists for the given input(s) without downloading the cache                           | `false`    |
 
 ### Outputs
 
-| Output | Description |
-|--------|-------------|
+| Output      | Description                                                              |
+|-------------|--------------------------------------------------------------------------|
 | `cache-hit` | A boolean value to indicate an exact match was found for the primary key |
 
 ### Features

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -74,10 +74,10 @@ runs:
           development/kv/data/sonarqube-us token | SQC_US_TOKEN;
           development/kv/data/sonarcloud url | SQC_EU_URL;
           development/kv/data/sonarcloud token | SQC_EU_TOKEN;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_USERNAME;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} access_token | ARTIFACTORY_ACCESS_TOKEN;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} username | ARTIFACTORY_DEPLOY_USERNAME;
-          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} access_token | ARTIFACTORY_DEPLOY_PASSWORD;
-          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_READER_USERNAME;
-          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} access_token | ARTIFACTORY_READER_PASSWORD;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} access_token | ARTIFACTORY_DEPLOY_ACCESS_TOKEN;
           development/kv/data/sign key | SIGN_KEY;
           development/kv/data/sign passphrase | PGP_PASSPHRASE;
           development/kv/data/sign key_id | SIGN_KEY_ID;
@@ -92,6 +92,13 @@ runs:
          ${{ inputs.use-develocity == 'true' &&
          fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN || '' }}
         develocity-injection-enabled: ${{ inputs.use-develocity == 'true' }}
+    # $GRADLE_USER_HOME is typically set to ~/.gradle/ by gradle/actions/setup-gradle
+    - name: Configure Gradle Authentication
+      shell: bash
+      run: |
+        GRADLE_INIT_DIR="$GRADLE_USER_HOME/init.d"
+        mkdir -p "$GRADLE_INIT_DIR"
+        cp "${GITHUB_ACTION_PATH}/resources/repoxAuth.init.gradle.kts" "$GRADLE_INIT_DIR/"
 
     - name: Build, analyze and deploy
       id: build
@@ -104,12 +111,15 @@ runs:
 
         # Action inputs
         ARTIFACTORY_URL: ${{ inputs.repox-url }}/artifactory
+        ARTIFACTORY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }} # unused; present for backward compliance
+        ARTIFACTORY_ACCESS_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }} # deprecated, backward compliance
+        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+        ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }} # deprecated, backward compliance
         ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
           (inputs.public == 'true' && 'sonarsource-public-qa' || 'sonarsource-private-qa') }}
         ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
-        ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
-        ARTIFACTORY_PRIVATE_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_READER_PASSWORD }}
-        ARTIFACTORY_PRIVATE_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_READER_USERNAME }}
+        ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
+        ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }} # used in parent POM
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
         SKIP_TESTS: ${{ inputs.skip-tests }}
         GRADLE_ARGS: ${{ inputs.gradle-args }}
@@ -127,7 +137,15 @@ runs:
         ORG_GRADLE_PROJECT_signingPassword: ${{ fromJSON(steps.secrets.outputs.vault).PGP_PASSPHRASE }}
         ORG_GRADLE_PROJECT_signingKeyId: ${{ fromJSON(steps.secrets.outputs.vault).SIGN_KEY_ID }}
       run: |
-        ${{ github.action_path }}/build.sh
+        ${GITHUB_ACTION_PATH}/build.sh
+
+    - name: Archive problems report
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: problems-report
+        path: build/reports/problems/problems-report.html
+        if-no-files-found: ignore
 
     - name: Generate workflow summary
       if: always()
@@ -140,7 +158,7 @@ runs:
         echo "### 📋 Build Information" >> $GITHUB_STEP_SUMMARY
         echo "- **Project**: ${GITHUB_REPOSITORY#*/}" >> $GITHUB_STEP_SUMMARY
         echo "- **Version**: ${{ steps.build.outputs.project-version || 'Unknown' }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Build Number**: ${{ env.BUILD_NUMBER }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Build Number**: $BUILD_NUMBER" >> $GITHUB_STEP_SUMMARY
         echo "- **Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
 

--- a/build-gradle/resources/repoxAuth.init.gradle.kts
+++ b/build-gradle/resources/repoxAuth.init.gradle.kts
@@ -1,0 +1,117 @@
+/**
+ * Authenticate repox.jfrog.io repositories with Bearer scheme
+ *
+ * Credentials can be set by using one of these options:
+ * - Gradle property:
+ *   - ~/.gradle/gradle.properties:
+ *     - {repo name}AuthHeaderValue=...
+ *     - {repo name}AuthAccessToken=...
+ *     - artifactoryPassword=...
+ *   - CLI arg:
+ *     - -P{repo name}AuthHeaderValue=...
+ *     - -P{repo name}AuthAccessToken=...
+ *     - -PartifactoryPassword=...
+ *     - -Dorg.gradle.project.{repo name}AuthHeaderValue=...
+ *     - -Dorg.gradle.project.{repo name}AuthAccessToken=...
+ *     - -Dorg.gradle.project.artifactoryPassword=...
+ * - Environment variable:
+ *   - ORG_GRADLE_PROJECT_{repo name}AuthHeaderValue=...
+ *   - ORG_GRADLE_PROJECT_{repo name}AuthAccessToken=...
+ *   - ORG_GRADLE_PROJECT_artifactoryPassword=...
+ *   - ARTIFACTORY_ACCESS_TOKEN=...
+ *   - ARTIFACTORY_PASSWORD=...
+ *   - ARTIFACTORY_PRIVATE_READER_TOKEN=...
+ *   - ARTIFACTORY_PRIVATE_PASSWORD=...
+ *   - ARTIFACTORY_DEPLOY_PASSWORD=...
+ *   - ARTIFACTORY_DEPLOY_ACCESS_TOKEN=...
+ *
+ * The first one presented will be used.
+ */
+
+beforeSettings {
+    pluginManagement {
+        // hook between repository configuration and plugin resolution
+        resolutionStrategy {
+            eachPlugin {
+                repositories {
+                    enableBearerAuthForRepoxRepositories(providers)
+                }
+            }
+        }
+    }
+}
+
+allprojects {
+    beforeEvaluate {
+        repositories {
+            enableBearerAuthForRepoxRepositories(providers)
+        }
+    }
+    afterEvaluate {
+        repositories {
+            enableBearerAuthForRepoxRepositories(providers)
+        }
+    }
+}
+
+class RepoxAuth {
+    companion object {
+        const val host = "repox.jfrog.io"
+        const val authType = "header"
+        const val authHeaderName = "Authorization"
+        const val authValueScheme = "Bearer"
+        val accessTokenEnvVars = listOf(
+                "ARTIFACTORY_ACCESS_TOKEN",
+                "ARTIFACTORY_DEPLOY_ACCESS_TOKEN",
+                "ARTIFACTORY_PASSWORD", // deprecated
+                "ARTIFACTORY_PRIVATE_READER_TOKEN", // deprecated
+                "ARTIFACTORY_PRIVATE_PASSWORD", // deprecated
+                "ARTIFACTORY_DEPLOY_PASSWORD" // deprecated
+        )
+    }
+}
+
+fun RepositoryHandler.addBearerAuthForRepoxRepositories(token: (String) -> Provider<String>) {
+    filter {
+        (it as? UrlArtifactRepository)?.url?.host == RepoxAuth.host
+    }.forEach { repoCandidate ->
+        (repoCandidate as? AuthenticationSupported)?.runCatching {
+            if (authentication.any { it is HttpHeaderAuthentication }) return@forEach
+            apply {
+                credentials(HttpHeaderCredentials::class) {
+                    name = RepoxAuth.authHeaderName
+                    value = token(repoCandidate.name).map {
+                        "${RepoxAuth.authValueScheme} ${it.substringAfter(" ")}"
+                    }.orNull
+                }
+            }
+        }?.onSuccess {
+            it.authentication {
+                add(create<HttpHeaderAuthentication>(RepoxAuth.authType))
+            }
+            logger.info(
+                    "Set '{}' auth for '{}' repository",
+                    RepoxAuth.authType,
+                    repoCandidate.name,
+            )
+
+        }
+    }
+}
+
+fun <T> Provider<T>.orElse(vararg providers: Provider<T>) =
+        listOf(this, *providers).reduce { p1, p2 ->
+            p1.orElse(p2)
+        }
+
+fun RepositoryHandler.enableBearerAuthForRepoxRepositories(providers: ProviderFactory) {
+    addBearerAuthForRepoxRepositories {
+        providers.gradleProperty("${it}AuthHeaderValue").orElse(
+                providers.gradleProperty("${it}AuthAccessToken"),
+                providers.gradleProperty("artifactoryPassword"),
+                *(RepoxAuth.accessTokenEnvVars.map { envVar ->
+                    providers.environmentVariable(envVar)
+                }.toTypedArray())
+        )
+    }
+}

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -73,10 +73,10 @@ runs:
       uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       with:
         secrets: |
-          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_ACCESS_USERNAME;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_USERNAME;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} access_token | ARTIFACTORY_ACCESS_TOKEN;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} username | ARTIFACTORY_DEPLOY_USERNAME;
-          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} access_token | ARTIFACTORY_DEPLOY_PASSWORD;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} access_token | ARTIFACTORY_DEPLOY_ACCESS_TOKEN;
 
           development/kv/data/next url | NEXT_URL;
           development/kv/data/next token | NEXT_TOKEN;
@@ -113,11 +113,14 @@ runs:
       id: build
       env:
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        ARTIFACTORY_ACCESS_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_USERNAME }}
+        ARTIFACTORY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }} # unused; present for backward compliance
+        ARTIFACTORY_ACCESS_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }} # deprecated, backward compliance
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+        ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }} # deprecated, backward compliance
         ARTIFACTORY_DEPLOY_REPO: ${{ inputs.public == 'true' && 'sonarsource-public-qa' || 'sonarsource-private-qa' }}
         ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
-        ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_PASSWORD }}
+        ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
+        ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }} # used in parent POM
         SIGN_KEY: ${{ fromJSON(steps.secrets.outputs.vault).SIGN_KEY }}
 
         # Vault secrets

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -13,10 +13,10 @@
 # - SQC_EU_TOKEN: Access token to send analysis reports to SonarQube for sqc-eu platform
 # - RUN_SHADOW_SCANS: If true, run sonar scanner on all 3 platforms. If false, run on the platform provided by SONAR_PLATFORM.
 # - ARTIFACTORY_URL: Artifactory repository URL
+# - ARTIFACTORY_ACCESS_TOKEN: Access token to read Repox repositories
 # - ARTIFACTORY_DEPLOY_REPO: Deployment repository name
-# - ARTIFACTORY_DEPLOY_PASSWORD: Access token to deploy to the repository
-# - ARTIFACTORY_ACCESS_TOKEN: Access token to access the private repository
 # - ARTIFACTORY_DEPLOY_USERNAME: Username used by artifactory-maven-plugin
+# - ARTIFACTORY_DEPLOY_PASSWORD: Access token to deploy to the repository
 # - DEFAULT_BRANCH: Default branch name (e.g. main)
 # - PULL_REQUEST: Pull request number (e.g. 1234) or empty string
 #

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -13,7 +13,7 @@
 # - SQC_EU_TOKEN: Access token to send analysis reports to SonarQube for sqc-eu platform
 # - RUN_SHADOW_SCANS: If true, run sonar scanner on all 3 platforms. If false, run on the platform provided by SONAR_PLATFORM.
 # - ARTIFACTORY_URL: URL to Artifactory repository
-# - ARTIFACTORY_ACCESS_TOKEN: Access token to access the repository
+# - ARTIFACTORY_ACCESS_TOKEN: Access token to read Repox repositories
 # - ARTIFACTORY_DEPLOY_ACCESS_TOKEN: Access token to deploy to Artifactory
 # - ARTIFACTORY_DEPLOY_REPO: Name of deployment repository
 # - DEFAULT_BRANCH: Default branch name (e.g. main)

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -6,7 +6,7 @@
 # - BUILD_NUMBER: Build number for versioning
 # - ARTIFACTORY_URL: URL to Artifactory repository
 # - ARTIFACTORY_PYPI_REPO: Repository to install dependencies from
-# - ARTIFACTORY_ACCESS_TOKEN: Access token to access the repository
+# - ARTIFACTORY_ACCESS_TOKEN: Access token to read Repox repositories
 # - ARTIFACTORY_DEPLOY_REPO: Deployment repository name
 # - ARTIFACTORY_DEPLOY_ACCESS_TOKEN: Access token to deploy to the repository
 # - DEFAULT_BRANCH: Default branch name (e.g. main)

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -13,7 +13,7 @@
 # - SQC_EU_TOKEN: Access token to send analysis reports to SonarQube for sqc-eu platform
 # - RUN_SHADOW_SCANS: If true, run sonar scanner on all 3 platforms. If false, run on the platform provided by SONAR_PLATFORM.
 # - ARTIFACTORY_URL: URL to Artifactory repository
-# - ARTIFACTORY_ACCESS_TOKEN: Access token to access the repository
+# - ARTIFACTORY_ACCESS_TOKEN: Access token to read Repox repositories
 # - ARTIFACTORY_DEPLOY_ACCESS_TOKEN: Access token to deploy to Artifactory
 # - ARTIFACTORY_DEPLOY_REPO: Name of deployment repository
 # - DEFAULT_BRANCH: Default branch name (e.g. main)

--- a/shared/common-functions.sh
+++ b/shared/common-functions.sh
@@ -38,12 +38,7 @@ set_sonar_platform_vars() {
       return 1
       ;;
   esac
-
-  if [ -n "${SONAR_REGION:-}" ]; then
-    echo "Using Sonar platform: $platform (URL: $SONAR_HOST_URL, Region: $SONAR_REGION)"
-  else
-    echo "Using Sonar platform: $platform (URL: $SONAR_HOST_URL)"
-  fi
+  echo "Using Sonar platform: $platform (URL: ${SONAR_HOST_URL#*//}, Region: ${SONAR_REGION:-none})"
 }
 
 # ORCHESTRATOR FUNCTION: Multi-platform SonarQube analysis coordinator

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -381,7 +381,7 @@ End
     It 'sets sonar variables for next platform'
       When call set_sonar_platform_vars "next"
       The status should be success
-      The output should include "Using Sonar platform: next (URL: https://next.sonarqube.com)"
+      The line 1 should equal "Using Sonar platform: next (URL: next.sonarqube.com, Region: none)"
       The variable SONAR_HOST_URL should equal "https://next.sonarqube.com"
       The variable SONAR_TOKEN should equal "next-token"
     End
@@ -389,7 +389,7 @@ End
     It 'sets sonar variables for sqc-us platform'
       When call set_sonar_platform_vars "sqc-us"
       The status should be success
-      The output should include "Using Sonar platform: sqc-us (URL: https://sonarqube-us.example.com, Region: us)"
+      The line 1 should equal "Using Sonar platform: sqc-us (URL: sonarqube-us.example.com, Region: us)"
       The variable SONAR_HOST_URL should equal "https://sonarqube-us.example.com"
       The variable SONAR_TOKEN should equal "sqc-us-token"
     End
@@ -397,7 +397,7 @@ End
     It 'sets sonar variables for sqc-eu platform'
       When call set_sonar_platform_vars "sqc-eu"
       The status should be success
-      The output should include "Using Sonar platform: sqc-eu (URL: https://sonarcloud.io)"
+      The line 1 should equal "Using Sonar platform: sqc-eu (URL: sonarcloud.io, Region: none)"
       The variable SONAR_HOST_URL should equal "https://sonarcloud.io"
       The variable SONAR_TOKEN should equal "sqc-eu-token"
     End

--- a/spec/build-yarn_spec.sh
+++ b/spec/build-yarn_spec.sh
@@ -248,7 +248,7 @@ Describe 'build-yarn/build.sh'
     It 'sets sonar variables for next platform'
       When call set_sonar_platform_vars "next"
       The status should be success
-      The output should include "Using Sonar platform: next (URL: https://next.sonarqube.com)"
+      The line 1 should equal "Using Sonar platform: next (URL: next.sonarqube.com, Region: none)"
       The variable SONAR_HOST_URL should equal "https://next.sonarqube.com"
       The variable SONAR_TOKEN should equal "next-token"
     End
@@ -256,7 +256,7 @@ Describe 'build-yarn/build.sh'
     It 'sets sonar variables for sqc-us platform'
       When call set_sonar_platform_vars "sqc-us"
       The status should be success
-      The output should include "Using Sonar platform: sqc-us (URL: https://sonarqube-us.example.com, Region: us)"
+      The line 1 should equal "Using Sonar platform: sqc-us (URL: sonarqube-us.example.com, Region: us)"
       The variable SONAR_HOST_URL should equal "https://sonarqube-us.example.com"
       The variable SONAR_TOKEN should equal "sqc-us-token"
     End
@@ -264,7 +264,7 @@ Describe 'build-yarn/build.sh'
     It 'sets sonar variables for sqc-eu platform'
       When call set_sonar_platform_vars "sqc-eu"
       The status should be success
-      The output should include "Using Sonar platform: sqc-eu (URL: https://sonarcloud.io)"
+      The line 1 should equal "Using Sonar platform: sqc-eu (URL: sonarcloud.io, Region: none)"
       The variable SONAR_HOST_URL should equal "https://sonarcloud.io"
       The variable SONAR_TOKEN should equal "sqc-eu-token"
     End


### PR DESCRIPTION
[BUILD-8714](https://sonarsource.atlassian.net/browse/BUILD-8714)

Authenticate Gradle with Repox, using `ARTIFACTORY_ACCESS_TOKEN` environment variable.
The `repoxAuth.init.gradle.kts` file is the same init script which can be used locally by developers.
There is a fallback to the legacy variables for backward compliance.

The build-gradle action sets the following environment variables:
- `ARTIFACTORY_USERNAME`: unused; present for eventual backward compliance
- `ARTIFACTORY_ACCESS_TOKEN`: token used to authenticate for build
- `ARTIFACTORY_PASSWORD`: backward compliance; this is used by some client Gradle projects
- `ARTIFACTORY_DEPLOY_ACCESS_TOKEN`: token used to deploy artifacts, this is configured in the client Gradle projects
- `ARTIFACTORY_DEPLOY_PASSWORD`: backward compliance; this is used by some client Gradle projects

The Gradle problem reports file is archived when present.
See https://github.com/SonarSource/sonar-dummy-gradle-oss/actions/runs/17240749748/artifacts/3854078587

Fixed SQ URL output for info.

Slightly simplified code and tests.

Tested by https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/275

[BUILD-8714]: https://sonarsource.atlassian.net/browse/BUILD-8714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ