### PR TITLE
BUILD-9252 pin @sonar/scan@4.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,9 +603,9 @@ jobs:
 
 ### Input Environment Variables
 
-| Environment Variable                    | Description                                                                       | Default                               |
-|-----------------------------------------|-----------------------------------------------------------------------------------|---------------------------------------|
-| `SQ_SCANNER_VERSION`                    | SonarQube scanner version.                                                        | 'latest'                              |
+| Environment Variable                    | Description                                                                       | Default |
+|-----------------------------------------|-----------------------------------------------------------------------------------|---------|
+| `SQ_SCANNER_VERSION`                    | SonarQube scanner version.                                                        | '4.3.0' |
 
 See also [`config-npm`](#config-npm) input environment variables.
 
@@ -713,6 +713,12 @@ jobs:
           # Primary platform when shadow scans disabled (optional)
           sonar-platform: 'next'
 ```
+
+### Input Environment Variables
+
+| Environment Variable                    | Description                                                                       | Default |
+|-----------------------------------------|-----------------------------------------------------------------------------------|---------|
+| `SQ_SCANNER_VERSION`                    | SonarQube scanner version.                                                        | '4.3.0' |
 
 ### Inputs
 

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -32,7 +32,7 @@
 # Optional user customization:
 # - DEPLOY_PULL_REQUEST: Whether to deploy pull request artifacts (default: false)
 # - SKIP_TESTS: Whether to skip running tests (default: false)
-# - SQ_SCANNER_VERSION: Version of sonarqube-scanner to use (default: latest)
+# - SQ_SCANNER_VERSION: Version of sonarqube-scanner to use (default: 4.3.0)
 
 # shellcheck source-path=SCRIPTDIR
 
@@ -53,7 +53,7 @@ fi
 : "${DEPLOY_PULL_REQUEST:=false}" "${SKIP_TESTS:=false}"
 export DEPLOY_PULL_REQUEST SKIP_TESTS
 : "${BUILD_NAME:?}" "${PROJECT_VERSION:?}" "${CURRENT_VERSION:?}"
-: "${SQ_SCANNER_VERSION:=latest}"
+: "${SQ_SCANNER_VERSION:=4.3.0}"
 
 git_fetch_unshallow() {
   if [ "$SONAR_PLATFORM" = "none" ]; then
@@ -97,8 +97,8 @@ sonar_scanner_implementation() {
 
     scanner_args+=("${additional_params[@]+\"${additional_params[@]}\"}")
 
-    echo "npx command: npx sonarqube-scanner@$SQ_SCANNER_VERSION -X ${scanner_args[*]}"
-    npx "sonarqube-scanner@$SQ_SCANNER_VERSION" -X "${scanner_args[@]}"
+    echo "npx command: npx @sonar/scan@$SQ_SCANNER_VERSION -X ${scanner_args[*]}"
+    npx "@sonar/scan@$SQ_SCANNER_VERSION" -X "${scanner_args[@]}"
 }
 
 jfrog_npm_publish() {

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -53,6 +53,7 @@ if [[ "${SONAR_PLATFORM}" != "none" ]]; then
 fi
 : "${DEPLOY_PULL_REQUEST:=false}" "${SKIP_TESTS:=false}"
 export ARTIFACTORY_URL DEPLOY_PULL_REQUEST SKIP_TESTS
+: "${SQ_SCANNER_VERSION:=4.3.0}"
 
 git_fetch_unshallow() {
   if [ "$SONAR_PLATFORM" = "none" ]; then
@@ -152,8 +153,8 @@ sonar_scanner_implementation() {
 
     scanner_args+=("${additional_params[@]+\"${additional_params[@]}\"}")
 
-    echo "npx command: npx sonarqube-scanner -X ${scanner_args[*]}"
-    npx sonarqube-scanner -X "${scanner_args[@]}"
+    echo "npx command: npx @sonar/scan@$SQ_SCANNER_VERSION -X ${scanner_args[*]}"
+    npx "@sonar/scan@$SQ_SCANNER_VERSION" -X "${scanner_args[@]}"
 }
 
 jfrog_yarn_publish() {

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -157,7 +157,7 @@ Describe 'build_npm()'
     The status should be success
     The output should include "======= Building main branch ======="
     The output should include "Installing npm dependencies..."
-    The output should include "npx sonarqube-scanner"
+    The output should include "npx @sonar/scan"
     The output should include "Building project..."
   End
 
@@ -197,7 +197,7 @@ Describe 'build_npm()'
     The output should include "======= Building pull request ======="
     The output should include "======= no deploy ======="
     The output should include "Installing npm dependencies..."
-    The output should include "npx sonarqube-scanner"
+    The output should include "npx @sonar/scan"
     The output should not include "DEBUG: JFrog operations"
   End
 
@@ -235,7 +235,7 @@ Describe 'build_npm()'
     The status should be success
     The output should include "======= Build long-lived feature branch ======="
     The output should include "Installing npm dependencies..."
-    The output should include "npx sonarqube-scanner"
+    The output should include "npx @sonar/scan"
     The output should not include "DEBUG: JFrog operations"
   End
 
@@ -277,7 +277,7 @@ Describe 'sonar_scanner_implementation()'
     export GITHUB_REPOSITORY="test/repo"
     When call sonar_scanner_implementation
     The status should be success
-    The output should include "npx sonarqube-scanner"
+    The output should include "npx @sonar/scan"
     The output should include "-Dsonar.host.url=https://sonar.example.com"
     The output should include "-Dsonar.token=test-token"
     The output should include "-Dsonar.analysis.buildNumber=42"

--- a/spec/build-yarn_spec.sh
+++ b/spec/build-yarn_spec.sh
@@ -186,7 +186,7 @@ Describe 'build-yarn/build.sh'
       When call run_standard_pipeline
       The output should include "Installing yarn dependencies..."
       The output should include "Running tests..."
-      The output should include "npx sonarqube-scanner"
+      The output should include "npx @sonar/scan"
       The output should include "Building project..."
       The output should not include "::debug::JFrog operations completed successfully"
     End
@@ -237,7 +237,7 @@ Describe 'build-yarn/build.sh'
       export CURRENT_VERSION="1.2.3"
       When call sonar_scanner_implementation
       The status should be success
-      The output should include "npx sonarqube-scanner -X"
+      The output should include "npx @sonar/scan"
       The output should include "-Dsonar.host.url=https://sonar.example.com"
       The output should include "-Dsonar.token=test-token"
       The output should include "-Dsonar.analysis.buildNumber=42"


### PR DESCRIPTION
[BUILD-9252](https://sonarsource.atlassian.net/browse/BUILD-9252)

Default to pinned version 4.3.0 instead of latest until new versions are compliant
Use the new namespaced "@sonar/scan" instead of legacy "sonarqube-scanner" name


[BUILD-9252]: https://sonarsource.atlassian.net/browse/BUILD-9252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ