### PR TITLE
BUILD-9038 custom run

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ jobs:
 | `sonar-platform`              | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us'                                                                 | `next`                                                               |
 | `working-directory`           | Relative path under github.workspace to execute the build in                                                               | `.`                                                                  |
 | `run-shadow-scans`            | If true, run SonarQube analysis on all 3 platforms (next, sqc-eu, sqc-us); if false, only on the selected `sonar-platform` | `false`                                                              |
+| `custom-run`                  | Custom run block to replace the call to build.sh. See sonar-dummy for an example.                                          | (optional)                                                           |
 
 ### Outputs
 

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -48,6 +48,9 @@ inputs:
     description: If true, run SonarQube analysis on all three platforms (next, sqc-eu, sqc-us).
       If false, run analysis on the platform specified with sonar-platform.
     default: 'false'
+  custom-run:
+    description: Custom run block to replace the call to build.sh
+    default: ''
 outputs:
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
@@ -149,10 +152,8 @@ runs:
           format('develocity.sonar.build={0}', fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN) || '' }}
         USER_MAVEN_OPTS: ${{ inputs.maven-opts }}
         SONAR_SCANNER_JAVA_OPTS: ${{ inputs.scanner-java-opts }}
-      run: |
-        export MAVEN_OPTS="$USER_MAVEN_OPTS -Duser.home=$HOME"
-        cd "${{ inputs.working-directory }}"
-        ${GITHUB_ACTION_PATH}/build.sh
+      working-directory: ${{ inputs.working-directory }}
+      run: ${{ inputs.custom-run != '' && inputs.custom-run || '${GITHUB_ACTION_PATH}/build.sh' }}
     - name: Cleanup Maven repository before caching
       shell: bash
       run: |

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -56,10 +56,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/../shared/common-functions.sh"
 : "${PULL_REQUEST?}" "${DEFAULT_BRANCH:?}"
 : "${SONAR_PLATFORM:?}" "${NEXT_URL:?}" "${NEXT_TOKEN:?}" "${SQC_US_URL:?}" "${SQC_US_TOKEN:?}" "${SQC_EU_URL:?}" "${SQC_EU_TOKEN:?}"
 : "${RUN_SHADOW_SCANS:?}"
-: "${MAVEN_LOCAL_REPOSITORY:=$HOME/.m2/repository}"
+: "${MAVEN_LOCAL_REPOSITORY:=$HOME/.m2/repository}" "${USER_MAVEN_OPTS:=}"
 : "${DEPLOY_PULL_REQUEST:=false}"
 export ARTIFACTORY_URL DEPLOY_PULL_REQUEST MAVEN_LOCAL_REPOSITORY
 : "${MAVEN_SETTINGS:=$HOME/.m2/settings.xml}"
+export MAVEN_OPTS="$USER_MAVEN_OPTS -Duser.home=$HOME"
 
 # FIXME Workaround for SonarSource parent POM; it can be removed after releases of parent 73+ and parent-oss 84+
 export BUILD_ID=$BUILD_NUMBER


### PR DESCRIPTION
[BUILD-9038](https://sonarsource.atlassian.net/browse/BUILD-9038)
add `custom-run` input for build-maven which allows to provide a custom run block to replace the default call to build.sh

Typical usage for custom-run is:
```
custom-run: |
  # Load the original build.sh script without executing it
  source ${GITHUB_ACTION_PATH}/build.sh

  # Eventually save the original function before override
  original_func_def=$(declare -f someFunctionToOverride)
  eval "original_${original_func_def}"

  # Override the function to customize
  someFunctionToOverride() {
    ... # custom code
  }

  # Call the root build function to execute the build with the custom behavior
  build_maven
```

Tested with https://github.com/SonarSource/sonar-dummy/pull/488
https://github.com/SonarSource/sonar-dummy/actions/runs/17650810332/job/50161104590 echoes from the customized function:
```
Custom build example with overridden set_project_version function
```

[BUILD-9038]: https://sonarsource.atlassian.net/browse/BUILD-9038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ