### PR TITLE
BUILD-8957 use local action checkout

### DIFF
--- a/.cursor/cirrus-github-migration.md
+++ b/.cursor/cirrus-github-migration.md
@@ -657,9 +657,8 @@ Adaptive cache action that automatically chooses the appropriate caching backend
     path: |
       ~/.m2/repository
       ~/.cache/pip
-    key: ${{ runner.os }}-cache-${{ hashFiles('**/pom.xml', '**/requirements.txt') }}
-    restore-keys: |
-      ${{ runner.os }}-cache
+    key: cache-${{ runner.os }}-${{ hashFiles('**/pom.xml', '**/requirements.txt') }}
+    restore-keys: cache-${{ runner.os }}-
     # Optional parameters
     upload-chunk-size: ""                           # Chunk size for large files (bytes)
     enableCrossOsArchive: false                     # Allow cross-platform cache restore

--- a/README.md
+++ b/README.md
@@ -679,9 +679,8 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.cache/maven
-          key: ${{ runner.os }}-cache-${{ hashFiles('**/requirements.txt', '**/pom.xml') }}
-          restore-keys: |
-            cache-${{ runner.os }}
+          key: cache-${{ runner.os }}-${{ hashFiles('**/requirements.txt', '**/pom.xml') }}
+          restore-keys: cache-${{ runner.os }}-
 ```
 
 ### Inputs

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -52,8 +52,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Get build number
-      uses: SonarSource/ci-github-actions/get-build-number@master
     - name: Set build parameters
       shell: bash
       env:
@@ -64,7 +62,9 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
-
+        mkdir .actions/
+        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
+    - uses: ./.actions/get-build-number
     - name: Vault
       id: secrets
       uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -52,8 +52,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get build number
-      uses: SonarSource/ci-github-actions/get-build-number@master
     - name: Set build parameters
       shell: bash
       env:
@@ -64,8 +62,12 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
+        mkdir .actions/
+        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
+        ln -s "${GITHUB_ACTION_PATH}/../cache" .actions/cache
+    - uses: ./.actions/get-build-number
     - name: Cache local Maven repository
-      uses: SonarSource/ci-github-actions/cache@master
+      uses: ./.actions/cache
       with:
         path: ~/${{ inputs.maven-local-repository-path }}
         key: maven-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -54,8 +54,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Get build number
-      uses: SonarSource/ci-github-actions/get-build-number@master
     - name: Set build parameters
       shell: bash
       env:
@@ -66,24 +64,22 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
-
-    - name: Setup build tools
-      shell: bash
-      run: |
         cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
-
+        mkdir .actions/
+        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
+        ln -s "${GITHUB_ACTION_PATH}/../cache" .actions/cache
+    - uses: ./.actions/get-build-number
     - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
       with:
         version: 2025.7.12
 
     - name: Cache NPM dependencies
       if: ${{ inputs.cache-npm == 'true' }}
-      uses: SonarSource/ci-github-actions/cache@master
+      uses: ./.actions/cache
       with:
         path: ~/.npm
         key: npm-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          npm-${{ runner.os }}-
+        restore-keys: npm-${{ runner.os }}-
 
     - name: Vault
       # yamllint disable rule:line-length

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -48,8 +48,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Get build number
-      uses: SonarSource/ci-github-actions/get-build-number@master
     - name: Set build parameters
       shell: bash
       env:
@@ -61,6 +59,9 @@ runs:
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
         cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
+        mkdir .actions/
+        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
+    - uses: ./.actions/get-build-number
     - name: Cache local Poetry cache
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -50,8 +50,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Get build number
-      uses: SonarSource/ci-github-actions/get-build-number@master
     - name: Set build parameters
       shell: bash
       env:
@@ -62,25 +60,23 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
-
-    - name: Setup build tools
-      shell: bash
-      run: |
         cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
-
+        mkdir .actions/
+        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
+        ln -s "${GITHUB_ACTION_PATH}/../cache" .actions/cache
+    - uses: ./.actions/get-build-number
     - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
       with:
         version: 2025.7.12
 
     - name: Cache Yarn dependencies
       if: ${{ inputs.cache-yarn == 'true' }}
-      uses: SonarSource/ci-github-actions/cache@master
+      uses: ./.actions/cache
       with:
         path: |
           ~/.yarn
         key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          yarn-${{ runner.os }}-
+        restore-keys: yarn-${{ runner.os }}-
 
     - name: Vault
       # yamllint disable rule:line-length

--- a/promote/action.yml
+++ b/promote/action.yml
@@ -15,12 +15,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Get build number
-      uses: SonarSource/ci-github-actions/get-build-number@master
     - name: Set build parameters
       shell: bash
       run: |
         cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
+        mkdir .actions/
+        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
+    - uses: ./.actions/get-build-number
     - name: Vault
       id: secrets
       uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0


### PR DESCRIPTION
[BUILD-8957](https://sonarsource.atlassian.net/browse/BUILD-8957)

Refer to the local checkout to use other actions from the same repository, instead of a hardcoded reference to master.
There is no available environment variable to refer the proper hash, while the code has been checkouted with the proper hash.
A symlink is used because GitHub Actions rejects `..` relative path in the `uses: ` field.

[BUILD-8957]: https://sonarsource.atlassian.net/browse/BUILD-8957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ