### PR TITLE
BUILD-8830 disable sonar scans for build-yarn option, improve spec files and minor bug fixes

### DIFF
--- a/.shellspec
+++ b/.shellspec
@@ -1,5 +1,5 @@
 # kcov (coverage) options
---kcov-options "--include-pattern=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-npm,build-maven,build-npm,build-yarn"
+--kcov-options "--include-pattern=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-npm,build-maven,build-npm,build-yarn,shared"
 # --kcov-options "--exclude-pattern=.github,.idea,.git"
 
 # define minimum coverage (fail otherwise)

--- a/README.md
+++ b/README.md
@@ -522,7 +522,7 @@ jobs:
 | `cache-yarn`                | Whether to cache Yarn dependencies                                             | `true`                                                               |
 | `repox-url`                 | URL for Repox                                                                  | `https://repox.jfrog.io`                                             |
 | `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)    | (optional)                                                           |
-| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us'                     | `next`                                                               |
+| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans | `next`                                                               |
 | `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                              |
 
 ### Outputs

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -279,7 +279,7 @@ run_standard_pipeline() {
   if [ "${BUILD_ENABLE_SONAR}" = "true" ]; then
     read -ra sonar_args <<< "$BUILD_SONAR_ARGS"
     # This will call back to shared sonar_scanner_implementation() function
-    orchestrate_sonar_platforms "${sonar_args[@]}"
+    orchestrate_sonar_platforms "${sonar_args[@]+${sonar_args[@]}}"
   fi
 
   echo "Building project..."

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -32,7 +32,7 @@ inputs:
     description: URL for Repox Artifactory API (overrides repox-url/artifactory if provided)
     default: ''
   sonar-platform:
-    description: SonarQube primary platform (next, sqc-eu, or sqc-us)
+    description: SonarQube primary platform (next, sqc-eu, sqc-us, or none). Use 'none' to skip sonar scans.
     default: next
   run-shadow-scans:
     description: If true, run sonar scanner on all 3 platforms using the provided URL and token.

--- a/shared/common-functions.sh
+++ b/shared/common-functions.sh
@@ -33,8 +33,12 @@ set_sonar_platform_vars() {
       export SONAR_TOKEN="$SQC_EU_TOKEN"
       unset SONAR_REGION
       ;;
+    "none")
+      echo "Sonar analysis disabled (platform: none)"
+      return 0
+      ;;
     *)
-      echo "ERROR: Invalid Sonar platform '$platform'. Must be one of: next, sqc-us, sqc-eu" >&2
+      echo "ERROR: Invalid Sonar platform '$platform'. Must be one of: next, sqc-us, sqc-eu, none" >&2
       return 1
       ;;
   esac
@@ -51,6 +55,11 @@ set_sonar_platform_vars() {
 # CALLBACK DEPENDENCY:
 # Requires build script to implement sonar_scanner_implementation() function
 orchestrate_sonar_platforms() {
+  if [ "$SONAR_PLATFORM" = "none" ] && [ "${RUN_SHADOW_SCANS}" != "true" ]; then
+      echo "=== ORCHESTRATOR: Skipping Sonar analysis (platform: none) ==="
+      return 0
+  fi
+
   if [ "${RUN_SHADOW_SCANS}" = "true" ]; then
       echo "=== ORCHESTRATOR: Running Sonar analysis on all platforms (shadow scan enabled) ==="
       local platforms=("next" "sqc-us" "sqc-eu")

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -352,38 +352,6 @@ Describe 'sonar_scanner_implementation()'
   End
 End
 
-Describe 'orchestrate_sonar_platforms integration()'
-  It 'runs analysis on single platform when shadow scans disabled'
-    export RUN_SHADOW_SCANS="false"
-    export SONAR_PLATFORM="next"
-    export GRADLE_ARGS=""
-    Mock build_gradle_args
-      echo "--no-daemon build sonar"
-    End
-
-    When call orchestrate_sonar_platforms
-    The line 1 should include "=== ORCHESTRATOR: Running Sonar analysis on selected platform: next ==="
-    The line 2 should equal "Using Sonar platform: next (URL: next.sonarqube.com, Region: none)"
-    The line 4 should equal "gradle --no-daemon build sonar"
-    The lines of stdout should equal 4
-  End
-
-  It 'runs analysis on all platforms when shadow scans enabled'
-    export RUN_SHADOW_SCANS="true"
-    export SONAR_PLATFORM="next"
-    export GRADLE_ARGS=""
-    Mock build_gradle_args
-      echo "--no-daemon build sonar"
-    End
-
-    When call orchestrate_sonar_platforms
-    The output should include "=== ORCHESTRATOR: Running Sonar analysis on all platforms (shadow scan enabled) ==="
-    The output should include "--- ORCHESTRATOR: Analyzing with platform: next ---"
-    The output should include "--- ORCHESTRATOR: Analyzing with platform: sqc-us ---"
-    The output should include "--- ORCHESTRATOR: Analyzing with platform: sqc-eu ---"
-    The output should include "=== ORCHESTRATOR: Completed Sonar analysis on all platforms ==="
-  End
-End
 
 Describe 'set_gradle_cmd()'
   It 'uses gradlew when available'

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -91,40 +91,6 @@ Describe 'build.sh'
   End
 End
 
-Describe 'set_sonar_platform_vars()'
-  It 'sets variables for next platform'
-    When call set_sonar_platform_vars "next"
-    The status should be success
-    The lines of stdout should equal 1
-    The line 1 should include "Using Sonar platform: next"
-    The variable SONAR_HOST_URL should equal "$NEXT_URL"
-    The variable SONAR_TOKEN should equal "$NEXT_TOKEN"
-  End
-
-  It 'sets variables for sqc-us platform'
-    When call set_sonar_platform_vars "sqc-us"
-    The status should be success
-    The lines of stdout should equal 1
-    The line 1 should include "Using Sonar platform: sqc-us"
-    The variable SONAR_HOST_URL should equal "$SQC_US_URL"
-    The variable SONAR_TOKEN should equal "$SQC_US_TOKEN"
-  End
-
-  It 'sets variables for sqc-eu platform'
-    When call set_sonar_platform_vars "sqc-eu"
-    The status should be success
-    The lines of stdout should equal 1
-    The line 1 should include "Using Sonar platform: sqc-eu"
-    The variable SONAR_HOST_URL should equal "$SQC_EU_URL"
-    The variable SONAR_TOKEN should equal "$SQC_EU_TOKEN"
-  End
-
-  It 'fails with unknown platform'
-    When call set_sonar_platform_vars "unknown"
-    The status should be failure
-    The error should include "ERROR: Invalid Sonar platform 'unknown'"
-  End
-End
 
 Describe 'run_sonar_scanner()'
   Mock mvn
@@ -155,45 +121,6 @@ Describe 'run_sonar_scanner()'
   End
 End
 
-Describe 'orchestrate_sonar_platforms()'
-  Mock mvn
-    echo "mvn $*"
-  End
-  Mock sonar_scanner_implementation
-    echo "sonar_scanner_implementation $*"
-  End
-
-  export PROJECT_VERSION="1.2.3.42"
-
-  It 'runs analysis on single platform when shadow scans disabled'
-    export RUN_SHADOW_SCANS="false"
-    export SONAR_PLATFORM="next"
-    When call orchestrate_sonar_platforms "-Dsome.property=value"
-    The status should be success
-    The lines of stdout should equal 3
-    The line 1 should include "ORCHESTRATOR: Running Sonar analysis on selected platform: next"
-    The line 2 should include "Using Sonar platform: next"
-    The line 3 should include "sonar_scanner_implementation -Dsome.property=value"
-  End
-
-  It 'runs analysis on all platforms when shadow scans enabled'
-    export RUN_SHADOW_SCANS="true"
-    When call orchestrate_sonar_platforms "-Dsome.property=value"
-    The status should be success
-    The lines of stdout should equal 17
-    The line 1 should include "ORCHESTRATOR: Running Sonar analysis on all platforms (shadow scan enabled)"
-    The line 3 should include "--- ORCHESTRATOR: Analyzing with platform: next ---"
-    The line 4 should include "Using Sonar platform: next"
-    The line 5 should include "sonar_scanner_implementation -Dsome.property=value"
-    The line 8 should include "--- ORCHESTRATOR: Analyzing with platform: sqc-us ---"
-    The line 9 should include "Using Sonar platform: sqc-us"
-    The line 10 should include "sonar_scanner_implementation -Dsome.property=value"
-    The line 13 should include "--- ORCHESTRATOR: Analyzing with platform: sqc-eu ---"
-    The line 14 should include "Using Sonar platform: sqc-eu"
-    The line 15 should include "sonar_scanner_implementation -Dsome.property=value"
-    The line 17 should include "ORCHESTRATOR: Completed Sonar analysis on all platforms"
-  End
-End
 
 Describe 'check_tool()'
   It 'reports not installed tool'

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -364,37 +364,6 @@ Describe 'build_npm()'
   End
 End
 
-Describe 'Sonar platform configuration'
-  It 'sets sonar variables for next platform'
-    When call set_sonar_platform_vars "next"
-    The status should be success
-    The line 1 should equal "Using Sonar platform: next (URL: next.sonarqube.com, Region: none)"
-    The variable SONAR_HOST_URL should equal "https://next.sonarqube.com"
-    The variable SONAR_TOKEN should equal "next-token"
-  End
-
-  It 'sets sonar variables for sqc-us platform'
-    When call set_sonar_platform_vars "sqc-us"
-    The status should be success
-    The line 1 should equal "Using Sonar platform: sqc-us (URL: sonarqube-us.example.com, Region: us)"
-    The variable SONAR_HOST_URL should equal "https://sonarqube-us.example.com"
-    The variable SONAR_TOKEN should equal "sqc-us-token"
-  End
-
-  It 'sets sonar variables for sqc-eu platform'
-    When call set_sonar_platform_vars "sqc-eu"
-    The status should be success
-    The line 1 should equal "Using Sonar platform: sqc-eu (URL: sonarcloud.io, Region: none)"
-    The variable SONAR_HOST_URL should equal "https://sonarcloud.io"
-    The variable SONAR_TOKEN should equal "sqc-eu-token"
-  End
-
-  It 'fails with invalid platform'
-    When run set_sonar_platform_vars "invalid"
-    The status should be failure
-    The stderr should include "ERROR: Invalid Sonar platform 'invalid'. Must be one of: next, sqc-us, sqc-eu"
-  End
-End
 
 Describe 'sonar_scanner_implementation()'
   export CURRENT_VERSION="1.2.3"
@@ -445,30 +414,6 @@ Describe 'sonar_scanner_implementation()'
   End
 End
 
-Describe 'orchestrate_sonar_platforms()'
-  export CURRENT_VERSION="1.2.3"
-  It 'runs single platform analysis when shadow scans disabled'
-    export RUN_SHADOW_SCANS="false"
-    export SONAR_PLATFORM="next"
-    When call orchestrate_sonar_platforms "-Dsonar.test=value"
-    The status should be success
-    The output should include "=== ORCHESTRATOR: Running Sonar analysis on selected platform: next ==="
-    The output should include "Using Sonar platform: next"
-    The output should not include "shadow scan enabled"
-  End
-
-  It 'runs multi-platform analysis when shadow scans enabled'
-    export RUN_SHADOW_SCANS="true"
-    export SONAR_PLATFORM="next"
-    When call orchestrate_sonar_platforms "-Dsonar.test=value"
-    The status should be success
-    The output should include "=== ORCHESTRATOR: Running Sonar analysis on all platforms (shadow scan enabled) ==="
-    The output should include "--- ORCHESTRATOR: Analyzing with platform: next ---"
-    The output should include "--- ORCHESTRATOR: Analyzing with platform: sqc-us ---"
-    The output should include "--- ORCHESTRATOR: Analyzing with platform: sqc-eu ---"
-    The output should include "=== ORCHESTRATOR: Completed Sonar analysis on all platforms ==="
-  End
-End
 
 Describe 'Shadow scans deployment prevention'
   It 'disables deployment when shadow scans enabled on main branch'

--- a/spec/shared-functions_spec.sh
+++ b/spec/shared-functions_spec.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+eval "$(shellspec - -c) exit 1"
+export NEXT_URL="https://next.sonarqube.com"
+export NEXT_TOKEN="next-token"
+export SQC_US_URL="https://sonarqube-us.example.com"
+export SQC_US_TOKEN="sqc-us-token"
+export SQC_EU_URL="https://sonarcloud.io"
+export SQC_EU_TOKEN="sqc-eu-token"
+
+Describe 'shared/common-functions.sh'
+  Include shared/common-functions.sh
+
+  Describe 'set_sonar_platform_vars()'
+    It 'sets sonar variables for next platform'
+      When call set_sonar_platform_vars "next"
+      The status should be success
+      The line 1 should equal "Using Sonar platform: next (URL: next.sonarqube.com, Region: none)"
+      The variable SONAR_HOST_URL should equal "https://next.sonarqube.com"
+      The variable SONAR_TOKEN should equal "next-token"
+    End
+
+    It 'sets sonar variables for sqc-us platform'
+      When call set_sonar_platform_vars "sqc-us"
+      The status should be success
+      The line 1 should equal "Using Sonar platform: sqc-us (URL: sonarqube-us.example.com, Region: us)"
+      The variable SONAR_HOST_URL should equal "https://sonarqube-us.example.com"
+      The variable SONAR_TOKEN should equal "sqc-us-token"
+    End
+
+    It 'sets sonar variables for sqc-eu platform'
+      When call set_sonar_platform_vars "sqc-eu"
+      The status should be success
+      The line 1 should equal "Using Sonar platform: sqc-eu (URL: sonarcloud.io, Region: none)"
+      The variable SONAR_HOST_URL should equal "https://sonarcloud.io"
+      The variable SONAR_TOKEN should equal "sqc-eu-token"
+    End
+
+    It 'handles none platform'
+      When call set_sonar_platform_vars "none"
+      The status should be success
+      The line 1 should equal "Sonar analysis disabled (platform: none)"
+      The variable SONAR_HOST_URL should be undefined
+      The variable SONAR_TOKEN should be undefined
+    End
+
+    It 'fails with invalid platform'
+      When call set_sonar_platform_vars "invalid"
+      The status should be failure
+      The stderr should include "ERROR: Invalid Sonar platform 'invalid'. Must be one of: next, sqc-us, sqc-eu, none"
+    End
+
+    It 'correctly formats URL display removing protocol'
+      When call set_sonar_platform_vars "next"
+      The status should be success
+      The line 1 should include "(URL: next.sonarqube.com"
+      The line 1 should not include "https://"
+    End
+  End
+
+  Describe 'orchestrate_sonar_platforms()'
+    # Mock sonar_scanner_implementation for orchestrator tests
+    sonar_scanner_implementation() {
+      echo "sonar_scanner_implementation called with: $*"
+      echo "Using SONAR_HOST_URL: ${SONAR_HOST_URL}"
+      echo "Using SONAR_TOKEN: ${SONAR_TOKEN}"
+    }
+
+    It 'runs single platform analysis when shadow scans disabled'
+      export RUN_SHADOW_SCANS="false"
+      export SONAR_PLATFORM="next"
+      When call orchestrate_sonar_platforms "-Dsonar.test=value"
+      The status should be success
+      The output should include "=== ORCHESTRATOR: Running Sonar analysis on selected platform: next ==="
+      The output should include "Using Sonar platform: next"
+      The output should not include "shadow scan enabled"
+    End
+
+    It 'runs multi-platform analysis when shadow scans enabled'
+      export RUN_SHADOW_SCANS="true"
+      export SONAR_PLATFORM="next"
+      When call orchestrate_sonar_platforms "-Dsonar.test=value"
+      The status should be success
+      The output should include "=== ORCHESTRATOR: Running Sonar analysis on all platforms (shadow scan enabled) ==="
+      The output should include "--- ORCHESTRATOR: Analyzing with platform: next ---"
+      The output should include "--- ORCHESTRATOR: Analyzing with platform: sqc-us ---"
+      The output should include "--- ORCHESTRATOR: Analyzing with platform: sqc-eu ---"
+      The output should include "=== ORCHESTRATOR: Completed Sonar analysis on all platforms ==="
+    End
+
+    It 'skips sonar analysis when platform is none'
+      export RUN_SHADOW_SCANS="false"
+      export SONAR_PLATFORM="none"
+      When call orchestrate_sonar_platforms "-Dsonar.test=value"
+      The status should be success
+      The line 1 should equal "=== ORCHESTRATOR: Skipping Sonar analysis (platform: none) ==="
+      The output should not include "sonar_scanner_implementation"
+    End
+
+    It 'runs shadow scans even when platform is none'
+      export RUN_SHADOW_SCANS="true"
+      export SONAR_PLATFORM="none"
+      When call orchestrate_sonar_platforms "-Dsonar.test=value"
+      The status should be success
+      The output should include "=== ORCHESTRATOR: Running Sonar analysis on all platforms (shadow scan enabled) ==="
+      The output should not include "Skipping Sonar analysis"
+    End
+  End
+End


### PR DESCRIPTION
- Add sonar-platform:none option to disable sonar scans for yarn
- change to avoid an "unbound variable" error that occurs in bash when running with set -u
- remove shared-functions tests from specific language spec files and create a dedicated spec for shared-functions

Sample run: https://github.com/SonarSource/sonar-dummy-yarn/actions/runs/17730471264/job/50380381738?pr=28