### PR TITLE
BUILD-9169 fix condition for summary

### DIFF
--- a/.cursor/cirrus-github-migration.md
+++ b/.cursor/cirrus-github-migration.md
@@ -679,7 +679,7 @@ build_script:
 - NPM dependency caching for faster builds (configurable)
 - JFrog build info publishing with UI links
 - **Required permissions:** `id-token: write`, `contents: write`
-- **Outputs:** `project-version` from package.json, `build-info-url` when deployment occurs
+- **Outputs:** `project-version` from package.json
 
 #### YARN Projects (JavaScript/TypeScript)
 
@@ -703,7 +703,7 @@ build_script:
 - NPM dependency caching for faster builds (configurable)
 - JFrog build info publishing with UI links
 - **Required permissions:** `id-token: write`, `contents: write`
-- **Outputs:** `project-version` from package.json, `build-info-url` when deployment occurs
+- **Outputs:** `project-version` from package.json
 
 ##### Overriding Pull Request Deployment and Promotion
 

--- a/README.md
+++ b/README.md
@@ -634,7 +634,6 @@ See also [`config-npm`](#config-npm) input environment variables.
 | `current-version` | The project version from package.json                     |
 | `project-version` | The project version with build number (after replacement) |
 | `BUILD_NUMBER`    | The current build number                                  |
-| `build-info-url`  | The JFrog build info UI URL                               |
 
 ### Output Environment Variables
 
@@ -742,7 +741,6 @@ jobs:
 | Output            | Description                           |
 |-------------------|---------------------------------------|
 | `project-version` | The project version from package.json |
-| `build-info-url`  | The JFrog build info UI URL           |
 
 ### Features
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -120,7 +120,7 @@ runs:
 
     - name: Restore Gradle Cache
       if: ${{ inputs.disable-caching != 'true' }}
-      uses: SonarSource/gh-action_cache@master
+      uses: SonarSource/gh-action_cache@v1
       id: gradle-cache-restore
       with:
         path: |
@@ -198,28 +198,25 @@ runs:
     - name: Generate workflow summary
       if: always()
       shell: bash
+      env:
+        ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
+          format('{0}/artifactory', inputs.repox-url) }}
       run: |
+        build_name="${GITHUB_REPOSITORY#*/}"
         echo "## 🏗️ Gradle Build Summary" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-
-        # Basic build information
+        if [[ "${{ steps.build.conclusion }}" == "success" ]]; then
+          echo "✅ **Build SUCCESS**" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "❌ **Build FAILED**" >> $GITHUB_STEP_SUMMARY
+        fi
         echo "### 📋 Build Information" >> $GITHUB_STEP_SUMMARY
-        echo "- **Project**: ${GITHUB_REPOSITORY#*/}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Version**: ${{ steps.build.outputs.project-version || 'Unknown' }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Build Number**: $BUILD_NUMBER" >> $GITHUB_STEP_SUMMARY
-        echo "- **Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Project**: \`$build_name\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Version**: \`${PROJECT_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Build Number**: \`${BUILD_NUMBER}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Commit**: \`$GITHUB_SHA\`" >> $GITHUB_STEP_SUMMARY
 
-        # Deployment information
-        if [[ -n "${{ inputs.artifactory-deploy-repo }}" ]]; then
+        if [[ "${{ steps.build.outputs.should-deploy }}" == true ]]; then
           echo "### 🚀 Deployment" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ steps.build.conclusion }}" == "success" ]]; then
-            echo "✅ **Artifacts deployed to Artifactory**" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            ARTIFACTORY_BROWSE_URL="${{ inputs.repox-url }}/ui/repos/tree/General/${{ inputs.artifactory-deploy-repo }}"
-            echo "🔗 **[Browse artifacts in Artifactory](${ARTIFACTORY_BROWSE_URL})**" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **Deployment failed** (build unsuccessful)" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
+          ARTIFACTORY_BROWSE_URL="${ARTIFACTORY_URL%/*}/ui/builds/$build_name/$BUILD_NUMBER"
+          echo "🔗 **[Browse artifacts in Artifactory](${ARTIFACTORY_BROWSE_URL})**" >> $GITHUB_STEP_SUMMARY
         fi

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -53,7 +53,13 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: SonarSource/ci-github-actions/config-maven@master
+    - name: Set local action
+      shell: bash
+      run: |
+        mkdir ".actions"
+        ln -s "${{github.action_path}}/../config-maven" .actions/config-maven
+        ln -s "${{github.action_path}}/../shared" .actions/shared
+    - uses: ./.actions/config-maven # TODO BUILD-9094
       id: config
       with:
         working-directory: ${{ inputs.working-directory }}
@@ -129,20 +135,21 @@ runs:
       if: always()
       shell: bash
       run: |
+        build_name="${GITHUB_REPOSITORY#*/}"
+        echo "## 🏗️ Maven Build Summary" >> $GITHUB_STEP_SUMMARY
         if [[ "${{ steps.build.conclusion }}" == "success" ]]; then
-          echo "# ✅ Build & Deployment Successful" >> $GITHUB_STEP_SUMMARY
+          echo "✅ **Build SUCCESS**" >> $GITHUB_STEP_SUMMARY
         else
-          echo "# ❌ Build & Deployment Failed" >> $GITHUB_STEP_SUMMARY
+          echo "❌ **Build FAILED**" >> $GITHUB_STEP_SUMMARY
         fi
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## **Details**" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "- **Project**: \`${GITHUB_REPOSITORY#*/}\`" >> $GITHUB_STEP_SUMMARY
+        echo "### 📋 Build Information" >> $GITHUB_STEP_SUMMARY
+        echo "- **Project**: \`$build_name\`" >> $GITHUB_STEP_SUMMARY
         echo "- **Version**: \`${PROJECT_VERSION}\`" >> $GITHUB_STEP_SUMMARY
-        echo "- **Build Number**: ${BUILD_NUMBER}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-        ARTIFACTORY_BROWSE_URL="https://repox.jfrog.io/ui/builds/${GITHUB_REPOSITORY#*/}/$BUILD_NUMBER"
-        echo "- **Build**: [View in Artifactory](${ARTIFACTORY_BROWSE_URL})" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "---" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Build Number**: \`${BUILD_NUMBER}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Commit**: \`$GITHUB_SHA\`" >> $GITHUB_STEP_SUMMARY
+
+        if [[ "${{ steps.build.outputs.should-deploy }}" == true ]]; then
+          echo "### 🚀 Deployment" >> $GITHUB_STEP_SUMMARY
+          ARTIFACTORY_BROWSE_URL="${ARTIFACTORY_URL%/*}/ui/builds/$build_name/$BUILD_NUMBER"
+          echo "🔗 **[Browse artifacts in Artifactory](${ARTIFACTORY_BROWSE_URL})**" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: Whether to cache NPM dependencies
     default: 'true'
   repox-url:
-    description: URL for Repox Platform
+    description: URL for Repox
     default: https://repox.jfrog.io
   repox-artifactory-url:
     description: URL for Repox Artifactory API (overrides repox-url/artifactory if provided)
@@ -52,9 +52,6 @@ outputs:
   project-version:
     description: The project version with build number (after replacement). Also set as environment variable PROJECT_VERSION.
     value: ${{ steps.config.outputs.project-version }}
-  build-info-url:
-    description: The JFrog build info UI URL
-    value: ${{ steps.build.outputs.BUILD_INFO_URL }}
 
 runs:
   using: composite
@@ -72,6 +69,7 @@ runs:
         cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
         mkdir ".actions"
         ln -s "${{github.action_path}}/../config-npm" .actions/config-npm
+        ln -s "${{github.action_path}}/../shared" .actions/shared
 
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
@@ -140,28 +138,25 @@ runs:
     - name: Generate workflow summary
       if: always()
       shell: bash
+      env:
+        ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
+          format('{0}/artifactory', inputs.repox-url) }}
       run: |
+        build_name="${GITHUB_REPOSITORY#*/}"
         echo "## 📦 NPM Build Summary" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-
-        # Basic build information
+        if [[ "${{ steps.build.conclusion }}" == "success" ]]; then
+          echo "✅ **Build SUCCESS**" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "❌ **Build FAILED**" >> $GITHUB_STEP_SUMMARY
+        fi
         echo "### 📋 Build Information" >> $GITHUB_STEP_SUMMARY
-        echo "- **Project**: ${GITHUB_REPOSITORY#*/}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Version**: ${{ steps.build.outputs.project-version || 'Unknown' }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Build Number**: ${BUILD_NUMBER}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Project**: \`$build_name\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Version**: \`${PROJECT_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Build Number**: \`${BUILD_NUMBER}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Commit**: \`$GITHUB_SHA\`" >> $GITHUB_STEP_SUMMARY
 
-        # Deployment information
-        if [[ -n "${{ inputs.artifactory-deploy-repo }}" ]]; then
+        if [[ "${{ steps.build.outputs.should-deploy }}" == true ]]; then
           echo "### 🚀 Deployment" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ steps.build.conclusion }}" == "success" ]]; then
-            echo "✅ **Artifacts deployed to Artifactory**" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            ARTIFACTORY_BROWSE_URL="${{ steps.build.outputs.build-info-url }}"
-            echo "🔗 **[Browse artifacts in Artifactory](${ARTIFACTORY_BROWSE_URL})**" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **Deployment failed** (build unsuccessful)" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
+          ARTIFACTORY_BROWSE_URL="${ARTIFACTORY_URL%/*}/ui/builds/$build_name/$BUILD_NUMBER"
+          echo "🔗 **[Browse artifacts in Artifactory](${ARTIFACTORY_BROWSE_URL})**" >> $GITHUB_STEP_SUMMARY
         fi

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -121,3 +121,29 @@ runs:
       run: |
         cd "${{ inputs.working-directory }}"
         ${GITHUB_ACTION_PATH}/build.sh
+
+    - name: Generate workflow summary
+      if: always()
+      shell: bash
+      env:
+        ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
+          format('{0}/artifactory', inputs.repox-url) }}
+      run: |
+        build_name="${GITHUB_REPOSITORY#*/}"
+        echo "## 📦 Poetry Build Summary" >> $GITHUB_STEP_SUMMARY
+        if [[ "${{ steps.build.conclusion }}" == "success" ]]; then
+          echo "✅ **Build SUCCESS**" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "❌ **Build FAILED**" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "### 📋 Build Information" >> $GITHUB_STEP_SUMMARY
+        echo "- **Project**: \`$build_name\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Version**: \`${PROJECT_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Build Number**: \`${BUILD_NUMBER}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Commit**: \`$GITHUB_SHA\`" >> $GITHUB_STEP_SUMMARY
+
+        if [[ "${{ steps.build.outputs.should-deploy }}" == true ]]; then
+          echo "### 🚀 Deployment" >> $GITHUB_STEP_SUMMARY
+          ARTIFACTORY_BROWSE_URL="${ARTIFACTORY_URL%/*}/ui/builds/$build_name/$BUILD_NUMBER"
+          echo "🔗 **[Browse artifacts in Artifactory](${ARTIFACTORY_BROWSE_URL})**" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -48,9 +48,8 @@ source "$(dirname "${BASH_SOURCE[0]}")/../shared/common-functions.sh"
 : "${GITHUB_REF_NAME:?}" "${BUILD_NUMBER:?}" "${GITHUB_REPOSITORY:?}" "${GITHUB_EVENT_NAME:?}" "${GITHUB_EVENT_PATH:?}"
 : "${PULL_REQUEST?}" "${DEFAULT_BRANCH:?}"
 : "${GITHUB_ENV:?}" "${GITHUB_OUTPUT:?}" "${GITHUB_SHA:?}" "${GITHUB_RUN_ID:?}"
-: "${SONAR_PLATFORM:?}"
 # Only validate sonar credentials if platform is not 'none'
-if [[ "${SONAR_PLATFORM}" != "none" ]]; then
+if [[ "${SONAR_PLATFORM:?}" != "none" ]]; then
   : "${NEXT_URL:?}" "${NEXT_TOKEN:?}" "${SQC_US_URL:?}" "${SQC_US_TOKEN:?}" "${SQC_EU_URL:?}" "${SQC_EU_TOKEN:?}"
 fi
 : "${RUN_SHADOW_SCANS:?}"
@@ -190,6 +189,8 @@ set_project_version() {
   echo "Replacing version $current_version with $release_version"
   poetry version "$release_version"
   echo "project-version=$release_version" >> "$GITHUB_OUTPUT"
+  echo "PROJECT_VERSION=$release_version" >> "$GITHUB_ENV"
+  echo "PROJECT_VERSION=$release_version"
   export PROJECT_VERSION=$release_version
 }
 
@@ -245,6 +246,7 @@ get_build_config() {
   # Export the configuration for use by build_poetry
   export BUILD_ENABLE_SONAR="$enable_sonar"
   export BUILD_ENABLE_DEPLOY="$enable_deploy"
+  echo "should-deploy=$enable_deploy" >> "$GITHUB_OUTPUT"
   export BUILD_SONAR_ARGS="${sonar_args[*]:-}"
 }
 

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -43,9 +43,6 @@ outputs:
   project-version:
     description: The project version from package.json
     value: ${{ steps.build.outputs.project-version }}
-  build-info-url:
-    description: The JFrog build info UI URL
-    value: ${{ steps.build.outputs.BUILD_INFO_URL }}
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
     value: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
@@ -127,28 +124,25 @@ runs:
     - name: Generate workflow summary
       if: always()
       shell: bash
+      env:
+        ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
+          format('{0}/artifactory', inputs.repox-url) }}
       run: |
+        build_name="${GITHUB_REPOSITORY#*/}"
         echo "## 📦 Yarn Build Summary" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-
-        # Basic build information
+        if [[ "${{ steps.build.conclusion }}" == "success" ]]; then
+          echo "✅ **Build SUCCESS**" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "❌ **Build FAILED**" >> $GITHUB_STEP_SUMMARY
+        fi
         echo "### 📋 Build Information" >> $GITHUB_STEP_SUMMARY
-        echo "- **Project**: ${GITHUB_REPOSITORY#*/}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Version**: ${{ steps.build.outputs.project-version || 'Unknown' }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Build Number**: ${{ env.BUILD_NUMBER }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Commit**: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Project**: \`$build_name\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Version**: \`${PROJECT_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Build Number**: \`${BUILD_NUMBER}\`" >> $GITHUB_STEP_SUMMARY
+        echo "- **Commit**: \`$GITHUB_SHA\`" >> $GITHUB_STEP_SUMMARY
 
-        # Deployment information
-        if [[ -n "${{ inputs.artifactory-deploy-repo }}" ]]; then
+        if [[ "${{ steps.build.outputs.should-deploy }}" == true ]]; then
           echo "### 🚀 Deployment" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ steps.build.conclusion }}" == "success" ]]; then
-            echo "✅ **Artifacts deployed to Artifactory**" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            ARTIFACTORY_BROWSE_URL="${{ steps.build.outputs.build-info-url }}"
-            echo "🔗 **[Browse artifacts in Artifactory](${ARTIFACTORY_BROWSE_URL})**" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **Deployment failed** (build unsuccessful)" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
+          ARTIFACTORY_BROWSE_URL="${ARTIFACTORY_URL%/*}/ui/builds/$build_name/$BUILD_NUMBER"
+          echo "🔗 **[Browse artifacts in Artifactory](${ARTIFACTORY_BROWSE_URL})**" >> $GITHUB_STEP_SUMMARY
         fi

--- a/cache/action.yml
+++ b/cache/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Cache with S3 (private/internal repos)
       if: steps.repo-visibility.outputs.cache-backend == 's3'
-      uses: SonarSource/gh-action_cache@master # 1.0.0
+      uses: SonarSource/gh-action_cache@v1
       id: s3-cache
       with:
         path: ${{ inputs.path }}

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -60,7 +60,7 @@ runs:
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
     - name: Get secrets from Vault
       if: steps.from-env.outputs.skip != 'true'
-      id: vault
+      id: secrets
       uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       with:
         secrets: |
@@ -74,10 +74,10 @@ runs:
       env:
         ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
           format('{0}/artifactory', inputs.repox-url) }}
-        ARTIFACTORY_USERNAME: ${{ steps.vault.outputs.vault && fromJSON(steps.vault.outputs.vault).ARTIFACTORY_USERNAME || '' }}
-        ARTIFACTORY_ACCESS_TOKEN: ${{ steps.vault.outputs.vault && fromJSON(steps.vault.outputs.vault).ARTIFACTORY_ACCESS_TOKEN || '' }}
-        DEVELOCITY_ACCESS_KEY: ${{ inputs.use-develocity == 'true' && steps.vault.outputs.vault &&
-          format('develocity.sonar.build={0}', fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN) || '' }}
+        ARTIFACTORY_USERNAME: ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME || '' }}
+        ARTIFACTORY_ACCESS_TOKEN: ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN || '' }}
+        DEVELOCITY_ACCESS_KEY: ${{ inputs.use-develocity == 'true' && steps.secrets.outputs.vault &&
+          fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN || '' }}
       run: |
         echo "ARTIFACTORY_URL=$ARTIFACTORY_URL" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_USERNAME=$ARTIFACTORY_USERNAME" >> "$GITHUB_ENV"
@@ -85,7 +85,7 @@ runs:
         echo "ARTIFACTORY_ACCESS_TOKEN=$ARTIFACTORY_ACCESS_TOKEN" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_PASSWORD=$ARTIFACTORY_ACCESS_TOKEN" >> "$GITHUB_ENV"  # deprecated, backward compliance
         if [ "$DEVELOCITY_ACCESS_KEY" != "" ]; then
-          echo "DEVELOCITY_ACCESS_KEY=$DEVELOCITY_ACCESS_KEY" >> "$GITHUB_ENV"
+          echo "DEVELOCITY_ACCESS_KEY=develocity.sonar.build=$DEVELOCITY_ACCESS_KEY" >> "$GITHUB_ENV"
         fi
 
     - name: Configure Maven settings and set repository URL
@@ -107,6 +107,7 @@ runs:
         restore-keys: maven-${{ runner.os }}-${{ github.workflow }}-
 
     - name: Update project version and set current-version and project-version variables
+      id: config
       if: steps.from-env.outputs.skip != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/config-maven/set_maven_project_version.sh
+++ b/config-maven/set_maven_project_version.sh
@@ -69,7 +69,7 @@ set_project_version() {
   mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion="$release_version" -DgenerateBackupPoms=false --batch-mode --no-transfer-progress --errors
   echo "project-version=$release_version" >> "$GITHUB_OUTPUT"
   echo "PROJECT_VERSION=$release_version" >> "$GITHUB_ENV"
-  echo "PROJECT_VERSION=${release_version}"
+  echo "PROJECT_VERSION=$release_version"
   export PROJECT_VERSION="$release_version"
 }
 

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: Whether to cache NPM dependencies
     default: 'true'
   repox-url:
-    description: URL for Repox Platform
+    description: URL for Repox
     default: https://repox.jfrog.io
   repox-artifactory-url:
     description: URL for Repox Artifactory API (overrides repox-url/artifactory if provided)
@@ -48,7 +48,7 @@ runs:
         version: 2025.7.12
 
     - name: Get secrets from Vault
-      id: vault
+      id: secrets
       uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       with:
         secrets: |
@@ -70,7 +70,7 @@ runs:
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
           format('{0}/artifactory', inputs.repox-url) }}
-        ARTIFACTORY_USERNAME: ${{ fromJSON(steps.vault.outputs.vault).ARTIFACTORY_USERNAME }}
-        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.vault.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+        ARTIFACTORY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}
+        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
       working-directory: ${{ inputs.working-directory }}
       run: ${GITHUB_ACTION_PATH}/config.sh

--- a/config-npm/config.sh
+++ b/config-npm/config.sh
@@ -81,7 +81,7 @@ set_project_version() {
   check_version_format "${release_version}"
   echo "project-version=$release_version" >> "$GITHUB_OUTPUT"
   echo "PROJECT_VERSION=$release_version" >> "$GITHUB_ENV"
-  echo "PROJECT_VERSION=${release_version}"
+  echo "PROJECT_VERSION=$release_version"
   export PROJECT_VERSION="$release_version"
 }
 

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -72,6 +72,21 @@ Describe 'build-gradle/build.sh'
   End
 End
 
+common_setup() {
+  GITHUB_OUTPUT=$(mktemp)
+  export GITHUB_OUTPUT
+  GITHUB_ENV=$(mktemp)
+  export GITHUB_ENV
+}
+
+common_cleanup() {
+  [[ -f "$GITHUB_OUTPUT" ]] && rm "$GITHUB_OUTPUT"
+  [[ -f "$GITHUB_ENV" ]] && rm "$GITHUB_ENV"
+}
+
+BeforeEach 'common_setup'
+AfterEach 'common_cleanup'
+
 Include build-gradle/build.sh
 
 Describe 'set_build_env'

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -67,7 +67,6 @@ Describe 'build-maven/build.sh'
       echo "mvn $*"
     End
     When run script build-maven/build.sh
-    Dump
     The status should be success
     The output should include "Maven command: mvn"
   End

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -60,7 +60,7 @@ Describe 'build-poetry/build.sh'
     End
     When run script build-poetry/build.sh
       The status should be success
-      The lines of stdout should equal 25
+      The lines of stdout should equal 26
       The line 1 should include "jq"
       The line 2 should include "jq"
       The line 3 should include "python"
@@ -78,13 +78,14 @@ Describe 'build-poetry/build.sh'
       The line 15 should equal "Deploy Pull Request: false"
       The line 16 should equal "Replacing version 1.2 with 1.2.0.42"
       The line 17 should equal "poetry version 1.2.0.42"
-      The line 18 should equal "======= Build other branch ======="
-
-      The line 20 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token dummy access token"
-      The line 21 should equal "jf poetry-config --server-id-resolve repox --repo-resolve <repox pypi repo>"
-      The line 22 should equal "jf poetry install --build-name=my-repo --build-number=42"
-      The line 24 should equal "poetry build"
-      The line 25 should equal "=== Build completed successfully ==="
+      The line 18 should equal "PROJECT_VERSION=1.2.0.42"
+      The line 19 should equal "======= Build other branch ======="
+      The line 20 should equal "Installing dependencies..."
+      The line 21 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token dummy access token"
+      The line 22 should equal "jf poetry-config --server-id-resolve repox --repo-resolve <repox pypi repo>"
+      The line 23 should equal "jf poetry install --build-name=my-repo --build-number=42"
+      The line 25 should equal "poetry build"
+      The line 26 should equal "=== Build completed successfully ==="
     End
 End
 

--- a/spec/config-npm_spec.sh
+++ b/spec/config-npm_spec.sh
@@ -62,7 +62,6 @@ End
 
 Include config-npm/config.sh
 
-# Common setup function for all tests
 common_setup() {
   GITHUB_OUTPUT=$(mktemp)
   export GITHUB_OUTPUT
@@ -70,7 +69,6 @@ common_setup() {
   export GITHUB_ENV
 }
 
-# Common cleanup function for all tests
 common_cleanup() {
   [[ -f "$GITHUB_OUTPUT" ]] && rm "$GITHUB_OUTPUT"
   [[ -f "$GITHUB_ENV" ]] && rm "$GITHUB_ENV"


### PR DESCRIPTION
[BUILD-9169](https://sonarsource.atlassian.net/browse/BUILD-9169)

Use reliable condition for the deployment summary display in build-gradle, build-npm, build-yarn.
Move up should_deploy() in build-gradle/build.sh before its use.
Add build info URL to Gradle deployment summary.
Fix ARTIFACTORY_URL in config-maven and build-maven
Cleanup debug dump in the tests.

Tested with:
- https://github.com/SonarSource/sonar-dummy-js/pull/99
<img width="470" height="369" alt="image" src="https://github.com/user-attachments/assets/0c92f58b-80ca-4b9f-9620-0b8e8440e10a" />

- https://github.com/SonarSource/sonar-dummy/pull/497
<img width="456" height="277" alt="image" src="https://github.com/user-attachments/assets/27000f8d-8171-47b0-8e62-77efe3622fd6" />
<img width="469" height="368" alt="image" src="https://github.com/user-attachments/assets/4d7e2b96-35da-43bf-823e-2feb0636d7da" />


- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/293
<img width="472" height="355" alt="image" src="https://github.com/user-attachments/assets/1a7d5c55-1442-4317-afbb-0fd9d64c235c" />

- https://github.com/SonarSource/sonar-dummy-maven-enterprise/pull/96
<img width="470" height="806" alt="image" src="https://github.com/user-attachments/assets/f92609e8-f068-4057-8e6d-ed019b18d66d" />

- https://github.com/SonarSource/sonar-dummy-yarn/pull/30
<img width="458" height="363" alt="image" src="https://github.com/user-attachments/assets/233f760f-2f09-4569-9588-c281a10e58ea" />

- https://github.com/SonarSource/sonar-dummy-python-oss/pull/63
<img width="458" height="354" alt="image" src="https://github.com/user-attachments/assets/63b31596-675a-4d70-93ba-24281d8894b9" />


[BUILD-9169]: https://sonarsource.atlassian.net/browse/BUILD-9169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ