### PR TITLE
PREQ-2114 Allow custom project keys for shadow scan in maven builds

### DIFF
--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: If true, run SonarQube analysis on all three platforms (next, sqc-eu, sqc-us).
       If false, run analysis on the platform specified with sonar-platform.
     default: 'false'
+  sqc-us-project-key:
+    description: If run-shadow-scans is true, override the SonarQube Cloud US project key for the shadow scan
+  sqc-eu-project-key:
+    description: If run-shadow-scans is true, override the SonarQube Cloud EU project key for the shadow scan
 outputs:
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
@@ -153,6 +157,8 @@ runs:
         USER_MAVEN_OPTS: ${{ inputs.maven-opts }}
         USER_MAVEN_ARGS: ${{ inputs.maven-args }}
         SONAR_SCANNER_JAVA_OPTS: ${{ inputs.scanner-java-opts }}
+        SQS_US_PROJECT_KEY: ${{ inputs.sqc-us-project-key }}
+        SQS_EU_PROJECT_KEY: ${{ inputs.sqc-eu-project-key }}
       run: |
         export MAVEN_OPTS="$USER_MAVEN_OPTS -Duser.home=$HOME"
         cd "${{ inputs.working-directory }}"

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -113,7 +113,7 @@ sonar_scanner_implementation() {
     local sonar_props=("-Dsonar.host.url=${SONAR_HOST_URL}" "-Dsonar.token=${SONAR_TOKEN}")
     sonar_props+=("-Dsonar.projectVersion=${CURRENT_VERSION}" "-Dsonar.scm.revision=$GITHUB_SHA")
     if [[ -n "${PROJECT_KEY:-}" ]]; then
-      sonar_props+=("-Dsonar.projectKey=${PROJECT_KEY}" "-Dsonar.organization=\"sonarsource\"")
+      sonar_props+=("-Dsonar.projectKey=${PROJECT_KEY}")
     fi
     sonar_props+=("${additional_params[@]+"${additional_params[@]}"}")
 

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -112,7 +112,9 @@ sonar_scanner_implementation() {
     # Build sonar properties (using orchestrator-provided SONAR_HOST_URL/SONAR_TOKEN)
     local sonar_props=("-Dsonar.host.url=${SONAR_HOST_URL}" "-Dsonar.token=${SONAR_TOKEN}")
     sonar_props+=("-Dsonar.projectVersion=${CURRENT_VERSION}" "-Dsonar.scm.revision=$GITHUB_SHA")
-    sonar_props+=("-Dsonar.organization=\"sonarsource\"")
+    if [[ -n "${PROJECT_KEY:-}" ]]; then
+      sonar_props+=("-Dsonar.projectKey=${PROJECT_KEY}" "-Dsonar.organization=\"sonarsource\"")
+    fi
     sonar_props+=("${additional_params[@]+"${additional_params[@]}"}")
 
     echo "Maven command: mvn ${COMMON_MVN_FLAGS[*]} $SONAR_GOAL ${sonar_props[*]}"

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -113,7 +113,7 @@ sonar_scanner_implementation() {
     local sonar_props=("-Dsonar.host.url=${SONAR_HOST_URL}" "-Dsonar.token=${SONAR_TOKEN}")
     sonar_props+=("-Dsonar.projectVersion=${CURRENT_VERSION}" "-Dsonar.scm.revision=$GITHUB_SHA")
     if [[ -n "${PROJECT_KEY:-}" ]]; then
-      sonar_props+=("-Dsonar.projectKey=${PROJECT_KEY}")
+      sonar_props+=("-Dsonar.projectKey=${PROJECT_KEY}" "-Dsonar.organization=sonarsource")
     fi
     sonar_props+=("${additional_params[@]+"${additional_params[@]}"}")
 

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -112,6 +112,7 @@ sonar_scanner_implementation() {
     # Build sonar properties (using orchestrator-provided SONAR_HOST_URL/SONAR_TOKEN)
     local sonar_props=("-Dsonar.host.url=${SONAR_HOST_URL}" "-Dsonar.token=${SONAR_TOKEN}")
     sonar_props+=("-Dsonar.projectVersion=${CURRENT_VERSION}" "-Dsonar.scm.revision=$GITHUB_SHA")
+    sonar_props+=("-Dsonar.organization=\"sonarsource\"")
     sonar_props+=("${additional_params[@]+"${additional_params[@]}"}")
 
     echo "Maven command: mvn ${COMMON_MVN_FLAGS[*]} $SONAR_GOAL ${sonar_props[*]}"

--- a/shared/common-functions.sh
+++ b/shared/common-functions.sh
@@ -28,13 +28,13 @@ set_sonar_platform_vars() {
       export SONAR_HOST_URL="$SQC_US_URL"
       export SONAR_TOKEN="$SQC_US_TOKEN"
       export SONAR_REGION="us"
-      export PROJECT_KEY="${$SQS_US_PROJECT_KEY:-''}"
+      export PROJECT_KEY="${SQS_US_PROJECT_KEY:-''}"
       ;;
     "sqc-eu")
       export SONAR_HOST_URL="$SQC_EU_URL"
       export SONAR_TOKEN="$SQC_EU_TOKEN"
       unset SONAR_REGION
-      export PROJECT_KEY="${$SQS_EU_PROJECT_KEY:-''}"
+      export PROJECT_KEY="${SQS_EU_PROJECT_KEY:-''}"
       ;;
     "none")
       echo "Sonar analysis disabled (platform: none)"

--- a/shared/common-functions.sh
+++ b/shared/common-functions.sh
@@ -28,13 +28,13 @@ set_sonar_platform_vars() {
       export SONAR_HOST_URL="$SQC_US_URL"
       export SONAR_TOKEN="$SQC_US_TOKEN"
       export SONAR_REGION="us"
-      export PROJECT_KEY="$SQS_US_PROJECT_KEY"
+      export PROJECT_KEY="${$SQS_US_PROJECT_KEY:-''}"
       ;;
     "sqc-eu")
       export SONAR_HOST_URL="$SQC_EU_URL"
       export SONAR_TOKEN="$SQC_EU_TOKEN"
       unset SONAR_REGION
-      export PROJECT_KEY="$SQS_EU_PROJECT_KEY"
+      export PROJECT_KEY="${$SQS_EU_PROJECT_KEY:-''}"
       ;;
     "none")
       echo "Sonar analysis disabled (platform: none)"

--- a/shared/common-functions.sh
+++ b/shared/common-functions.sh
@@ -22,16 +22,19 @@ set_sonar_platform_vars() {
       export SONAR_HOST_URL="$NEXT_URL"
       export SONAR_TOKEN="$NEXT_TOKEN"
       unset SONAR_REGION
+      unset PROJECT_KEY
       ;;
     "sqc-us")
       export SONAR_HOST_URL="$SQC_US_URL"
       export SONAR_TOKEN="$SQC_US_TOKEN"
       export SONAR_REGION="us"
+      export PROJECT_KEY="$SQS_US_PROJECT_KEY"
       ;;
     "sqc-eu")
       export SONAR_HOST_URL="$SQC_EU_URL"
       export SONAR_TOKEN="$SQC_EU_TOKEN"
       unset SONAR_REGION
+      export PROJECT_KEY="$SQS_EU_PROJECT_KEY"
       ;;
     "none")
       echo "Sonar analysis disabled (platform: none)"


### PR DESCRIPTION
[PREQ-2114](https://sonarsource.atlassian.net/browse/PREQ-2114)

Add support for overriding the SonarQube Cloud US and EU project keys when running shadow scans in the Maven build process, as it defaults to `<groupId>:<artifactId>`, which does not fit the keys like `SonarSource_sonar-rpg.` It introduces new inputs to the GitHub Action, ensures these inputs are passed through the workflow, and updates the scripts to use the overridden project keys as needed.

**GitHub Action input and environment variable updates:**

* Added new inputs `sqc-us-project-key` and `sqc-eu-project-key` to `build-maven/action.yml` to allow overriding the SonarQube Cloud US and EU project keys for shadow scans.
* Updated the environment variables in the `runs` section of `build-maven/action.yml` to pass the new project key inputs to the build scripts as `SQS_US_PROJECT_KEY` and `SQS_EU_PROJECT_KEY`.

**Script and variable handling enhancements:**

* Modified `shared/common-functions.sh` to set or unset the `PROJECT_KEY` environment variable based on the selected SonarQube platform, using the new override values when appropriate.
* Updated `build-maven/build.sh` to include the `sonar.projectKey` property in the SonarQube analysis step if the `PROJECT_KEY` variable is set, ensuring the correct project key is used.

**Proof of concept:**

https://github.com/SonarSource/sonar-rpg/pull/284/files

[PREQ-2114]: https://sonarsource.atlassian.net/browse/PREQ-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ