### PR TITLE
BUILD-9058 output BUILD_NUMBER

### DIFF
--- a/.github/workflows/test-build-number.yml
+++ b/.github/workflows/test-build-number.yml
@@ -46,7 +46,7 @@ jobs:
           if [[ "${BUILD_NUMBER}" != "${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}" ]]; then
             echo -e "::error title=test-build-number-reuse::Build number '${BUILD_NUMBER}' does not match the previous job build number" \
               "'${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run.\n" \
-              "Prefer using the output from SonarSource/ci-github-actions/get-build-number instead of calling it twice."
+              "Prefer using the output from SonarSource/ci-github-actions/get-build-number instead of calling it from distinct jobs."
           fi
 
   test-build-number-reuse-windows:
@@ -66,6 +66,6 @@ jobs:
           echo "Build number: ${BUILD_NUMBER}"
           if [[ "${BUILD_NUMBER}" != "${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}" ]]; then
             echo -e "::error title=test-build-number-reuse::Build number '${BUILD_NUMBER}' does not match the previous job build number" \
-              "'${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run."
-            exit 1
+              "'${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run.\n" \
+              "Prefer using the output from SonarSource/ci-github-actions/get-build-number instead of calling it from distinct jobs."
           fi

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -54,6 +54,9 @@ outputs:
   project-version:
     description: The release version set as Gradle project version in gradle.properties
     value: ${{ steps.build.outputs.project-version }}
+  BUILD_NUMBER:
+    description: The build number, incremented or reused if already cached
+    value: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
 
 runs:
   using: composite
@@ -71,6 +74,7 @@ runs:
         mkdir .actions/
         ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
     - uses: ./.actions/get-build-number
+      id: get_build_number
     - name: Vault
       id: secrets
       uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: If true, run SonarQube analysis on all three platforms (next, sqc-eu, sqc-us).
       If false, run analysis on the platform specified with sonar-platform.
     default: 'false'
+outputs:
+  BUILD_NUMBER:
+    description: The build number, incremented or reused if already cached
+    value: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
 
 runs:
   using: composite
@@ -66,6 +70,7 @@ runs:
         ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
         ln -s "${GITHUB_ACTION_PATH}/../cache" .actions/cache
     - uses: ./.actions/get-build-number
+      id: get_build_number
     - name: Cache local Maven repository
       uses: ./.actions/cache
       with:

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -49,7 +49,9 @@ outputs:
   build-info-url:
     description: The JFrog build info UI URL
     value: ${{ steps.build.outputs.BUILD_INFO_URL }}
-
+  BUILD_NUMBER:
+    description: The build number, incremented or reused if already cached
+    value: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
 
 runs:
   using: composite
@@ -69,6 +71,7 @@ runs:
         ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
         ln -s "${GITHUB_ACTION_PATH}/../cache" .actions/cache
     - uses: ./.actions/get-build-number
+      id: get_build_number
     - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
       with:
         version: 2025.7.12

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -44,6 +44,9 @@ outputs:
   project-version:
     description: The project version from pyproject.toml with BUILD_NUMBER
     value: ${{ steps.build.outputs.project-version }}
+  BUILD_NUMBER:
+    description: The build number, incremented or reused if already cached
+    value: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
 
 runs:
   using: composite
@@ -62,6 +65,7 @@ runs:
         mkdir .actions/
         ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
     - uses: ./.actions/get-build-number
+      id: get_build_number
     - name: Cache local Poetry cache
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       with:

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -46,6 +46,9 @@ outputs:
   build-info-url:
     description: The JFrog build info UI URL
     value: ${{ steps.build.outputs.BUILD_INFO_URL }}
+  BUILD_NUMBER:
+    description: The build number, incremented or reused if already cached
+    value: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
 
 runs:
   using: composite
@@ -65,6 +68,7 @@ runs:
         ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
         ln -s "${GITHUB_ACTION_PATH}/../cache" .actions/cache
     - uses: ./.actions/get-build-number
+      id: get_build_number
     - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
       with:
         version: 2025.7.12

--- a/promote/action.yml
+++ b/promote/action.yml
@@ -22,6 +22,8 @@ runs:
         mkdir .actions/
         ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
     - uses: ./.actions/get-build-number
+      if: env.BUILD_NUMBER == ''
+      id: get_build_number
     - name: Vault
       id: secrets
       uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0


### PR DESCRIPTION
[BUILD-9058](https://sonarsource.atlassian.net/browse/BUILD-9058)

The cache that is used to share the build number between jobs was confirmed as **not reliable** by GitHub support!
Output the build number from the build actions to allow its reuse.

The promote action is reusing the BUILD_NUMBER from env if provided, otherwise it's calling the get-build-number action.

[BUILD-9058]: https://sonarsource.atlassian.net/browse/BUILD-9058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ