### PR TITLE
BUILD-8939 sonar project version

### DIFF
--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -46,7 +46,7 @@ inputs:
 
 outputs:
   project-version:
-    description: The project version from gradle.properties
+    description: The release version set as Gradle project version in gradle.properties
     value: ${{ steps.build.outputs.project-version }}
 
 runs:

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -155,6 +155,7 @@ runs:
         rm -rf "$MAVEN_LOCAL_REPOSITORY/org/sonarsource/"
         rm -rf "$MAVEN_LOCAL_REPOSITORY/repository/com/sonarsource/"
         /usr/bin/find "$MAVEN_LOCAL_REPOSITORY" -name resolver-status.properties -delete
+
     - name: Generate workflow summary
       if: always()
       shell: bash
@@ -169,6 +170,7 @@ runs:
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "* **Project**: \`${GITHUB_REPOSITORY#*/}\`" >> $GITHUB_STEP_SUMMARY
         echo "* **Version**: \`${{ steps.build.outputs.project-version || 'Unknown' }}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Build Number**: ${{ env.BUILD_NUMBER }}" >> $GITHUB_STEP_SUMMARY
         echo "* **Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
         ARTIFACTORY_BROWSE_URL="https://repox.jfrog.io/ui/builds/${GITHUB_REPOSITORY#*/}/$BUILD_NUMBER"
         echo "* **Build**: [View in Artifactory](${ARTIFACTORY_BROWSE_URL})" >> $GITHUB_STEP_SUMMARY

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -43,7 +43,7 @@ inputs:
 outputs:
   project-version:
     description: The project version from pyproject.toml with BUILD_NUMBER
-    value: ${{ env.PROJECT_VERSION }}
+    value: ${{ steps.build.outputs.project-version }}
 
 runs:
   using: composite
@@ -87,6 +87,7 @@ runs:
           development/kv/data/sonarcloud token | SQC_EU_TOKEN;
       # yamllint enable rule:line-length
     - name: Build, Analyze and deploy
+      id: build
       shell: bash
       env:
         # GitHub context

--- a/shared/common-functions.sh
+++ b/shared/common-functions.sh
@@ -56,12 +56,13 @@ orchestrate_sonar_platforms() {
       local platforms=("next" "sqc-us" "sqc-eu")
 
       for platform in "${platforms[@]}"; do
+          echo "::group::Sonar analysis on $platform"
           echo "--- ORCHESTRATOR: Analyzing with platform: $platform ---"
           set_sonar_platform_vars "$platform"
           # CALLBACK: Hand control back to build script's implementation
           sonar_scanner_implementation "$@"
+          echo "::endgroup::"
       done
-
       echo "=== ORCHESTRATOR: Completed Sonar analysis on all platforms ==="
   else
       echo "=== ORCHESTRATOR: Running Sonar analysis on selected platform: $SONAR_PLATFORM ==="

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -97,10 +97,9 @@ echo '{"version": "1.2.3-SNAPSHOT", "name": "test-project"}' > package.json
 
 # Source shared functions before including build script
 Include shared/common-functions.sh
+Include build-npm/build.sh
 
 Describe 'build-npm/build.sh'
-  Include build-npm/build.sh
-
   Describe 'Tool checking'
     It 'checks required tools are available'
       When call check_tool jq --version
@@ -135,7 +134,7 @@ Describe 'build-npm/build.sh'
       The output should include "git fetch --filter=blob:none origin main"
     End
   End
-
+End
 
 Describe 'git_fetch_unshallow()'
   It 'fetches unshallow when repository is shallow'
@@ -197,7 +196,162 @@ Describe 'Version format checking'
   End
 End
 
-Describe 'Maintenance branch 2-digit version handling'
+Describe 'set_project_version()'
+  It 'exits with error when version cannot be read from package.json'
+    export MOCK_VERSION="null"
+    export BUILD_NUMBER="42"
+    export GITHUB_OUTPUT=/dev/null
+    export GITHUB_REF_NAME="main"
+    When run set_project_version
+    The status should be failure
+    The stderr should include "Could not get version from package.json"
+    The variable CURRENT_VERSION should be undefined
+    The variable PROJECT_VERSION should be undefined
+  End
+
+  It 'exits with error when version is empty'
+    export MOCK_VERSION=""
+    export BUILD_NUMBER="42"
+    export GITHUB_OUTPUT=/dev/null
+    export GITHUB_REF_NAME="main"
+    When run set_project_version
+    The status should be failure
+    The stderr should include "Could not get version from package.json"
+    The variable CURRENT_VERSION should be undefined
+    The variable PROJECT_VERSION should be undefined
+  End
+
+  It 'adds .0 to 2-digit version numbers'
+    export MOCK_VERSION="1.2-SNAPSHOT"
+    export BUILD_NUMBER="42"
+    export GITHUB_OUTPUT=/dev/null
+    export GITHUB_REF_NAME="main"
+    When call set_project_version
+    The status should be success
+    The output should include "Replacing version 1.2-SNAPSHOT with 1.2.0-42"
+    The variable CURRENT_VERSION should equal "1.2-SNAPSHOT"
+    The variable PROJECT_VERSION should equal "1.2.0-42"
+  End
+End
+
+Describe 'build_npm()'
+  It 'builds main branch correctly'
+    export GITHUB_REF_NAME="main"
+    export DEFAULT_BRANCH="main"
+    export GITHUB_EVENT_NAME="push"
+    export PROJECT="test-project"
+    export BUILD_NUMBER="42"
+    When call build_npm
+    The status should be success
+    The output should include "======= Building main branch ======="
+    The output should include "Installing npm dependencies..."
+    The output should include "npx sonarqube-scanner"
+    The output should include "Building project..."
+  End
+
+  It 'builds maintenance branch with SNAPSHOT version'
+    export GITHUB_REF_NAME="branch-1.2"
+    export GITHUB_EVENT_NAME="push"
+    export PROJECT="test-project"
+    export BUILD_NUMBER="42"
+    When call build_npm
+    The status should be success
+    The output should include "======= Building maintenance branch ======="
+    The output should include "Replacing version 1.2.3-SNAPSHOT with 1.2.3-42"
+  End
+
+  It 'builds maintenance branch with RELEASE version'
+    export MOCK_VERSION="1.2.3"  # No SNAPSHOT suffix, valid semantic version
+    export GITHUB_REF_NAME="branch-1.2"
+    export GITHUB_EVENT_NAME="push"
+    export PROJECT="test-project"
+    export BUILD_NUMBER="42"
+    When call build_npm
+    The status should be success
+    The output should include "======= Building maintenance branch ======="
+    The output should include "Found RELEASE version on maintenance branch, skipping version update."
+  End
+
+  It 'builds pull request without deploy'
+    export GITHUB_REF_NAME="feature/test"
+    export GITHUB_EVENT_NAME="pull_request"
+    export DEPLOY_PULL_REQUEST="false"
+    export PULL_REQUEST="123"
+    export PROJECT="test-project"
+    export BUILD_NUMBER="42"
+    When call build_npm
+    The status should be success
+    The output should include "======= Building pull request ======="
+    The output should include "======= no deploy ======="
+    The output should include "Installing npm dependencies..."
+    The output should include "npx sonarqube-scanner"
+    The output should not include "DEBUG: JFrog operations"
+  End
+
+  It 'builds pull request with deploy when enabled'
+    export GITHUB_REF_NAME="feature/test"
+    export GITHUB_EVENT_NAME="pull_request"
+    export DEPLOY_PULL_REQUEST="true"
+    export PULL_REQUEST="123"
+    export PROJECT="test-project"
+    export BUILD_NUMBER="42"
+    When call build_npm
+    The status should be success
+    The output should include "======= Building pull request ======="
+    The output should include "======= with deploy ======="
+  End
+
+  It 'builds dogfood branch without sonar'
+    export GITHUB_REF_NAME="dogfood-on-feature"
+    export GITHUB_EVENT_NAME="push"
+    export PROJECT="test-project"
+    export BUILD_NUMBER="42"
+    When call build_npm
+    The status should be success
+    The output should include "======= Build dogfood branch ======="
+    The output should include "Installing npm dependencies..."
+    The output should not include "SonarQube scanner"
+  End
+
+  It 'builds long-lived feature branch without deploy'
+    export GITHUB_REF_NAME="feature/long/test-feature"
+    export GITHUB_EVENT_NAME="push"
+    export PROJECT="test-project"
+    export BUILD_NUMBER="42"
+    When call build_npm
+    The status should be success
+    The output should include "======= Build long-lived feature branch ======="
+    The output should include "Installing npm dependencies..."
+    The output should include "npx sonarqube-scanner"
+    The output should not include "DEBUG: JFrog operations"
+  End
+
+  It 'builds other branches without sonar or deploy'
+    export GITHUB_REF_NAME="feature/test"
+    export GITHUB_EVENT_NAME="push"
+    export PROJECT="test-project"
+    export BUILD_NUMBER="42"
+    When call build_npm
+    The status should be success
+    The output should include "======= Build other branch ======="
+    The output should include "Installing npm dependencies..."
+    The output should not include "SonarQube scanner"
+    The output should not include "DEBUG: JFrog operations"
+  End
+
+  It 'skips tests when SKIP_TESTS is true'
+    export SKIP_TESTS="true"
+    export GITHUB_REF_NAME="main"
+    export DEFAULT_BRANCH="main"
+    export GITHUB_EVENT_NAME="push"
+    export PROJECT="test-project"
+    export BUILD_NUMBER="42"
+    When call build_npm
+    The status should be success
+    The output should include "Skipping tests (SKIP_TESTS=true)"
+    The output should not include "Running tests..."
+  End
+
   It 'handles 2-digit version in maintenance branch SNAPSHOT'
     export MOCK_VERSION="1.2-SNAPSHOT"
     export GITHUB_REF_NAME="branch-1.2"
@@ -210,340 +364,177 @@ Describe 'Maintenance branch 2-digit version handling'
   End
 End
 
-  Describe 'Version error handling'
-    It 'exits with error when version cannot be read from package.json'
-      export MOCK_VERSION="null"
-      export BUILD_NUMBER="42"
-      export GITHUB_OUTPUT=/dev/null
-      export GITHUB_REF_NAME="main"
-      When run set_project_version
-      The status should be failure
-      The stderr should include "Could not get version from package.json"
-    End
+Describe 'JFrog deployment error scenarios'
+  It 'fails when missing ARTIFACTORY_URL'
+    unset ARTIFACTORY_URL
+    export PROJECT="test-project"
+    export BUILD_NUMBER="42"
+    When run jfrog_npm_publish
+    The status should be failure
+    The stderr should include "ERROR: Deployment requires ARTIFACTORY_URL and ARTIFACTORY_DEPLOY_ACCESS_TOKEN"
+  End
+End
 
-    It 'exits with error when version is empty'
-      export MOCK_VERSION=""
-      export BUILD_NUMBER="42"
-      export GITHUB_OUTPUT=/dev/null
-      export GITHUB_REF_NAME="main"
-      When run set_project_version
-      The status should be failure
-      The stderr should include "Could not get version from package.json"
-    End
-
-    It 'adds .0 to 2-digit version numbers'
-      export MOCK_VERSION="1.2-SNAPSHOT"
-      export BUILD_NUMBER="42"
-      export GITHUB_OUTPUT=/dev/null
-      export GITHUB_REF_NAME="main"
-      When call set_project_version
-      The status should be success
-      The output should include "Replacing version 1.2-SNAPSHOT with 1.2.0-42"
-      The variable PROJECT_VERSION should equal "1.2.0-42"
-    End
+Describe 'Sonar platform configuration'
+  It 'sets sonar variables for next platform'
+    When call set_sonar_platform_vars "next"
+    The status should be success
+    The line 1 should equal "Using Sonar platform: next (URL: next.sonarqube.com, Region: none)"
+    The variable SONAR_HOST_URL should equal "https://next.sonarqube.com"
+    The variable SONAR_TOKEN should equal "next-token"
   End
 
-  Describe 'Build scenarios'
-    It 'builds main branch correctly'
-      export GITHUB_REF_NAME="main"
-      export DEFAULT_BRANCH="main"
-      export GITHUB_EVENT_NAME="push"
-      export PROJECT="test-project"
-      export BUILD_NUMBER="42"
-      When call build_npm
-      The status should be success
-      The output should include "======= Building main branch ======="
-      The output should include "Current version: 1.2.3-SNAPSHOT"
-      The output should include "Installing npm dependencies..."
-      The output should include "npx sonarqube-scanner"
-      The output should include "Building project..."
-    End
-
-    It 'builds maintenance branch with SNAPSHOT version'
-      export GITHUB_REF_NAME="branch-1.2"
-      export GITHUB_EVENT_NAME="push"
-      export PROJECT="test-project"
-      export BUILD_NUMBER="42"
-      When call build_npm
-      The status should be success
-      The output should include "======= Building maintenance branch ======="
-      The output should include "======= Found SNAPSHOT version ======="
-      The output should include "Replacing version 1.2.3-SNAPSHOT with 1.2.3-42"
-    End
-
-    It 'builds maintenance branch with RELEASE version'
-      export MOCK_VERSION="1.2.3"  # No SNAPSHOT suffix, valid semantic version
-      export GITHUB_REF_NAME="branch-1.2"
-      export GITHUB_EVENT_NAME="push"
-      export PROJECT="test-project"
-      export BUILD_NUMBER="42"
-      When call build_npm
-      The status should be success
-      The output should include "======= Building maintenance branch ======="
-      The output should include "======= Found RELEASE version ======="
-      The output should include "======= Deploy 1.2.3 ======="
-    End
-
-    It 'builds pull request without deploy'
-      export GITHUB_REF_NAME="feature/test"
-      export GITHUB_EVENT_NAME="pull_request"
-      export DEPLOY_PULL_REQUEST="false"
-      export PULL_REQUEST="123"
-      export PROJECT="test-project"
-      export BUILD_NUMBER="42"
-      When call build_npm
-      The status should be success
-      The output should include "======= Building pull request ======="
-      The output should include "======= no deploy ======="
-      The output should include "Installing npm dependencies..."
-      The output should include "npx sonarqube-scanner"
-      The output should not include "DEBUG: JFrog operations"
-    End
-
-    It 'builds pull request with deploy when enabled'
-      export GITHUB_REF_NAME="feature/test"
-      export GITHUB_EVENT_NAME="pull_request"
-      export DEPLOY_PULL_REQUEST="true"
-      export PULL_REQUEST="123"
-      export PROJECT="test-project"
-      export BUILD_NUMBER="42"
-      When call build_npm
-      The status should be success
-      The output should include "======= Building pull request ======="
-      The output should include "======= with deploy ======="
-    End
-
-    It 'builds dogfood branch without sonar'
-      export GITHUB_REF_NAME="dogfood-on-feature"
-      export GITHUB_EVENT_NAME="push"
-      export PROJECT="test-project"
-      export BUILD_NUMBER="42"
-      When call build_npm
-      The status should be success
-      The output should include "======= Build dogfood branch ======="
-      The output should include "Installing npm dependencies..."
-      The output should not include "SonarQube scanner"
-    End
-
-    It 'builds long-lived feature branch without deploy'
-      export GITHUB_REF_NAME="feature/long/test-feature"
-      export GITHUB_EVENT_NAME="push"
-      export PROJECT="test-project"
-      export BUILD_NUMBER="42"
-      When call build_npm
-      The status should be success
-      The output should include "======= Build long-lived feature branch ======="
-      The output should include "Installing npm dependencies..."
-      The output should include "npx sonarqube-scanner"
-      The output should not include "DEBUG: JFrog operations"
-    End
-
-    It 'builds other branches without sonar or deploy'
-      export GITHUB_REF_NAME="feature/test"
-      export GITHUB_EVENT_NAME="push"
-      export PROJECT="test-project"
-      export BUILD_NUMBER="42"
-      When call build_npm
-      The status should be success
-      The output should include "======= Build other branch ======="
-      The output should include "Installing npm dependencies..."
-      The output should not include "SonarQube scanner"
-      The output should not include "DEBUG: JFrog operations"
-    End
-
-    It 'skips tests when SKIP_TESTS is true'
-      export SKIP_TESTS="true"
-      export GITHUB_REF_NAME="main"
-      export DEFAULT_BRANCH="main"
-      export GITHUB_EVENT_NAME="push"
-      export PROJECT="test-project"
-      export BUILD_NUMBER="42"
-      When call build_npm
-      The status should be success
-      The output should include "Skipping tests (SKIP_TESTS=true)"
-      The output should not include "Running tests..."
-    End
+  It 'sets sonar variables for sqc-us platform'
+    When call set_sonar_platform_vars "sqc-us"
+    The status should be success
+    The line 1 should equal "Using Sonar platform: sqc-us (URL: sonarqube-us.example.com, Region: us)"
+    The variable SONAR_HOST_URL should equal "https://sonarqube-us.example.com"
+    The variable SONAR_TOKEN should equal "sqc-us-token"
   End
 
-  Describe 'JFrog deployment error scenarios'
-    It 'fails when missing ARTIFACTORY_URL'
-      unset ARTIFACTORY_URL
-      export PROJECT="test-project"
-      export BUILD_NUMBER="42"
-      When run jfrog_npm_publish
-      The status should be failure
-      The stderr should include "ERROR: Deployment requires ARTIFACTORY_URL and ARTIFACTORY_DEPLOY_ACCESS_TOKEN"
-    End
-
+  It 'sets sonar variables for sqc-eu platform'
+    When call set_sonar_platform_vars "sqc-eu"
+    The status should be success
+    The line 1 should equal "Using Sonar platform: sqc-eu (URL: sonarcloud.io, Region: none)"
+    The variable SONAR_HOST_URL should equal "https://sonarcloud.io"
+    The variable SONAR_TOKEN should equal "sqc-eu-token"
   End
 
-  Describe 'Sonar platform configuration'
-    It 'sets sonar variables for next platform'
-      When call set_sonar_platform_vars "next"
-      The status should be success
-      The line 1 should equal "Using Sonar platform: next (URL: next.sonarqube.com, Region: none)"
-      The variable SONAR_HOST_URL should equal "https://next.sonarqube.com"
-      The variable SONAR_TOKEN should equal "next-token"
-    End
+  It 'fails with invalid platform'
+    When run set_sonar_platform_vars "invalid"
+    The status should be failure
+    The stderr should include "ERROR: Invalid Sonar platform 'invalid'. Must be one of: next, sqc-us, sqc-eu"
+  End
+End
 
-    It 'sets sonar variables for sqc-us platform'
-      When call set_sonar_platform_vars "sqc-us"
-      The status should be success
-      The line 1 should equal "Using Sonar platform: sqc-us (URL: sonarqube-us.example.com, Region: us)"
-      The variable SONAR_HOST_URL should equal "https://sonarqube-us.example.com"
-      The variable SONAR_TOKEN should equal "sqc-us-token"
-    End
-
-    It 'sets sonar variables for sqc-eu platform'
-      When call set_sonar_platform_vars "sqc-eu"
-      The status should be success
-      The line 1 should equal "Using Sonar platform: sqc-eu (URL: sonarcloud.io, Region: none)"
-      The variable SONAR_HOST_URL should equal "https://sonarcloud.io"
-      The variable SONAR_TOKEN should equal "sqc-eu-token"
-    End
-
-    It 'fails with invalid platform'
-      When run set_sonar_platform_vars "invalid"
-      The status should be failure
-      The stderr should include "ERROR: Invalid Sonar platform 'invalid'. Must be one of: next, sqc-us, sqc-eu"
-    End
+Describe 'sonar_scanner_implementation()'
+  export CURRENT_VERSION="1.2.3"
+  It 'runs sonar scanner with base parameters'
+    export SONAR_HOST_URL="https://sonar.example.com"
+    export SONAR_TOKEN="test-token"
+    export BUILD_NUMBER="42"
+    export GITHUB_RUN_ID="12345"
+    export GITHUB_SHA="abc123"
+    export GITHUB_REPOSITORY="test/repo"
+    When call sonar_scanner_implementation
+    The status should be success
+    The output should include "npx sonarqube-scanner -X"
+    The output should include "-Dsonar.host.url=https://sonar.example.com"
+    The output should include "-Dsonar.token=test-token"
+    The output should include "-Dsonar.analysis.buildNumber=42"
+    The output should include "-Dsonar.analysis.pipeline=12345"
+    The output should include "-Dsonar.analysis.sha1=abc123"
+    The output should include "-Dsonar.analysis.repository=test/repo"
+    The output should include "-Dsonar.projectVersion=1.2.3"
+    The output should include "-Dsonar.scm.revision=abc123"
   End
 
-  Describe 'Sonar scanner functionality'
-    It 'runs sonar scanner with base parameters'
-      export SONAR_HOST_URL="https://sonar.example.com"
-      export SONAR_TOKEN="test-token"
-      export BUILD_NUMBER="42"
-      export GITHUB_RUN_ID="12345"
-      export GITHUB_SHA="abc123"
-      export GITHUB_REPOSITORY="test/repo"
-      export PROJECT_VERSION="1.2.3-42"
-      When call sonar_scanner_implementation
-      The status should be success
-      The output should include "npx sonarqube-scanner -X"
-      The output should include "-Dsonar.host.url=https://sonar.example.com"
-      The output should include "-Dsonar.token=test-token"
-      The output should include "-Dsonar.analysis.buildNumber=42"
-      The output should include "-Dsonar.analysis.pipeline=12345"
-      The output should include "-Dsonar.analysis.sha1=abc123"
-      The output should include "-Dsonar.analysis.repository=test/repo"
-      The output should include "-Dsonar.projectVersion=1.2.3-42"
-      The output should include "-Dsonar.scm.revision=abc123"
-      The output should include "SonarQube scanner finished for platform: sonar.example.com"
-    End
-
-    It 'runs sonar scanner with region parameter for sqc-us'
-      export SONAR_HOST_URL="https://sonarqube-us.example.com"
-      export SONAR_TOKEN="us-token"
-      export SONAR_REGION="us"
-      export BUILD_NUMBER="42"
-      export GITHUB_RUN_ID="12345"
-      export GITHUB_SHA="abc123"
-      export GITHUB_REPOSITORY="test/repo"
-      export PROJECT_VERSION="1.2.3-42"
-      When call sonar_scanner_implementation
-      The status should be success
-      The output should include "-Dsonar.region=us"
-      The output should include "SonarQube scanner finished for platform: sonarqube-us.example.com"
-    End
-
-    It 'runs sonar scanner with additional parameters'
-      export SONAR_HOST_URL="https://sonar.example.com"
-      export SONAR_TOKEN="test-token"
-      export BUILD_NUMBER="42"
-      export GITHUB_RUN_ID="12345"
-      export GITHUB_SHA="abc123"
-      export GITHUB_REPOSITORY="test/repo"
-      export PROJECT_VERSION="1.2.3-42"
-      When call sonar_scanner_implementation "-Dsonar.pullrequest.key=123" "-Dsonar.branch.name=feature"
-      The status should be success
-      The output should include "-Dsonar.pullrequest.key=123"
-      The output should include "-Dsonar.branch.name=feature"
-    End
+  It 'runs sonar scanner with region parameter for sqc-us'
+    export SONAR_HOST_URL="https://sonarqube-us.example.com"
+    export SONAR_TOKEN="us-token"
+    export SONAR_REGION="us"
+    export BUILD_NUMBER="42"
+    export GITHUB_RUN_ID="12345"
+    export GITHUB_SHA="abc123"
+    export GITHUB_REPOSITORY="test/repo"
+    When call sonar_scanner_implementation
+    The status should be success
+    The output should include "-Dsonar.region=us"
   End
 
-  Describe 'Sonar analysis functionality'
-    It 'runs single platform analysis when shadow scans disabled'
-      export RUN_SHADOW_SCANS="false"
-      export SONAR_PLATFORM="next"
-      export PROJECT_VERSION="1.2.3-42"
-      When call orchestrate_sonar_platforms "-Dsonar.test=value"
-      The status should be success
-      The output should include "=== ORCHESTRATOR: Running Sonar analysis on selected platform: next ==="
-      The output should include "Using Sonar platform: next"
-      The output should include "SonarQube scanner finished for platform: next.sonarqube.com"
-      The output should not include "shadow scan enabled"
-    End
+  It 'runs sonar scanner with additional parameters'
+    export SONAR_HOST_URL="https://sonar.example.com"
+    export SONAR_TOKEN="test-token"
+    export BUILD_NUMBER="42"
+    export GITHUB_RUN_ID="12345"
+    export GITHUB_SHA="abc123"
+    export GITHUB_REPOSITORY="test/repo"
+    When call sonar_scanner_implementation "-Dsonar.pullrequest.key=123" "-Dsonar.branch.name=feature"
+    The status should be success
+    The output should include "-Dsonar.pullrequest.key=123"
+    The output should include "-Dsonar.branch.name=feature"
+  End
+End
 
-    It 'runs multi-platform analysis when shadow scans enabled'
-      export RUN_SHADOW_SCANS="true"
-      export SONAR_PLATFORM="next"
-      export PROJECT_VERSION="1.2.3-42"
-      When call orchestrate_sonar_platforms "-Dsonar.test=value"
-      The status should be success
-      The output should include "=== ORCHESTRATOR: Running Sonar analysis on all platforms (shadow scan enabled) ==="
-      The output should include "--- ORCHESTRATOR: Analyzing with platform: next ---"
-      The output should include "--- ORCHESTRATOR: Analyzing with platform: sqc-us ---"
-      The output should include "--- ORCHESTRATOR: Analyzing with platform: sqc-eu ---"
-      The output should include "=== ORCHESTRATOR: Completed Sonar analysis on all platforms ==="
-    End
+Describe 'orchestrate_sonar_platforms()'
+  export CURRENT_VERSION="1.2.3"
+  It 'runs single platform analysis when shadow scans disabled'
+    export RUN_SHADOW_SCANS="false"
+    export SONAR_PLATFORM="next"
+    When call orchestrate_sonar_platforms "-Dsonar.test=value"
+    The status should be success
+    The output should include "=== ORCHESTRATOR: Running Sonar analysis on selected platform: next ==="
+    The output should include "Using Sonar platform: next"
+    The output should not include "shadow scan enabled"
   End
 
-  Describe 'Shadow scans deployment prevention'
-    It 'disables deployment when shadow scans enabled on main branch'
-      export GITHUB_REF_NAME="main"
-      export DEFAULT_BRANCH="main"
-      export GITHUB_EVENT_NAME="push"
-      export RUN_SHADOW_SCANS="true"
-      export CURRENT_VERSION="1.2.3-SNAPSHOT"
-      export PROJECT_VERSION="1.2.3-42"
-      export BUILD_NUMBER="42"
-      When call get_build_config
-      The status should be success
-      The output should include "======= Shadow scans enabled - disabling deployment to prevent duplicate artifacts ======="
-      The variable BUILD_ENABLE_DEPLOY should equal "false"
-      The variable BUILD_ENABLE_SONAR should equal "true"
-    End
+  It 'runs multi-platform analysis when shadow scans enabled'
+    export RUN_SHADOW_SCANS="true"
+    export SONAR_PLATFORM="next"
+    When call orchestrate_sonar_platforms "-Dsonar.test=value"
+    The status should be success
+    The output should include "=== ORCHESTRATOR: Running Sonar analysis on all platforms (shadow scan enabled) ==="
+    The output should include "--- ORCHESTRATOR: Analyzing with platform: next ---"
+    The output should include "--- ORCHESTRATOR: Analyzing with platform: sqc-us ---"
+    The output should include "--- ORCHESTRATOR: Analyzing with platform: sqc-eu ---"
+    The output should include "=== ORCHESTRATOR: Completed Sonar analysis on all platforms ==="
+  End
+End
 
-    It 'allows deployment when shadow scans disabled on main branch'
-      export GITHUB_REF_NAME="main"
-      export DEFAULT_BRANCH="main"
-      export GITHUB_EVENT_NAME="push"
-      export RUN_SHADOW_SCANS="false"
-      export CURRENT_VERSION="1.2.3-SNAPSHOT"
-      export PROJECT_VERSION="1.2.3-42"
-      export BUILD_NUMBER="42"
-      When call get_build_config
-      The status should be success
-      The output should not include "shadow scans enabled"
-      The variable BUILD_ENABLE_DEPLOY should equal "true"
-      The variable BUILD_ENABLE_SONAR should equal "true"
-    End
+Describe 'Shadow scans deployment prevention'
+  It 'disables deployment when shadow scans enabled on main branch'
+    export GITHUB_REF_NAME="main"
+    export DEFAULT_BRANCH="main"
+    export GITHUB_EVENT_NAME="push"
+    export RUN_SHADOW_SCANS="true"
+    export CURRENT_VERSION="1.2.3-SNAPSHOT"
+    export PROJECT_VERSION="1.2.3-42"
+    export BUILD_NUMBER="42"
+    When call get_build_config
+    The status should be success
+    The output should include "======= Shadow scans enabled - disabling deployment to prevent duplicate artifacts ======="
+    The variable BUILD_ENABLE_DEPLOY should equal "false"
+    The variable BUILD_ENABLE_SONAR should equal "true"
   End
 
-  Describe 'Full build with shadow scans'
-    It 'displays shadow scan information in build output'
-      export GITHUB_REF_NAME="main"
-      export DEFAULT_BRANCH="main"
-      export GITHUB_EVENT_NAME="push"
-      export RUN_SHADOW_SCANS="true"
-      export SONAR_PLATFORM="next"
-      export PROJECT="test-project"
-      export BUILD_NUMBER="42"
-      When call build_npm
-      The status should be success
-      The output should include "Run Shadow Scans: true"
-      The output should include "Sonar Platform: next"
-      The output should include "shadow scan enabled"
-      The output should not include "DEBUG: JFrog operations"
-    End
+  It 'allows deployment when shadow scans disabled on main branch'
+    export GITHUB_REF_NAME="main"
+    export DEFAULT_BRANCH="main"
+    export GITHUB_EVENT_NAME="push"
+    export RUN_SHADOW_SCANS="false"
+    export CURRENT_VERSION="1.2.3-SNAPSHOT"
+    export PROJECT_VERSION="1.2.3-42"
+    export BUILD_NUMBER="42"
+    When call get_build_config
+    The status should be success
+    The output should not include "shadow scans enabled"
+    The variable BUILD_ENABLE_DEPLOY should equal "true"
+    The variable BUILD_ENABLE_SONAR should equal "true"
   End
+End
 
-  Describe 'Main function execution'
-    It 'runs main function when executed directly'
-      When run script build-npm/build.sh
-      The status should be success
-      The output should include "=== NPM Build, Deploy, and Analyze ==="
-    End
+Describe 'Full build with shadow scans'
+  It 'displays shadow scan information in build output'
+    export GITHUB_REF_NAME="main"
+    export DEFAULT_BRANCH="main"
+    export GITHUB_EVENT_NAME="push"
+    export RUN_SHADOW_SCANS="true"
+    export SONAR_PLATFORM="next"
+    export PROJECT="test-project"
+    export BUILD_NUMBER="42"
+    When call build_npm
+    The status should be success
+    The output should include "Run Shadow Scans: true"
+    The output should include "Sonar Platform: next"
+    The output should include "shadow scan enabled"
+    The output should not include "DEBUG: JFrog operations"
+  End
+End
+
+Describe 'Main function execution'
+  It 'runs main function when executed directly'
+    When run script build-npm/build.sh
+    The status should be success
+    The output should include "=== NPM Build, Deploy, and Analyze ==="
   End
 End

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -220,6 +220,7 @@ Describe 'set_project_version()'
     End
     When call set_project_version
     The line 1 should equal "Replacing version 1.2 with 1.2.0.42"
+    The variable CURRENT_VERSION should equal "1.2"
     The variable PROJECT_VERSION should equal "1.2.0.42"
   End
 
@@ -233,6 +234,7 @@ Describe 'set_project_version()'
     End
     When call set_project_version
     The line 1 should equal "Replacing version 1.2.3 with 1.2.3.42"
+    The variable CURRENT_VERSION should equal "1.2.3"
     The variable PROJECT_VERSION should equal "1.2.3.42"
   End
 
@@ -246,10 +248,11 @@ Describe 'set_project_version()'
     End
     When call set_project_version
     The line 1 should equal "Replacing version 1.2.3.dev with 1.2.3.42"
+    The variable CURRENT_VERSION should equal "1.2.3.dev"
     The variable PROJECT_VERSION should equal "1.2.3.42"
   End
 
-  It 'replaces 41 with BUILD_NUMBER given version is 1.2.3.dev'
+  It 'replaces 41 with BUILD_NUMBER given version is 1.2.3.41'
     Mock poetry
       if [[ "$*" == "version -s" ]]; then
         echo "1.2.3.41"
@@ -260,6 +263,7 @@ Describe 'set_project_version()'
     When call set_project_version
     The line 1 should equal "WARN: version was truncated to 1.2.3 because it had more than 3 digits"
     The line 2 should equal "Replacing version 1.2.3.41 with 1.2.3.42"
+    The variable CURRENT_VERSION should equal "1.2.3.41"
     The variable PROJECT_VERSION should equal "1.2.3.42"
   End
 
@@ -275,6 +279,7 @@ Describe 'set_project_version()'
     When call set_project_version
     The line 1 of error should equal "Could not get version from Poetry project ('poetry version -s')"
     The line 2 of error should equal "Failed to get version"
+    The variable CURRENT_VERSION should be undefined
     The variable PROJECT_VERSION should be undefined
     The status should be failure
   End
@@ -323,18 +328,18 @@ Describe 'build_poetry()'
     The line 4 should equal 'Deploy Pull Request: false'
     The line 5 should equal '======= Building main branch ======='
     The line 8 should equal 'poetry build'
-    The line 9 should equal '=== Running Sonar analysis on selected platform: next ==='
-    The line 10 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
-    The line 11 should equal 'poetry run pip install pysonar'
-    The line 12 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
-    The line 13 should equal 'SonarQube scanner finished for platform: next.sonarqube.com'
-    The line 14 should equal 'jf config remove repox'
-    The line 15 should equal 'jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>'
-    The line 16 should include '/dist'
-    The line 17 should equal 'jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42'
-    The line 19 should equal 'jf rt build-collect-env my-repo 42'
-    The line 20 should include 'jf rt build-publish my-repo 42'
-    The line 21 should include '=== Build completed successfully ==='
+    The line 9 should equal 'run_sonar_analysis()'
+    The line 10 should equal '=== Running Sonar analysis on selected platform: next ==='
+    The line 12 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
+    The line 13 should equal 'poetry run pip install pysonar'
+    The line 15 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
+    The line 17 should equal 'jf config remove repox'
+    The line 18 should equal 'jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>'
+    The line 19 should include '/dist'
+    The line 20 should equal 'jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42'
+    The line 22 should equal 'jf rt build-collect-env my-repo 42'
+    The line 23 should include 'jf rt build-publish my-repo 42'
+    The line 24 should include '=== Build completed successfully ==='
     The status should be success
   End
 
@@ -351,12 +356,12 @@ Describe 'build_poetry()'
     The line 5 should equal '======= Building pull request ======='
     The line 6 should equal '======= no deploy ======='
     The line 9 should equal 'poetry build'
-    The line 10 should equal '=== Running Sonar analysis on selected platform: next ==='
-    The line 11 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
-    The line 12 should equal 'poetry run pip install pysonar'
-    The line 13 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
-    The line 14 should equal 'SonarQube scanner finished for platform: next.sonarqube.com'
-    The line 15 should equal '=== Build completed successfully ==='
+    The line 10 should equal 'run_sonar_analysis()'
+    The line 11 should equal '=== Running Sonar analysis on selected platform: next ==='
+    The line 13 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
+    The line 14 should equal 'poetry run pip install pysonar'
+    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
+    The line 18 should equal '=== Build completed successfully ==='
     The status should be success
   End
 
@@ -374,17 +379,17 @@ Describe 'build_poetry()'
     The line 5 should equal '======= Building pull request ======='
     The line 6 should equal '======= with deploy ======='
     The line 9 should equal 'poetry build'
-    The line 10 should equal '=== Running Sonar analysis on selected platform: next ==='
-    The line 11 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
-    The line 12 should equal 'poetry run pip install pysonar'
-    The line 13 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
-    The line 14 should equal 'SonarQube scanner finished for platform: next.sonarqube.com'
-    The line 15 should equal "jf config remove repox"
-    The line 16 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>"
-    The line 17 should include "/dist"
-    The line 18 should equal "jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42"
-    The line 20 should equal "jf rt build-collect-env my-repo 42"
-    The line 21 should include "jf rt build-publish my-repo 42"
+    The line 10 should equal 'run_sonar_analysis()'
+    The line 11 should equal '=== Running Sonar analysis on selected platform: next ==='
+    The line 13 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
+    The line 14 should equal 'poetry run pip install pysonar'
+    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
+    The line 18 should equal "jf config remove repox"
+    The line 19 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>"
+    The line 20 should include "/dist"
+    The line 21 should equal "jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42"
+    The line 23 should equal "jf rt build-collect-env my-repo 42"
+    The line 24 should include "jf rt build-publish my-repo 42"
     The status should be success
   End
 
@@ -454,23 +459,21 @@ Describe 'build_poetry()'
     The line 4 should equal 'Deploy Pull Request: false'
     The line 5 should equal '======= Building main branch ======='
     The line 8 should equal 'poetry build'
-    The line 9 should equal '=== Running Sonar analysis on all platforms (shadow scan enabled) ==='
-    The line 10 should equal '--- Analyzing with platform: next ---'
-    The line 11 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
-    The line 12 should equal 'poetry run pip install pysonar'
-    The line 13 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
-    The line 14 should equal 'SonarQube scanner finished for platform: next.sonarqube.com'
-    The line 15 should equal '--- Analyzing with platform: sqc-us ---'
-    The line 16 should equal 'Using Sonar platform: sqc-us (URL: https://sonarqube-us.com)'
-    The line 17 should equal 'poetry run pip install pysonar'
-    The line 18 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarqube-us.com -Dsonar.token=sqc-us-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
-    The line 19 should equal 'SonarQube scanner finished for platform: sonarqube-us.com'
-    The line 20 should equal '--- Analyzing with platform: sqc-eu ---'
-    The line 21 should equal 'Using Sonar platform: sqc-eu (URL: https://sonarcloud.io)'
-    The line 22 should equal 'poetry run pip install pysonar'
-    The line 23 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=sqc-eu-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
-    The line 24 should equal 'SonarQube scanner finished for platform: sonarcloud.io'
-    The line 25 should equal '=== Completed Sonar analysis on all platforms ==='
+    The line 9 should equal 'run_sonar_analysis()'
+    The line 10 should equal '=== Running Sonar analysis on all platforms (shadow scan enabled) ==='
+    The line 12 should equal '--- ORCHESTRATOR: Analyzing with platform: next ---'
+    The line 13 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
+    The line 14 should equal 'poetry run pip install pysonar'
+    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
+    The line 19 should equal '--- ORCHESTRATOR: Analyzing with platform: sqc-us ---'
+    The line 20 should equal 'Using Sonar platform: sqc-us (URL: https://sonarqube-us.com)'
+    The line 21 should equal 'poetry run pip install pysonar'
+    The line 23 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarqube-us.com -Dsonar.token=sqc-us-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
+    The line 26 should equal '--- ORCHESTRATOR: Analyzing with platform: sqc-eu ---'
+    The line 27 should equal 'Using Sonar platform: sqc-eu (URL: https://sonarcloud.io)'
+    The line 28 should equal 'poetry run pip install pysonar'
+    The line 30 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=sqc-eu-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.sha1=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
+    The line 32 should equal '=== Completed Sonar analysis on all platforms ==='
     The status should be success
   End
 
@@ -486,8 +489,8 @@ Describe 'build_poetry()'
     The line 4 should equal 'Deploy Pull Request: false'
     The line 5 should equal '======= Building main branch ======='
     The line 8 should equal 'poetry build'
-    The line 9 should equal '=== Running Sonar analysis on selected platform: none ==='
-    The line 10 should equal 'Sonar platform set to '"'"'none'"'"'. Skipping sonar analysis.'
+    The line 9 should equal 'run_sonar_analysis()'
+    The line 10 should equal "=== Sonar platform set to 'none'. Skipping Sonar analysis."
     The line 11 should equal 'jf config remove repox'
     The line 12 should equal 'jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>'
     The line 13 should include '/dist'


### PR DESCRIPTION
BUILD-8939 use `CURRENT_VERSION` instead of `PROJECT_VERSION` for `sonar.projectVersion` parameter.

The Sonar project version must remain unchanged between master and PRs for comparison purpose.
`CURRENT_VERSION` is the version configured in the project, with no change, fix or cleanup (like `-SNAPSHOT`).
`PROJECT_VERSION` is the sanitized version, and appended with the build number for most cases (equivalent to the release version). There are a few cases for which the version is kept unchanged, equal to `CURRENT_VERSION`.

Sonar parameter updated in `build-gradle`, `build-maven`, `build-npm`, `build-poetry`, and `build-yarn`.
For consistency, all `set_project_version()` functions now export `CURRENT_VERSION` and `PROJECT_VERSION`.

Tested by:
- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/277
- https://github.com/SonarSource/sonar-dummy/pull/481
- https://github.com/SonarSource/sonar-dummy-python-oss/pull/60
- https://github.com/SonarSource/sonar-dummy-js/pull/89
- https://github.com/SonarSource/sonar-dummy-yarn/pull/22 -> test confirmed