### PR TITLE
BUILD-8928 Fix Windows Gradle build

### DIFF
--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -86,9 +86,8 @@ set_build_env() {
 }
 
 set_project_version() {
-  current_version=$($GRADLE_CMD properties --no-scan | grep 'version:' | tr -d "[:space:]" | cut -d ":" -f 2)
+  current_version=$($GRADLE_CMD properties --no-scan --no-daemon --console plain | grep 'version:' | tr -d "[:space:]" | cut -d ":" -f 2)
   export CURRENT_VERSION=$current_version
-
   release_version="${current_version/-SNAPSHOT/}"
   if [[ "${release_version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
     release_version="${release_version}.0"
@@ -254,6 +253,9 @@ gradle_build() {
 }
 
 main() {
+  # Unsetting JAVA_HOME fixes an issue on GitHub hosted Windows runners, where JAVA_HOME is set by default
+  # and Gradle prioritizes this JDK instead of using the JDK from the path.
+  unset JAVA_HOME
   command_exists java -version
   set_gradle_cmd
   set_build_env

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -6,7 +6,7 @@ Mock java
   echo "java $*"
 End
 Mock gradle
-  if [[ "$*" == "properties --no-scan" ]]; then
+  if [[ "$*" == "properties --no-scan --no-daemon --console plain" ]]; then
     echo "version: 1.2.3-SNAPSHOT"
   else
     echo "gradle $*"


### PR DESCRIPTION
[BUILD-8928](https://sonarsource.atlassian.net/browse/BUILD-8928)

- add `--console plain` argument to `set_project_version`, the gradle command hangs without this 
- unset `JAVA_HOME` environment variable to fix an issue on GitHub hosted Windows runners, where `JAVA_HOME` is set by default and Gradle prioritizes this JDK instead of the JDK from the path

[BUILD-8928]: https://sonarsource.atlassian.net/browse/BUILD-8928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ