### PR TITLE
BUILD-8962 cross OS build number

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,8 @@
 # Configuration for https://github.com/rhysd/actionlint run by pre-commit
 self-hosted-runner:
   labels:
-    - ubuntu-24.04       # GitHub-Hosted runner for public workflows
-    - ubuntu-24.04-large # GitHub-Hosted Large runner for public workflows performing authenticated actions
-    - sonar-runner-large # GitHub-Hosted Large with Docker-in-Docker enabled
+    - ubuntu-24.04       # GitHub-Hosted runner for public workflows - DEPRECATED
+    - ubuntu-24.04-large # GitHub-Hosted Large runner for public workflows performing authenticated actions - DEPRECATED
+    - sonar-runner-large # GitHub-Hosted Large with Docker-in-Docker enabled - DEPRECATED
+    - github-ubuntu-latest-s
+    - github-windows-latest-s

--- a/.github/workflows/test-build-number.yml
+++ b/.github/workflows/test-build-number.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-build-number-generation:
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
       contents: read
@@ -22,6 +22,7 @@ jobs:
         with:
           sparse-checkout: get-build-number
       - uses: ./get-build-number
+      - uses: ./get-build-number
         id: get_build_number
       - name: Check build number generation
         run: |
@@ -30,7 +31,7 @@ jobs:
 
   test-build-number-reuse:
     needs: test-build-number-generation
-    runs-on: ubuntu-24.04-large
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
       contents: read
@@ -43,7 +44,28 @@ jobs:
         run: |
           echo "Build number: ${BUILD_NUMBER}"
           if [[ "${BUILD_NUMBER}" != "${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}" ]]; then
-            echo -e "::warning title=test-build-number-reuse::Build number '${BUILD_NUMBER}' does not match the previous job build number" \
+            echo -e "::error title=test-build-number-reuse::Build number '${BUILD_NUMBER}' does not match the previous job build number" \
               "'${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run.\n" \
               "Prefer using the output from SonarSource/ci-github-actions/get-build-number instead of calling it twice."
+          fi
+
+  test-build-number-reuse-windows:
+    needs: test-build-number-generation
+    runs-on: github-windows-latest-s
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          sparse-checkout: get-build-number
+      - uses: ./get-build-number
+      - name: Check build number was reused
+        shell: bash
+        run: |
+          echo "Build number: ${BUILD_NUMBER}"
+          if [[ "${BUILD_NUMBER}" != "${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}" ]]; then
+            echo -e "::error title=test-build-number-reuse::Build number '${BUILD_NUMBER}' does not match the previous job build number" \
+              "'${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run."
+            exit 1
           fi

--- a/get-build-number/action.yml
+++ b/get-build-number/action.yml
@@ -16,6 +16,7 @@ runs:
       with:
         path: build_number.txt
         key: build-number-${{ github.run_id }}
+        enableCrossOsArchive: true
 
     # Otherwise, increment the build number
     - name: Get secrets from Vault
@@ -46,3 +47,4 @@ runs:
       with:
         path: build_number.txt
         key: build-number-${{ github.run_id }}
+        enableCrossOsArchive: true


### PR DESCRIPTION
Use `enableCrossOsArchive: true` for saving and restoring the cached build number.

Add a test on github-windows-latest-s.
Fail in case of mismatch. Note that this is not reliable and may need a rerun.

Update the runners from ubuntu-24.04-large to github-ubuntu-latest-s

Call twice get-build-number within the same job, but does not check the value.
We can see in the various runs that the two sequential calls can work, and then a second job call will fail! The cache is not reliable with short duration between calls from distinct runners.