### PR TITLE
BUILD-9058 reuse BUILD_NUMBER from env

### DIFF
--- a/.github/workflows/test-build-number.yml
+++ b/.github/workflows/test-build-number.yml
@@ -22,14 +22,26 @@ jobs:
         with:
           sparse-checkout: get-build-number
       - uses: ./get-build-number
-      - uses: ./get-build-number
         id: get_build_number
       - name: Check build number generation
         run: |
-          echo "Build number: ${BUILD_NUMBER}"
+          echo "BUILD_NUMBER: ${BUILD_NUMBER}"
           [[ "${BUILD_NUMBER}" =~ ^[0-9]+$ ]]
 
-  test-build-number-reuse:
+      - uses: ./get-build-number
+        id: get_build_number_second_call
+      - name: Check build number is stable across calls
+        env:
+          BUILD_NUMBER_FROM_FIRST_CALL: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
+          BUILD_NUMBER_FROM_SECOND_CALL: ${{ steps.get_build_number_second_call.outputs.BUILD_NUMBER }}
+        run: |
+          if [[ "${BUILD_NUMBER_FROM_FIRST_CALL}" != "${BUILD_NUMBER_FROM_SECOND_CALL}" ]]; then
+              echo -e "::error title=test-build-number-generation::Build number '${BUILD_NUMBER_FROM_FIRST_CALL}' from first call" \
+              "does not match the build number from second call '${BUILD_NUMBER_FROM_SECOND_CALL}'."
+              exit 1
+          fi
+
+  test-build-number-reuse-from-cache:
     needs: test-build-number-generation
     runs-on: github-ubuntu-latest-s
     permissions:
@@ -42,14 +54,14 @@ jobs:
       - uses: ./get-build-number
       - name: Check build number was reused
         run: |
-          echo "Build number: ${BUILD_NUMBER}"
+          echo "BUILD_NUMBER: ${BUILD_NUMBER}"
           if [[ "${BUILD_NUMBER}" != "${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}" ]]; then
             echo -e "::error title=test-build-number-reuse::Build number '${BUILD_NUMBER}' does not match the previous job build number" \
               "'${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run.\n" \
               "Prefer using the output from SonarSource/ci-github-actions/get-build-number instead of calling it from distinct jobs."
           fi
 
-  test-build-number-reuse-windows:
+  test-build-number-reuse-from-cache-windows:
     needs: test-build-number-generation
     runs-on: github-windows-latest-s
     permissions:
@@ -63,9 +75,48 @@ jobs:
       - name: Check build number was reused
         shell: bash
         run: |
-          echo "Build number: ${BUILD_NUMBER}"
+          echo "BUILD_NUMBER: ${BUILD_NUMBER}"
           if [[ "${BUILD_NUMBER}" != "${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}" ]]; then
-            echo -e "::error title=test-build-number-reuse::Build number '${BUILD_NUMBER}' does not match the previous job build number" \
-              "'${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run.\n" \
+            echo -e "::error title=test-build-number-reuse-from-cache-windows::Build number '${BUILD_NUMBER}' does not match the previous" \
+              "job build number '${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run.\n" \
               "Prefer using the output from SonarSource/ci-github-actions/get-build-number instead of calling it from distinct jobs."
           fi
+
+  test-build-number-reuse-from-env:
+    needs: test-build-number-generation
+    runs-on: github-ubuntu-latest-s
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          sparse-checkout: get-build-number
+      - uses: ./get-build-number
+        id: get_build_number
+        env:
+          BUILD_NUMBER: ${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}
+      - name: Check build number was reused
+        env:
+          BUILD_NUMBER_FROM_ENV: ${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}
+          BUILD_NUMBER_RETURNED: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
+        run: |
+          echo "BUILD_NUMBER: ${BUILD_NUMBER}"
+          if [[ "${BUILD_NUMBER_FROM_ENV}" != "${BUILD_NUMBER_RETURNED}" ]]; then
+            echo -e "::error title=test-build-number-reuse-from-env::Build number returned by get-build-number '${BUILD_NUMBER_RETURNED}'" \
+              "does not match the build number passed by env ${BUILD_NUMBER_FROM_ENV}."
+            exit 1
+          fi
+
+  test-build-number-reuse:
+    if: always()
+    needs:
+      - test-build-number-generation
+      - test-build-number-reuse-from-cache
+      - test-build-number-reuse-from-cache-windows
+      - test-build-number-reuse-from-env
+    runs-on: github-ubuntu-latest-s
+    steps:
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ jobs:
       - uses: SonarSource/ci-github-actions/get-build-number@v1
 ```
 
+### Environment variables
+
+If `BUILD_NUMBER` is present in the environment, it will be reused as the build number.
+
 ### Inputs
 
 No inputs are required for this action.

--- a/get-build-number/action.yml
+++ b/get-build-number/action.yml
@@ -9,8 +9,19 @@ outputs:
 runs:
   using: composite
   steps:
+    # Reuse build number from environment if provided (e.g. from a parent workflow)
+    - name: Save build number from environment to file
+      id: from-env
+      if: env.BUILD_NUMBER != ''
+      shell: bash
+      run: |
+        echo "BUILD_NUMBER ${BUILD_NUMBER} provided from environment, skipping both increment and save to cache."
+        echo "${BUILD_NUMBER}" > build_number.txt
+        echo "skip=true" >> $GITHUB_OUTPUT
+
     # Reuse current build number in case of rerun
     - name: Get cached build number
+      if: steps.from-env.outputs.skip != 'true'
       uses: actions/cache/restore@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
       id: current-build-number
       with:
@@ -21,16 +32,16 @@ runs:
     # Otherwise, increment the build number
     - name: Get secrets from Vault
       id: secrets
-      if: steps.current-build-number.outputs.cache-hit != 'true'
+      if: steps.from-env.outputs.skip != 'true' && steps.current-build-number.outputs.cache-hit != 'true'
       uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       with:
         secrets: development/github/token/{REPO_OWNER_NAME_DASH}-build-number token | github_token;
     - name: Get new build number
-      if: steps.current-build-number.outputs.cache-hit != 'true'
+      if: steps.from-env.outputs.skip != 'true' && steps.current-build-number.outputs.cache-hit != 'true'
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ steps.current-build-number.outputs.cache-hit != 'true' && fromJSON(steps.secrets.outputs.vault).github_token
-          || '' }}
+        GITHUB_TOKEN: ${{ steps.current-build-number.outputs.cache-hit != 'true' &&
+          steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).github_token || '' }}
       run: ${GITHUB_ACTION_PATH}/get_build_number.sh
 
     - name: Export build number
@@ -41,9 +52,10 @@ runs:
         echo "BUILD_NUMBER: ${BUILD_NUMBER}"
         echo "BUILD_NUMBER=${BUILD_NUMBER}" >> "$GITHUB_ENV"
         echo "BUILD_NUMBER=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
+
     - name: Save build number to cache
       uses: actions/cache/save@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      if: steps.current-build-number.outputs.cache-hit != 'true'
+      if: steps.from-env.outputs.skip != 'true' && steps.current-build-number.outputs.cache-hit != 'true'
       with:
         path: build_number.txt
         key: build-number-${{ github.run_id }}

--- a/promote/action.yml
+++ b/promote/action.yml
@@ -22,8 +22,6 @@ runs:
         mkdir .actions/
         ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
     - uses: ./.actions/get-build-number
-      if: env.BUILD_NUMBER == ''
-      id: get_build_number
     - name: Vault
       id: secrets
       uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0


### PR DESCRIPTION
[BUILD-9058](https://sonarsource.atlassian.net/browse/BUILD-9058)

The GitHub cache used by get-build-number is not reliable and can be desynchronized between two jobs.
To circumvent, this PR makes it possible to pass the BUILD_NUMBER through environment, in which case, the get-build-number action will skip its steps.

Add tests to check for the behavior.

Tested with
- https://github.com/SonarSource/sonar-dummy/pull/483
- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/284

[BUILD-9058]: https://sonarsource.atlassian.net/browse/BUILD-9058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ