### PR TITLE
PREQ-1938 Fix RepoX auth for build-gradle

### DIFF
--- a/build-gradle/resources/repoxAuth.init.gradle.kts
+++ b/build-gradle/resources/repoxAuth.init.gradle.kts
@@ -99,7 +99,7 @@ fun RepositoryHandler.addBearerAuthForRepoxRepositories(token: (String) -> Provi
     }
 }
 
-fun <T> Provider<T>.orElse(vararg providers: Provider<T>) =
+fun <T: Any> Provider<T>.orElse(vararg providers: Provider<T>) =
         listOf(this, *providers).reduce { p1, p2 ->
             p1.orElse(p2)
         }


### PR DESCRIPTION
[PREQ-1938](https://sonarsource.atlassian.net/browse/PREQ-1938)

This fixes the following issue in build-gradle action:

```
e: file:///home/runner/_work/sonar-php/sonar-php/.gradle/init.d/repoxAuth.init.gradle.kts:102:18: Type argument is not within its bounds: must be subtype of 'Any'.

FAILURE: Build failed with an exception.

* Where:
Initialization script '/home/runner/_work/sonar-php/sonar-php/.gradle/init.d/repoxAuth.init.gradle.kts' line: 102

* What went wrong:
Script compilation error:

  Line 102: fun <T> Provider<T>.orElse(vararg providers: Provider<T>) =
                             ^ Type argument is not within its bounds: must be subtype of 'Any'.

1 error
```

Spotted in sonar-php

[PREQ-1938]: https://sonarsource.atlassian.net/browse/PREQ-1938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ