### PR TITLE
BUILD-8999: fix JGit blobless cloning

### DIFF
--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -137,13 +137,12 @@ is_long_lived_feature_branch() {
 
 # Unshallow and fetch all commit history for SonarQube analysis and issue assignment
 git_fetch_unshallow() {
-  # The --filter=blob:none flag significantly speeds up the download
   if git rev-parse --is-shallow-repository --quiet >/dev/null 2>&1; then
     echo "Fetch Git references for SonarQube analysis..."
-    git fetch --unshallow --filter=blob:none
+    git fetch --unshallow
   elif is_pull_request; then
     echo "Fetch ${GITHUB_BASE_REF:?} for SonarQube analysis..."
-    git fetch --filter=blob:none origin "${GITHUB_BASE_REF}"
+    git fetch origin "${GITHUB_BASE_REF}"
   fi
 }
 

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -60,13 +60,12 @@ check_tool() {
 }
 
 git_fetch_unshallow() {
-  # The --filter=blob:none flag significantly speeds up the download
   if git rev-parse --is-shallow-repository --quiet >/dev/null 2>&1; then
     echo "Fetch Git references for SonarQube analysis..."
-    git fetch --unshallow --filter=blob:none
+    git fetch --unshallow
   elif [ -n "${GITHUB_BASE_REF:-}" ]; then
     echo "Fetch ${GITHUB_BASE_REF} for SonarQube analysis..."
-    git fetch --filter=blob:none origin "${GITHUB_BASE_REF}"
+    git fetch origin "${GITHUB_BASE_REF}"
   fi
 }
 

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -64,13 +64,12 @@ check_tool() {
 }
 
 git_fetch_unshallow() {
-  # The --filter=blob:none flag significantly speeds up the download
   if git rev-parse --is-shallow-repository --quiet >/dev/null 2>&1; then
     echo "Fetch Git references for SonarQube analysis..."
-    git fetch --unshallow --filter=blob:none
+    git fetch --unshallow
   elif [ -n "${GITHUB_BASE_REF:-}" ]; then
     echo "Fetch ${GITHUB_BASE_REF} for SonarQube analysis..."
-    git fetch --filter=blob:none origin "${GITHUB_BASE_REF}"
+    git fetch origin "${GITHUB_BASE_REF}"
   fi
 }
 

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -63,6 +63,7 @@ check_tool() {
   "$@"
 }
 
+# Unshallow and fetch all commit history for SonarQube analysis and issue assignment
 git_fetch_unshallow() {
   if git rev-parse --is-shallow-repository --quiet >/dev/null 2>&1; then
     echo "Fetch Git references for SonarQube analysis..."

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -62,13 +62,12 @@ check_tool() {
 }
 
 git_fetch_unshallow() {
-  # The --filter=blob:none flag significantly speeds up the download
   if git rev-parse --is-shallow-repository --quiet >/dev/null 2>&1; then
     echo "Fetch Git references for SonarQube analysis..."
-    git fetch --unshallow --filter=blob:none
+    git fetch --unshallow
   elif [ -n "${GITHUB_BASE_REF:-}" ]; then
     echo "Fetch ${GITHUB_BASE_REF} for SonarQube analysis..."
-    git fetch --filter=blob:none origin "${GITHUB_BASE_REF}"
+    git fetch origin "${GITHUB_BASE_REF}"
   fi
 }
 

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -208,7 +208,7 @@ Describe 'git_fetch_unshallow()'
     When call git_fetch_unshallow
     The lines of stdout should equal 2
     The line 1 should start with "Fetch Git references"
-    The line 2 should equal "git fetch --unshallow --filter=blob:none"
+    The line 2 should equal "git fetch --unshallow"
   End
 
   It 'fallbacks and fetches base branch for pull request'
@@ -223,7 +223,7 @@ Describe 'git_fetch_unshallow()'
     When call git_fetch_unshallow
     The lines of stdout should equal 2
     The line 1 should start with "Fetch def_main"
-    The line 2 should equal "git fetch --filter=blob:none origin def_main"
+    The line 2 should equal "git fetch origin def_main"
   End
 End
 

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -131,7 +131,7 @@ Describe 'build-npm/build.sh'
       When call git_fetch_unshallow
       The status should be success
       The output should include "Fetch main for SonarQube analysis..."
-      The output should include "git fetch --filter=blob:none origin main"
+      The output should include "git fetch origin main"
     End
   End
 End
@@ -149,7 +149,7 @@ Describe 'git_fetch_unshallow()'
     When call git_fetch_unshallow
     The lines of stdout should equal 2
     The line 1 should equal "Fetch Git references for SonarQube analysis..."
-    The line 2 should equal "git fetch --unshallow --filter=blob:none"
+    The line 2 should equal "git fetch --unshallow"
   End
 
   It 'fallbacks and fetches base branch for pull request'
@@ -164,7 +164,7 @@ Describe 'git_fetch_unshallow()'
     When call git_fetch_unshallow
     The lines of stdout should equal 2
     The line 1 should start with "Fetch def_main"
-    The line 2 should equal "git fetch --filter=blob:none origin def_main"
+    The line 2 should equal "git fetch origin def_main"
   End
 End
 

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -71,7 +71,7 @@ Describe 'build-poetry/build.sh'
       The line 8 should include "jf"
       The line 9 should equal "PROJECT: my-repo"
       The line 10 should equal "Fetch Git references for SonarQube analysis..."
-      The line 11 should equal "git fetch --unshallow --filter=blob:none"
+      The line 11 should equal "git fetch --unshallow"
       The line 12 should equal "=== Poetry Build, Deploy, and Analyze ==="
       The line 13 should equal "Branch: any-branch"
       The line 14 should equal "Pull Request: "

--- a/spec/build-yarn_spec.sh
+++ b/spec/build-yarn_spec.sh
@@ -126,14 +126,14 @@ Describe 'build-yarn/build.sh'
       unset GITHUB_BASE_REF
       When call git_fetch_unshallow
       The output should include "Fetch Git references for SonarQube analysis..."
-      The output should include "git fetch --unshallow --filter=blob:none"
+      The output should include "git fetch --unshallow"
     End
 
     It 'fetches base ref for PR'
       export GITHUB_BASE_REF="main"
       When call git_fetch_unshallow
       The output should include "Fetch main for SonarQube analysis..."
-      The output should include "git fetch --filter=blob:none origin main"
+      The output should include "git fetch origin main"
     End
   End
 


### PR DESCRIPTION
[BUILD-8999](https://sonarsource.atlassian.net/browse/BUILD-8999)



[BUILD-8999]: https://sonarsource.atlassian.net/browse/BUILD-8999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Removing filter from git fetch.
This has been tested here https://github.com/SonarSource/ops-releasability/actions/runs/17487273190/job/49668842783?pr=473.