### PR TITLE
BUILD-9094 local action

### DIFF
--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -64,6 +64,25 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set local action paths
+      id: set-path
+      shell: bash
+      run: |
+        echo "::group::Fix for using local actions"
+        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
+        echo "github.action_path=${{ github.action_path }}"
+        ACTION_PATH_BUILD_GRADLE="${{ github.action_path }}"
+        echo "ACTION_PATH_BUILD_GRADLE=$ACTION_PATH_BUILD_GRADLE"
+        echo "ACTION_PATH_BUILD_GRADLE=$ACTION_PATH_BUILD_GRADLE" >> "$GITHUB_ENV"
+        host_actions_root="$(dirname "$ACTION_PATH_BUILD_GRADLE")"
+        echo "host_actions_root=$host_actions_root" >> "$GITHUB_OUTPUT"
+
+        mkdir -p ".actions"
+        ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
+        ln -sf "$host_actions_root/shared" .actions/shared
+        ls -la .actions/*
+        echo "::endgroup::"
+
     - name: Set build parameters
       shell: bash
       env:
@@ -74,11 +93,12 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
-    - uses: SonarSource/ci-github-actions/get-build-number@v1
+    - uses: ./.actions/get-build-number
       id: get_build_number
-    - name: Vault
+      with:
+        host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
+    - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets
-      uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       with:
         # yamllint disable rule:line-length
         secrets: |
@@ -137,7 +157,7 @@ runs:
       run: |
         GRADLE_INIT_DIR="$GRADLE_USER_HOME/init.d"
         mkdir -p "$GRADLE_INIT_DIR"
-        cp "${GITHUB_ACTION_PATH}/resources/repoxAuth.init.gradle.kts" "$GRADLE_INIT_DIR/"
+        cp "$ACTION_PATH_BUILD_GRADLE/resources/repoxAuth.init.gradle.kts" "$GRADLE_INIT_DIR/"
 
     - name: Extract Develocity hostname
       id: develocity-hostname
@@ -192,7 +212,7 @@ runs:
         ORG_GRADLE_PROJECT_signingKeyId: ${{ fromJSON(steps.secrets.outputs.vault).SIGN_KEY_ID }}
         DEVELOCITY_ACCESS_KEY: ${{ inputs.use-develocity == 'true' &&
           format('{0}={1}', steps.develocity-hostname.outputs.hostname, fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN) || '' }}
-      run: ${GITHUB_ACTION_PATH}/build.sh
+      run: $ACTION_PATH_BUILD_GRADLE/build.sh
 
     - name: Archive problems report
       if: always()

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -63,15 +63,29 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set local action
+    - name: Set local action paths
+      id: set-path
       shell: bash
       run: |
+        echo "::group::Fix for using local actions"
+        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
+        echo "github.action_path=${{ github.action_path }}"
+        ACTION_PATH_BUILD_MAVEN="${{ github.action_path }}"
+        echo "ACTION_PATH_BUILD_MAVEN=$ACTION_PATH_BUILD_MAVEN"
+        echo "ACTION_PATH_BUILD_MAVEN=$ACTION_PATH_BUILD_MAVEN" >> "$GITHUB_ENV"
+        host_actions_root="$(dirname "$ACTION_PATH_BUILD_MAVEN")"
+        echo "host_actions_root=$host_actions_root" >> "$GITHUB_OUTPUT"
+
         mkdir -p ".actions"
-        ln -s "${{github.action_path}}/../config-maven" .actions/config-maven
-        ln -s "${{github.action_path}}/../shared" .actions/shared
-    - uses: ./.actions/config-maven # TODO BUILD-9094
+        ln -sf "$host_actions_root/config-maven" .actions/config-maven
+        ln -sf "$host_actions_root/shared" .actions/shared
+        ls -la .actions/*
+        echo "::endgroup::"
+
+    - uses: ./.actions/config-maven
       id: config
       with:
+        host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
         working-directory: ${{ inputs.working-directory }}
         artifactory-reader-role: ${{ inputs.artifactory-reader-role }}
         common-mvn-flags: ${{ inputs.common-mvn-flags }}
@@ -89,10 +103,9 @@ runs:
       run: |
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
         echo "SONARSOURCE_REPOSITORY_URL=${ARTIFACTORY_URL}/sonarsource" >> "$GITHUB_ENV"
-    - name: Vault
-      # yamllint disable rule:line-length
+    - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets
-      uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
+      # yamllint disable rule:line-length
       with:
         secrets: |
           ${{ inputs.sonar-platform != 'none' && 'development/kv/data/next url | NEXT_URL;' || '' }}
@@ -132,7 +145,7 @@ runs:
         USER_MAVEN_ARGS: ${{ inputs.maven-args }}
         SONAR_SCANNER_JAVA_OPTS: ${{ inputs.scanner-java-opts }}
       working-directory: ${{ inputs.working-directory }}
-      run: ${GITHUB_ACTION_PATH}/build.sh $USER_MAVEN_ARGS
+      run: $ACTION_PATH_BUILD_MAVEN/build.sh $USER_MAVEN_ARGS
 
     - name: Cleanup Maven repository before caching
       shell: bash

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -57,6 +57,26 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set local action paths
+      id: set-path
+      shell: bash
+      run: |
+        echo "::group::Fix for using local actions"
+        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
+        echo "github.action_path=${{ github.action_path }}"
+        ACTION_PATH_BUILD_NPM="${{ github.action_path }}"
+        echo "ACTION_PATH_BUILD_NPM=$ACTION_PATH_BUILD_NPM"
+        echo "ACTION_PATH_BUILD_NPM=$ACTION_PATH_BUILD_NPM" >> "$GITHUB_ENV"
+        host_actions_root="$(dirname "$ACTION_PATH_BUILD_NPM")"
+        echo "host_actions_root=$host_actions_root" >> "$GITHUB_OUTPUT"
+
+        mkdir -p ".actions"
+        ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
+        ln -sf "$host_actions_root/config-npm" .actions/config-npm
+        ln -sf "$host_actions_root/shared" .actions/shared
+        ls -la .actions/*
+        echo "::endgroup::"
+
     - name: Set build parameters
       shell: bash
       env:
@@ -67,28 +87,25 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
-        cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
-        mkdir -p ".actions"
-        ln -s "${{github.action_path}}/../config-npm" .actions/config-npm
-        ln -s "${{github.action_path}}/../shared" .actions/shared
+        cp "$ACTION_PATH_BUILD_NPM/mise.local.toml" mise.local.toml
 
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         version: 2025.7.12
 
-    - uses: ./.actions/config-npm # TODO BUILD-9094
+    - uses: ./.actions/config-npm
       id: config
       with:
+        host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
         artifactory-reader-role: ${{ env.ARTIFACTORY_READER_ROLE }}
         repox-url: ${{ inputs.repox-url }}
         repox-artifactory-url: ${{ inputs.repox-artifactory-url }}
         working-directory: ${{ inputs.working-directory }}
         cache-npm: ${{ inputs.cache-npm }}
 
-    - name: Vault
-      # yamllint disable rule:line-length
+    - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets
-      uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
+      # yamllint disable rule:line-length
       with:
         secrets: |
           ${{ inputs.sonar-platform != 'none' && 'development/kv/data/next url | NEXT_URL;' || '' }}
@@ -126,7 +143,7 @@ runs:
         SQC_US_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_URL }}
         SQC_US_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_TOKEN }}
       working-directory: ${{ inputs.working-directory }}
-      run: ${GITHUB_ACTION_PATH}/build.sh
+      run: $ACTION_PATH_BUILD_NPM/build.sh
 
     - name: Archive logs
       if: failure()

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -55,6 +55,25 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set local action paths
+      id: set-path
+      shell: bash
+      run: |
+        echo "::group::Fix for using local actions"
+        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
+        echo "github.action_path=${{ github.action_path }}"
+        ACTION_PATH_BUILD_POETRY="${{ github.action_path }}"
+        echo "ACTION_PATH_BUILD_POETRY=$ACTION_PATH_BUILD_POETRY"
+        echo "ACTION_PATH_BUILD_POETRY=$ACTION_PATH_BUILD_POETRY" >> "$GITHUB_ENV"
+        host_actions_root="$(dirname "$ACTION_PATH_BUILD_POETRY")"
+        echo "host_actions_root=$host_actions_root" >> "$GITHUB_OUTPUT"
+
+        mkdir -p ".actions"
+        ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
+        ln -sf "$host_actions_root/shared" .actions/shared
+        ls -la .actions/*
+        echo "::endgroup::"
+
     - name: Set build parameters
       shell: bash
       env:
@@ -65,9 +84,11 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
-        cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
-    - uses: SonarSource/ci-github-actions/get-build-number@v1
+        cp "$ACTION_PATH_BUILD_POETRY/mise.local.toml" mise.local.toml
+    - uses: ./.actions/get-build-number
       id: get_build_number
+      with:
+        host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
     - name: Cache local Poetry cache
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
@@ -77,10 +98,9 @@ runs:
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         version: 2025.7.12
-    - name: Vault
-      # yamllint disable rule:line-length
+    - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets
-      uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
+      # yamllint disable rule:line-length
       with:
         secrets: |
           ${{ inputs.sonar-platform != 'none' && 'development/kv/data/next url | NEXT_URL;' || '' }}
@@ -124,7 +144,7 @@ runs:
         RUN_SHADOW_SCANS: ${{ inputs.run-shadow-scans }}
       run: |
         cd "${{ inputs.working-directory }}"
-        ${GITHUB_ACTION_PATH}/build.sh
+        "$ACTION_PATH_BUILD_POETRY/build.sh"
 
     - name: Generate workflow summary
       if: always()

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -51,6 +51,31 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set local action paths
+      id: set-path
+      shell: bash
+      run: |
+        echo "::group::Fix for using local actions"
+        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
+        echo "github.action_path=${{ github.action_path }}"
+        ACTION_PATH_BUILD_YARN="${{ github.action_path }}"
+        echo "ACTION_PATH_BUILD_YARN=$ACTION_PATH_BUILD_YARN"
+        echo "ACTION_PATH_BUILD_YARN=$ACTION_PATH_BUILD_YARN" >> "$GITHUB_ENV"
+        host_actions_root="$(dirname "$ACTION_PATH_BUILD_YARN")"
+        echo "host_actions_root=$host_actions_root" >> "$GITHUB_OUTPUT"
+
+        mkdir -p ".actions"
+        ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
+        ln -sf "$host_actions_root/cache" .actions/cache
+        ln -sf "$host_actions_root/shared" .actions/shared
+        ls -la .actions/*
+        echo "::endgroup::"
+
+    - uses: ./.actions/get-build-number
+      id: get_build_number
+      with:
+        host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
+
     - name: Set build parameters
       shell: bash
       env:
@@ -61,26 +86,24 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
-        cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
-    - uses: SonarSource/ci-github-actions/get-build-number@v1
-      id: get_build_number
+        cp "$ACTION_PATH_BUILD_YARN/mise.local.toml" mise.local.toml
+
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         version: 2025.7.12
 
     - name: Cache Yarn dependencies
+      uses: ./.actions/cache
       if: ${{ inputs.cache-yarn == 'true' }}
-      uses: SonarSource/ci-github-actions/cache@v1
       with:
         path: |
           ~/.yarn
         key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
         restore-keys: yarn-${{ runner.os }}-
 
-    - name: Vault
-      # yamllint disable rule:line-length
+    - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets
-      uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
+      # yamllint disable rule:line-length
       with:
         secrets: |
           ${{ inputs.sonar-platform != 'none' && 'development/kv/data/next url | NEXT_URL;' || '' }}
@@ -92,6 +115,7 @@ runs:
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} access_token | ARTIFACTORY_ACCESS_TOKEN;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} access_token | ARTIFACTORY_DEPLOY_ACCESS_TOKEN;
       # yamllint enable rule:line-length
+
     - name: Build, test, analyze and deploy
       id: build
       shell: bash
@@ -119,8 +143,7 @@ runs:
         SQC_US_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_TOKEN }}
         SONAR_PLATFORM: ${{ inputs.sonar-platform }}
         RUN_SHADOW_SCANS: ${{ inputs.run-shadow-scans }}
-      run: |
-        ${GITHUB_ACTION_PATH}/build.sh
+      run: $ACTION_PATH_BUILD_YARN/build.sh
 
     - name: Generate workflow summary
       if: always()

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -30,6 +30,9 @@ inputs:
   disable-caching:
     description: Whether to disable Maven caching entirely
     default: 'false'
+  host-actions-root:
+    description: Path to the actions folder on the host (used when called from another local action)
+    default: ''
 
 outputs:
   BUILD_NUMBER:
@@ -45,9 +48,35 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Get build number
+    - name: Set local action paths
+      id: set-path
+      shell: bash
+      run: |
+        echo "::group::Fix for using local actions"
+        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
+        echo "github.action_path=${{ github.action_path }}"
+        ACTION_PATH_CONFIG_MAVEN="${{ github.action_path }}"
+        host_actions_root="${{ inputs.host-actions-root }}"
+        if [ -z "$host_actions_root" ]; then
+          host_actions_root="$(dirname "$ACTION_PATH_CONFIG_MAVEN")"
+        else
+          ACTION_PATH_CONFIG_MAVEN="$host_actions_root/config-maven"
+        fi
+        echo "ACTION_PATH_CONFIG_MAVEN=$ACTION_PATH_CONFIG_MAVEN"
+        echo "ACTION_PATH_CONFIG_MAVEN=$ACTION_PATH_CONFIG_MAVEN" >> "$GITHUB_ENV"
+        echo "host_actions_root=$host_actions_root" >> "$GITHUB_OUTPUT"
+
+        mkdir -p ".actions"
+        ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
+        ln -sf "$host_actions_root/cache" .actions/cache
+        ln -sf "$host_actions_root/shared" .actions/shared
+        ls -la .actions/*
+        echo "::endgroup::"
+
+    - uses: ./.actions/get-build-number
       id: get_build_number
-      uses: SonarSource/ci-github-actions/get-build-number@v1
+      with:
+        host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
 
     - id: from-env
       if: env.CONFIG_MAVEN_COMPLETED != ''
@@ -64,10 +93,9 @@ runs:
           (github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader') }}
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
-    - name: Get secrets from Vault
+    - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       if: steps.from-env.outputs.skip != 'true'
       id: secrets
-      uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       with:
         secrets: |
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_USERNAME;
@@ -106,12 +134,13 @@ runs:
       run: |
         MAVEN_CONFIG="$HOME/.m2"
         mkdir -p "$MAVEN_CONFIG"
-        cp "${GITHUB_ACTION_PATH}/resources/settings.xml" "$MAVEN_CONFIG/settings.xml"
-        echo "Copied Maven settings from ${GITHUB_ACTION_PATH}/resources/settings.xml to $MAVEN_CONFIG/settings.xml"
+        cp "${ACTION_PATH_CONFIG_MAVEN}/resources/settings.xml" "$MAVEN_CONFIG/settings.xml"
+        echo "Copied Maven settings from ${ACTION_PATH_CONFIG_MAVEN}/resources/settings.xml to $MAVEN_CONFIG/settings.xml"
+        echo "MAVEN_CONFIG=$MAVEN_CONFIG" >> "$GITHUB_ENV"
         echo "SONARSOURCE_REPOSITORY_URL=$ARTIFACTORY_URL/sonarsource-qa" >> "$GITHUB_ENV"
 
     - name: Cache local Maven repository
-      uses: SonarSource/ci-github-actions/cache@v1
+      uses: ./.actions/cache
       if: steps.from-env.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: |-
@@ -124,7 +153,14 @@ runs:
       if: steps.from-env.outputs.skip != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: ${GITHUB_ACTION_PATH}/set_maven_project_version.sh
+      run: |
+        echo "pwd: $(pwd)"
+        env|grep HOME
+        echo "user.home: $(mvn -q -Dexec.executable="echo" -Dexec.args="\${user.home}" \
+          --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)"
+        echo "env.HOME: $(mvn -q -Dexec.executable="echo" -Dexec.args="\${env.HOME}" \
+          --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)"
+        $ACTION_PATH_CONFIG_MAVEN/set_maven_project_version.sh
 
     - name: Deactivate UseContainerSupport on github-ubuntu-* runners
       if: runner.os == 'Linux' && runner.environment == 'github-hosted' && steps.from-env.outputs.skip != 'true'

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -18,6 +18,9 @@ inputs:
   repox-artifactory-url:
     description: URL for Repox Artifactory API (overrides repox-url/artifactory if provided)
     default: ''
+  host-actions-root:
+    description: Path to the actions folder on the host (used when called from another local action)
+    default: ''
 
 outputs:
   BUILD_NUMBER:
@@ -33,8 +36,36 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: SonarSource/ci-github-actions/get-build-number@v1
+    - name: Set local action paths
+      id: set-path
+      shell: bash
+      run: |
+        echo "::group::Fix for using local actions"
+        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
+        echo "github.action_path=${{ github.action_path }}"
+        ACTION_PATH_CONFIG_NPM="${{ github.action_path }}"
+        host_actions_root="${{ inputs.host-actions-root }}"
+        if [ -z "$host_actions_root" ]; then
+          host_actions_root="$(dirname "$ACTION_PATH_CONFIG_NPM")"
+        else
+          ACTION_PATH_CONFIG_NPM="$host_actions_root/config-npm"
+        fi
+        echo "ACTION_PATH_CONFIG_NPM=$ACTION_PATH_CONFIG_NPM"
+        echo "ACTION_PATH_CONFIG_NPM=$ACTION_PATH_CONFIG_NPM" >> "$GITHUB_ENV"
+        echo "host_actions_root=$host_actions_root" >> "$GITHUB_OUTPUT"
+
+        mkdir -p ".actions"
+        ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
+        ln -sf "$host_actions_root/cache" .actions/cache
+        ln -sf "$host_actions_root/shared" .actions/shared
+        ls -la .actions/*
+        echo "::endgroup::"
+
+    - uses: ./.actions/get-build-number
       id: get_build_number
+      with:
+        host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
+
     - name: Set parameters
       shell: bash
       env:
@@ -42,22 +73,22 @@ runs:
           (github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader') }}
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
-        cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
+        cp "$ACTION_PATH_CONFIG_NPM/mise.local.toml" mise.local.toml
+
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
         version: 2025.7.12
 
-    - name: Get secrets from Vault
+    - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets
-      uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       with:
         secrets: |
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_USERNAME;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} access_token | ARTIFACTORY_ACCESS_TOKEN;
 
     - name: Cache NPM dependencies
+      uses: ./.actions/cache
       if: ${{ inputs.cache-npm == 'true' }}
-      uses: SonarSource/ci-github-actions/cache@v1
       with:
         path: ~/.npm
         key: npm-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles('**/package-lock.json') }}
@@ -73,4 +104,4 @@ runs:
         ARTIFACTORY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
       working-directory: ${{ inputs.working-directory }}
-      run: ${GITHUB_ACTION_PATH}/config.sh
+      run: $ACTION_PATH_CONFIG_NPM/config.sh

--- a/get-build-number/action.yml
+++ b/get-build-number/action.yml
@@ -5,10 +5,32 @@ outputs:
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
     value: ${{ steps.export.outputs.BUILD_NUMBER }}
+inputs:
+  host-actions-root:
+    description: Path to the actions folder on the host (used when called from another local action)
+    default: ''
 
 runs:
   using: composite
   steps:
+    - name: Set local action paths
+      id: set-path
+      shell: bash
+      run: |
+        echo "::group::Fix for using local actions"
+        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
+        echo "github.action_path=${{ github.action_path }}"
+        ACTION_PATH_GET_BUILD_NUMBER="${{ github.action_path }}"
+        host_actions_root="${{ inputs.host-actions-root }}"
+        if [ -z "$host_actions_root" ]; then
+          host_actions_root="$(dirname "$ACTION_PATH_GET_BUILD_NUMBER")"
+        else
+          ACTION_PATH_GET_BUILD_NUMBER="$host_actions_root/get-build-number"
+        fi
+        echo "ACTION_PATH_GET_BUILD_NUMBER=$ACTION_PATH_GET_BUILD_NUMBER"
+        echo "ACTION_PATH_GET_BUILD_NUMBER=$ACTION_PATH_GET_BUILD_NUMBER" >> "$GITHUB_ENV"
+        echo "::endgroup::"
+
     # Reuse build number from environment if provided (e.g. from a parent workflow)
     - name: Save build number from environment to file
       id: from-env
@@ -30,10 +52,9 @@ runs:
         enableCrossOsArchive: true
 
     # Otherwise, increment the build number
-    - name: Get secrets from Vault
+    - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets
       if: steps.from-env.outputs.skip != 'true' && steps.current-build-number.outputs.cache-hit != 'true'
-      uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       with:
         secrets: development/github/token/{REPO_OWNER_NAME_DASH}-build-number token | github_token;
     - name: Get new build number
@@ -42,7 +63,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ steps.current-build-number.outputs.cache-hit != 'true' &&
           steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).github_token || '' }}
-      run: ${GITHUB_ACTION_PATH}/get_build_number.sh
+      run: ${ACTION_PATH_GET_BUILD_NUMBER}/get_build_number.sh
 
     - name: Export build number
       id: export

--- a/promote/action.yml
+++ b/promote/action.yml
@@ -18,14 +18,34 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set local action paths
+      id: set-path
+      shell: bash
+      run: |
+        echo "::group::Fix for using local actions"
+        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
+        echo "github.action_path=${{ github.action_path }}"
+        ACTION_PATH_PROMOTE="${{ github.action_path }}"
+        echo "ACTION_PATH_PROMOTE=$ACTION_PATH_PROMOTE"
+        echo "ACTION_PATH_PROMOTE=$ACTION_PATH_PROMOTE" >> "$GITHUB_ENV"
+        host_actions_root="$(dirname "$ACTION_PATH_PROMOTE")"
+        echo "host_actions_root=$host_actions_root" >> "$GITHUB_OUTPUT"
+
+        mkdir -p ".actions"
+        ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
+        ln -sf "$host_actions_root/shared" .actions/shared
+        ls -la .actions/*
+        echo "::endgroup::"
+
     - name: Set build parameters
       shell: bash
       run: |
-        cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
-    - uses: SonarSource/ci-github-actions/get-build-number@v1
-    - name: Vault
+        cp "$ACTION_PATH_PROMOTE/mise.local.toml" mise.local.toml
+    - uses: ./.actions/get-build-number
+      with:
+        host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
+    - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets
-      uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       with:
         secrets: |
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-promoter access_token | ARTIFACTORY_PROMOTE_ACCESS_TOKEN;
@@ -45,4 +65,4 @@ runs:
         PROMOTE_PULL_REQUEST: ${{ inputs.promote-pull-request }}
         BUILD_NAME: ${{ inputs.build-name || github.event.repository.name }}
       run: |
-        ${GITHUB_ACTION_PATH}/promote.sh
+        "$ACTION_PATH_PROMOTE/promote.sh"


### PR DESCRIPTION
[BUILD-9094](https://sonarsource.atlassian.net/browse/BUILD-9094)

When using local actions, there are inconsistencies in the paths leading to failures like:
- other local actions are not visible while they've been checkout'ed
- discrepancies between the path used to call a local action, the path used to parse its actions.yml and the path used during the action's execution
- action's resources are not in the current working directory
- `GITHUB_ACTION_PATH` value is not the same for an action and a child action
- `GITHUB_ACTION_PATH` and `${{ github.action_path }}` values are not consistent when executed in a container
- path used in `env` sections are translated by the runner agent into broken paths

Fix local action references to work by implementing symlink-based path resolution.
Fix container environments to work by using host paths instead of unstable and broken mounted container paths
Fix child action execution context to work by passing the `host-actions-root` path as input, when called in chain, otherwise use `${{ github.action_path }}`, not `GITHUB_ACTION_PATH`.
Document development guidelines in CONTRIBUTE.md

Tested with:
- https://github.com/SonarSource/docker-images/pull/101
- https://github.com/SonarSource/sonar-dummy/pull/503
- https://github.com/SonarSource/sonar-dummy-python-oss/pull/70
- https://github.com/SonarSource/sonar-dummy-js/pull/109
- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/307

[BUILD-9094]: https://sonarsource.atlassian.net/browse/BUILD-9094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ