### PR TITLE
BUILD-8928 windowsBuild

### DIFF
--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -143,7 +143,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: problems-report
+        name: problems-report-${{ github.job }}
         path: build/reports/problems/problems-report.html
         if-no-files-found: ignore
 


### PR DESCRIPTION
- **BUILD-8928 resolve upload-artifact conflict**

When the action is called multiple times, the artifact upload will fail if the name is the same.
