### PR TITLE
BUILD-8974 Use fixed develocity plugin version

### DIFF
--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -92,6 +92,7 @@ runs:
       uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
       with:
         develocity-injection-enabled: ${{ inputs.use-develocity == 'true' }}
+        develocity-plugin-version: '4.0'
     # $GRADLE_USER_HOME is typically set to ~/.gradle/ by gradle/actions/setup-gradle
     - name: Configure Gradle Authentication
       shell: bash


### PR DESCRIPTION
Use fixed develocity plugin version to prevent incompatibility issues between plugin and Develocity platform.