### PR TITLE
BUILD-9220 Set correct SONARSOURCE_REPOSITORY_URL in config and build-maven actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,7 @@ After running this action, the following environment variables are available:
 - `DEVELOCITY_ACCESS_KEY`: The Develocity access key when use-develicty is true
 - `MAVEN_OPTS`: JVM options for Maven execution. Defaults to `-Xmx1536m -Xms128m` by default
 - `PROJECT_VERSION`: The project version with build number appended
-- `SONARSOURCE_REPOSITORY_URL`: URL for SonarSource Artifactory root virtual repository (i.e.: sonarsource-qa for public builds or
-  sonarsource-qa for private builds)
+- `SONARSOURCE_REPOSITORY_URL`: URL for SonarSource Artifactory root virtual repository is set to [`sonarsource-qa`](https://repox.jfrog.io/artifactory/sonarsource-qa)
 
 ## `build-maven`
 
@@ -263,6 +262,8 @@ See also [`config-maven`](#config-maven) input environment variables.
 | `BUILD_NUMBER` | The current build number. Also set as environment variable `BUILD_NUMBER` |
 
 ### Output Environment Variables
+
+- `SONARSOURCE_REPOSITORY_URL`: URL for SonarSource Artifactory root virtual repository is set to [`sonarsource`](https://repox.jfrog.io/artifactory/sonarsource)
 
 See also [`config-maven`](#config-maven) output environment variables.
 

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -70,6 +70,7 @@ runs:
           (github.event.repository.visibility == 'public' && 'public-deployer' || 'qa-deployer') }}
       run: |
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
+        echo "SONARSOURCE_REPOSITORY_URL=${ARTIFACTORY_URL}/sonarsource" >> "$GITHUB_ENV"
     - name: Vault
       # yamllint disable rule:line-length
       id: secrets

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -91,15 +91,12 @@ runs:
     - name: Configure Maven settings and set repository URL
       if: steps.from-env.outputs.skip != 'true'
       shell: bash
-      env:
-        SONARSOURCE_REPOSITORY_URL: ${{ github.event.repository.visibility == 'private' &&
-          'https://repox.jfrog.io/artifactory/sonarsource-qa' || 'https://repox.jfrog.io/artifactory/sonarsource' }}
       run: |
         MAVEN_CONFIG="$HOME/.m2"
         mkdir -p "$MAVEN_CONFIG"
         cp "${GITHUB_ACTION_PATH}/resources/settings.xml" "$MAVEN_CONFIG/settings.xml"
         echo "Copied Maven settings from ${GITHUB_ACTION_PATH}/resources/settings.xml to $MAVEN_CONFIG/settings.xml"
-        echo "SONARSOURCE_REPOSITORY_URL=${SONARSOURCE_REPOSITORY_URL}" >> "$GITHUB_ENV"
+        echo "SONARSOURCE_REPOSITORY_URL=$ARTIFACTORY_URL/sonarsource-qa" >> "$GITHUB_ENV"
 
     - name: Cache local Maven repository
       uses: SonarSource/ci-github-actions/cache@v1


### PR DESCRIPTION
[BUILD-9220](https://sonarsource.atlassian.net/browse/BUILD-9220)

This aligns with the logic that was previously set in https://github.com/SonarSource/ci-common-scripts/blob/branch-3/src/cirrus-env

Tested with https://github.com/SonarSource/sonar-dummy-maven-enterprise/pull/97


[BUILD-9220]: https://sonarsource.atlassian.net/browse/BUILD-9220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ