### PR TITLE
PREQ-2006 build-npm: repox auth and default ARTIFACTORY_DEPLOY_REPO

### DIFF
--- a/.cursor/cirrus-github-migration.md
+++ b/.cursor/cirrus-github-migration.md
@@ -662,7 +662,6 @@ build_script:
     deploy-pull-request: false                        # Deploy pull request artifacts
     # All parameters below are optional
     artifactory-deploy-repo: ""                       # Artifactory repository name
-    artifactory-deploy-access-token: ""               # Artifactory access token
     skip-tests: false                                  # Skip running tests
     cache-npm: true                                    # Cache NPM dependencies
     repox-url: https://repox.jfrog.io                 # Repox URL
@@ -687,7 +686,6 @@ build_script:
     deploy-pull-request: false                        # Deploy pull request artifacts
     # All parameters below are optional
     artifactory-deploy-repo: ""                       # Artifactory repository name
-    artifactory-deploy-access-token: ""               # Artifactory access token
     skip-tests: false                                  # Skip running tests
     cache-yarn: true                                   # Cache Yarn dependencies
     repox-url: https://repox.jfrog.io                 # Repox URL

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ jobs:
 | `scanner-java-opts`           | Additional Java options for the Sonar scanner (`SONAR_SCANNER_JAVA_OPTS`)                                                  | `-Xmx512m`                                                           |
 | `use-develocity`              | Whether to use Develocity for build tracking                                                                               | `false`                                                              |
 | `repox-url`                   | URL for Repox                                                                                                              | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`       | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                               | (optional)                                                           |
+| `repox-artifactory-url`       | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                | (optional)                                                           |
 | `develocity-url`              | URL for Develocity                                                                                                         | `https://develocity.sonar.build/`                                    |
 | `sonar-platform`              | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us'                                                                 | `next`                                                               |
 | `working-directory`           | Relative path under github.workspace to execute the build in                                                               | `.`                                                                  |
@@ -334,7 +334,7 @@ jobs:
 | `gradle-args`               | Additional arguments to pass to Gradle                                         | (optional)                                                           |
 | `develocity-url`            | URL for Develocity                                                             | `https://develocity.sonar.build/`                                    |
 | `repox-url`                 | URL for Repox                                                                  | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)   | (optional)                                                           |
+| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)    | (optional)                                                           |
 | `sonar-platform`            | SonarQube variant - 'next', 'sqc-eu', or 'sqc-us'                              | `next`                                                               |
 | `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                              |
 
@@ -422,13 +422,12 @@ jobs:
 | `public`                          | Whether to build and deploy with/to public repositories                        | Auto-detected from repository visibility                             |
 | `artifactory-reader-role`         | Suffix for the Artifactory reader role in Vault                                | `private-reader` for private repos, `public-reader` for public repos |
 | `artifactory-deployer-role`       | Suffix for the Artifactory deployer role in Vault                              | `qa-deployer` for private repos, `public-deployer` for public repos  |
-| `artifactory-deploy-repo`         | Name of deployment repository                                                  | (optional)                                                           |
-| `artifactory-deploy-access-token` | Access token to deploy to Artifactory                                          | (optional)                                                           |
+| `artifactory-deploy-repo`         | Name of deployment repository                                                  | Auto-detected based on repository visibility                         |
 | `deploy-pull-request`             | Whether to deploy pull request artifacts                                       | `false`                                                              |
 | `skip-tests`                      | Whether to skip running tests                                                  | `false`                                                              |
 | `cache-npm`                       | Whether to cache NPM dependencies                                              | `true`                                                               |
 | `repox-url`                       | URL for Repox                                                                  | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`           | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)   | (optional)                                                           |
+| `repox-artifactory-url`           | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)    | (optional)                                                           |
 | `sonar-platform`                  | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us'                     | `next`                                                               |
 | `run-shadow-scans`                | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                              |
 
@@ -522,7 +521,7 @@ jobs:
 | `skip-tests`                | Whether to skip running tests                                                  | `false`                                                              |
 | `cache-yarn`                | Whether to cache Yarn dependencies                                             | `true`                                                               |
 | `repox-url`                 | URL for Repox                                                                  | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)   | (optional)                                                           |
+| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)    | (optional)                                                           |
 | `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us'                     | `next`                                                               |
 | `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                              |
 

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -16,9 +16,6 @@ inputs:
   artifactory-deploy-repo:
     description: Name of deployment repository
     default: ''
-  artifactory-deploy-access-token:
-    description: Access token to deploy to Artifactory
-    default: ''
   deploy-pull-request:
     description: Whether to deploy pull request artifacts
     default: 'false'
@@ -29,7 +26,7 @@ inputs:
     description: Whether to cache NPM dependencies
     default: 'true'
   repox-url:
-    description: URL for Repox
+    description: URL for Repox Platform
     default: https://repox.jfrog.io
   repox-artifactory-url:
     description: URL for Repox Artifactory API (overrides repox-url/artifactory if provided)
@@ -108,7 +105,8 @@ runs:
         # Action inputs
         ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
           format('{0}/artifactory', inputs.repox-url) }}
-        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo }}
+        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
+          (inputs.public == 'true' && 'sonarsource-npm-public-qa' || 'sonarsource-npm-private-qa') }}
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
@@ -125,6 +123,14 @@ runs:
         RUN_SHADOW_SCANS: ${{ inputs.run-shadow-scans }}
       run: |
         ${GITHUB_ACTION_PATH}/build.sh
+
+    - name: Archive logs
+      if: failure()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: npm-logs-${{ github.job }}
+        path: ~/.npm/_logs/
+        if-no-files-found: ignore
 
     - name: Generate workflow summary
       if: always()

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -74,19 +74,25 @@ git_fetch_unshallow() {
 set_build_env() {
   export PROJECT="${GITHUB_REPOSITORY#*/}"
   echo "PROJECT: ${PROJECT}"
+  git_fetch_unshallow
 
   # Validate required files exist
   if [ ! -f "package.json" ]; then
     echo "ERROR: package.json file not found in current directory." >&2
     exit 1
   fi
-
   if [ ! -f "yarn.lock" ]; then
     echo "ERROR: yarn.lock file not found. This is required for yarn --immutable installs." >&2
     exit 1
   fi
 
-  git_fetch_unshallow
+  echo "::debug::Configuring JFrog and NPM repositories..."
+  npm config set registry "$ARTIFACTORY_URL/api/npm/npm"
+  npm config set "${ARTIFACTORY_URL//https:}/api/npm/:_authToken=$ARTIFACTORY_ACCESS_TOKEN"
+  jf config remove repox > /dev/null 2>&1 || true # Do not log if the repox config were not present
+  jf config add repox --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_ACCESS_TOKEN"
+  jf config use repox
+  jf npm-config --repo-resolve "npm"
 }
 
 is_default_branch() {
@@ -177,18 +183,9 @@ sonar_scanner_implementation() {
 }
 
 jfrog_yarn_publish() {
-  if [ -z "${ARTIFACTORY_URL:-}" ] || [ -z "${ARTIFACTORY_DEPLOY_ACCESS_TOKEN:-}" ]; then
-    echo "ERROR: Deployment requires ARTIFACTORY_URL and ARTIFACTORY_DEPLOY_ACCESS_TOKEN to be set" >&2
-    exit 1
-  fi
-
-  echo "::debug::Removing existing JFrog config..."
+  echo "::debug::Configuring JFrog and NPM repositories..."
   jf config remove repox > /dev/null 2>&1 || true # Do not log if the repox config were not present
-
-  echo "::debug::Adding JFrog config..."
   jf config add repox --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_DEPLOY_ACCESS_TOKEN"
-
-  echo "::debug::Configuring Yarn repositories..."
   jf npm-config --repo-resolve "npm" --repo-deploy "$ARTIFACTORY_DEPLOY_REPO"
 
   echo "::debug::Publishing Yarn package..."
@@ -199,7 +196,6 @@ jfrog_yarn_publish() {
   echo "::debug::Publishing build info..."
   local build_publish_output
   build_publish_output=$(jf rt build-publish "$PROJECT" "$BUILD_NUMBER")
-
   echo "::debug::Build publish output: ${build_publish_output}"
 
   # Extract build info URL

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -364,17 +364,6 @@ Describe 'build_npm()'
   End
 End
 
-Describe 'JFrog deployment error scenarios'
-  It 'fails when missing ARTIFACTORY_URL'
-    unset ARTIFACTORY_URL
-    export PROJECT="test-project"
-    export BUILD_NUMBER="42"
-    When run jfrog_npm_publish
-    The status should be failure
-    The stderr should include "ERROR: Deployment requires ARTIFACTORY_URL and ARTIFACTORY_DEPLOY_ACCESS_TOKEN"
-  End
-End
-
 Describe 'Sonar platform configuration'
   It 'sets sonar variables for next platform'
     When call set_sonar_platform_vars "next"

--- a/spec/build-yarn_spec.sh
+++ b/spec/build-yarn_spec.sh
@@ -238,13 +238,6 @@ Describe 'build-yarn/build.sh'
       When call jfrog_yarn_publish
       The output should include "::debug::Build info URL saved:"
     End
-
-    It 'fails without ARTIFACTORY_URL'
-      unset ARTIFACTORY_URL
-      When run jfrog_yarn_publish
-      The status should be failure
-      The stderr should include "Deployment requires ARTIFACTORY_URL and ARTIFACTORY_DEPLOY_ACCESS_TOKEN"
-    End
   End
 
   Describe 'build_yarn() scenarios'


### PR DESCRIPTION
[PREQ-2006](https://sonarsource.atlassian.net/browse/PREQ-2006)

Set Repox as the default registry and authenticate.
Fix "npm ci" command which was not authenticated.
Remove unused input artifactory-deploy-access-token
Add default value for ARTIFACTORY_DEPLOY_REPO

Tested with
- https://github.com/SonarSource/ai-content-engine/pull/3
- https://github.com/SonarSource/sonar-dummy-js/pull/94
- https://github.com/SonarSource/sonar-dummy-yarn/pull/27

[PREQ-2006]: https://sonarsource.atlassian.net/browse/PREQ-2006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ