### PR TITLE
BUILD-8977 custom Gradle cache

### DIFF
--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -92,7 +92,35 @@ runs:
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
       with:
         develocity-injection-enabled: ${{ inputs.use-develocity == 'true' }}
+        cache-disabled: true
         develocity-plugin-version: '4.0'
+
+    - name: Generate Gradle Cache Key
+      shell: bash
+      run: |
+        # Generate cache key from all Gradle files
+        find . \( -name '*.gradle' -o -name '*.gradle.kts' \) -type f -exec md5sum {} \; | sort > gradle-md5-sums.txt
+        md5sum gradle/libs.versions.toml gradle/wrapper/gradle-wrapper.properties \
+          2>/dev/null >> gradle-md5-sums.txt || true
+
+        GRADLE_CACHE_KEY=gradle-$(md5sum gradle-md5-sums.txt | awk '{ print $1 }')
+
+        echo "🔑 Generated cache key: ${GRADLE_CACHE_KEY}"
+        echo "GRADLE_CACHE_KEY=${GRADLE_CACHE_KEY}" >> "$GITHUB_ENV"
+
+        rm -f gradle-md5-sums.txt
+
+    - name: Restore Gradle Cache
+      uses: SonarSource/gh-action_cache@master
+      id: gradle-cache-restore
+      with:
+        path: |
+          ${{ env.GRADLE_USER_HOME }}/caches
+          ${{ env.GRADLE_USER_HOME }}/wrapper
+        key: ${{ env.GRADLE_CACHE_KEY }}
+        restore-keys: |
+          gradle-
+
     # $GRADLE_USER_HOME is typically set to ~/.gradle/ by gradle/actions/setup-gradle
     - name: Configure Gradle Authentication
       shell: bash

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -43,6 +43,12 @@ inputs:
     description: If true, run sonar scanner on all 3 platforms using the provided URL and token.
      If false, run on the platform provided by SONAR_PLATFORM.
     default: 'false'
+  cache-paths:
+    description: Additional cache paths to include (multiline, one path per line)
+    default: ''
+  disable-caching:
+    description: Whether to disable Gradle caching entirely
+    default: 'false'
 
 outputs:
   project-version:
@@ -96,14 +102,14 @@ runs:
         develocity-plugin-version: '4.0'
 
     - name: Generate Gradle Cache Key
+      if: ${{ inputs.disable-caching != 'true' }}
       shell: bash
       run: |
         # Generate cache key from all Gradle files
         find . \( -name '*.gradle' -o -name '*.gradle.kts' \) -type f -exec md5sum {} \; | sort > gradle-md5-sums.txt
-        md5sum gradle/libs.versions.toml gradle/wrapper/gradle-wrapper.properties \
-          2>/dev/null >> gradle-md5-sums.txt || true
+        md5sum gradle/libs.versions.toml gradle/wrapper/gradle-wrapper.properties 2>/dev/null >> gradle-md5-sums.txt || true
 
-        GRADLE_CACHE_KEY=gradle-$(md5sum gradle-md5-sums.txt | awk '{ print $1 }')
+        GRADLE_CACHE_KEY=$(md5sum gradle-md5-sums.txt | awk '{ print $1 }')
 
         echo "🔑 Generated cache key: ${GRADLE_CACHE_KEY}"
         echo "GRADLE_CACHE_KEY=${GRADLE_CACHE_KEY}" >> "$GITHUB_ENV"
@@ -111,15 +117,17 @@ runs:
         rm -f gradle-md5-sums.txt
 
     - name: Restore Gradle Cache
+      if: ${{ inputs.disable-caching != 'true' }}
       uses: SonarSource/gh-action_cache@master
       id: gradle-cache-restore
       with:
         path: |
           ${{ env.GRADLE_USER_HOME }}/caches
           ${{ env.GRADLE_USER_HOME }}/wrapper
-        key: ${{ env.GRADLE_CACHE_KEY }}
+          ${{ inputs.cache-paths }}
+        key: gradle-${{ runner.os }}-${{ github.workflow }}-${{ env.GRADLE_CACHE_KEY }}
         restore-keys: |
-          gradle-
+          gradle-${{ runner.os }}-${{ github.workflow }}-
 
     # $GRADLE_USER_HOME is typically set to ~/.gradle/ by gradle/actions/setup-gradle
     - name: Configure Gradle Authentication


### PR DESCRIPTION
[BUILD-8977](https://sonarsource.atlassian.net/browse/BUILD-8977)
- disabled caching mechanism built in setup-gradle - this is required but also has a slight downside of false information in job summary. With moving towards having dedicated setup-gradle action this should be resolved soon.
<img width="1260" height="438" alt="image" src="https://github.com/user-attachments/assets/448f7174-ecf1-4873-a5cd-fdee31bfdd40" />

1. **Cache Key Generation**
   - **Based on SonarSource standard pattern** used across Cirrus CI configurations:
     ```bash
     find -type f \( -name "*.gradle*" -or -name "gradle*.properties" \) | sort | xargs cat
     ```
   - **GitHub Actions adaptation**: Generates MD5 hash from all Gradle configuration files:
     - All `*.gradle` and `*.gradle.kts` files (matches `*.gradle*` pattern)
     - `gradle/libs.versions.toml` (version catalog)
     - `gradle/wrapper/gradle-wrapper.properties` (matches `gradle*.properties` pattern)
   - **Key difference from Cirrus CI**: **Excludes** `gradle.properties` (modified during build with unique version numbers)
   - Creates composite cache key: `gradle-${{ runner.os }}-${{ github.workflow }}-${{ hash }}`

2. **Cached Directories**
   - `${{ env.GRADLE_USER_HOME }}/caches` - Gradle build cache and dependencies
   - `${{ env.GRADLE_USER_HOME }}/wrapper` - Gradle wrapper distributions
   - Custom paths via `cache-paths` input (optional)

3. **Cache Restore Strategy**
   - Primary key: Full hash-based key for exact matches
   - Fallback keys: `gradle-${{ runner.os }}-${{ github.workflow }}-` for partial matches

This is based on CirrusCI usage as well as usage in teams that migrated to GitHub already.

[BUILD-8977]: https://sonarsource.atlassian.net/browse/BUILD-8977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ