### PR TITLE
BUILD-9094 use remote v1 branch for local actions

### DIFF
--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -71,9 +71,7 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
-        mkdir .actions/
-        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
-    - uses: ./.actions/get-build-number
+    - uses: SonarSource/ci-github-actions/get-build-number@v1
       id: get_build_number
     - name: Vault
       id: secrets

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -66,13 +66,10 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
-        mkdir .actions/
-        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
-        ln -s "${GITHUB_ACTION_PATH}/../cache" .actions/cache
-    - uses: ./.actions/get-build-number
+    - uses: SonarSource/ci-github-actions/get-build-number@v1
       id: get_build_number
     - name: Cache local Maven repository
-      uses: ./.actions/cache
+      uses: SonarSource/ci-github-actions/cache@v1
       with:
         path: ~/${{ inputs.maven-local-repository-path }}
         key: maven-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -67,10 +67,7 @@ runs:
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
         cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
-        mkdir .actions/
-        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
-        ln -s "${GITHUB_ACTION_PATH}/../cache" .actions/cache
-    - uses: ./.actions/get-build-number
+    - uses: SonarSource/ci-github-actions/get-build-number@v1
       id: get_build_number
     - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
       with:
@@ -78,7 +75,7 @@ runs:
 
     - name: Cache NPM dependencies
       if: ${{ inputs.cache-npm == 'true' }}
-      uses: ./.actions/cache
+      uses: SonarSource/ci-github-actions/cache@v1
       with:
         path: ~/.npm
         key: npm-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -62,9 +62,7 @@ runs:
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
         cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
-        mkdir .actions/
-        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
-    - uses: ./.actions/get-build-number
+    - uses: SonarSource/ci-github-actions/get-build-number@v1
       id: get_build_number
     - name: Cache local Poetry cache
       uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -64,10 +64,7 @@ runs:
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
         cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
-        mkdir .actions/
-        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
-        ln -s "${GITHUB_ACTION_PATH}/../cache" .actions/cache
-    - uses: ./.actions/get-build-number
+    - uses: SonarSource/ci-github-actions/get-build-number@v1
       id: get_build_number
     - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
       with:
@@ -75,7 +72,7 @@ runs:
 
     - name: Cache Yarn dependencies
       if: ${{ inputs.cache-yarn == 'true' }}
-      uses: ./.actions/cache
+      uses: SonarSource/ci-github-actions/cache@v1
       with:
         path: |
           ~/.yarn

--- a/promote/action.yml
+++ b/promote/action.yml
@@ -19,9 +19,7 @@ runs:
       shell: bash
       run: |
         cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
-        mkdir .actions/
-        ln -s "${GITHUB_ACTION_PATH}/../get-build-number" .actions/get-build-number
-    - uses: ./.actions/get-build-number
+    - uses: SonarSource/ci-github-actions/get-build-number@v1
     - name: Vault
       id: secrets
       uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0


### PR DESCRIPTION
Remediation for BUILD-9094 with using v1 branch instead of the local checkout.
This is hopefully temporary, until we resolve the issue with the [GitHub container](https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/write-workflows/choose-where-workflows-run/run-jobs-in-a-container) using invalid paths.
