### PR TITLE
BUILD-9115 improved release notes template for Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1019,13 +1019,24 @@ After running this action, the following environment variables are available:
    >
    > The v1 branch has been updated, so workflows using `@v1` will automatically receive these improvements.
    >
+   > ---
+   >
    > ### ✨ What's New
    >
+   > - _Curated highlights from release notes: new features, important new options_
+   >
+   > ### 🚀 Improvements
+   >
+   > - _Curated highlights from release notes: improvement and upgrades_
+   >
+   > ### 🐛 Bug Fixes
+   >
    > - _Curated highlights from release notes_
    >
-   > ### 🐛 Key Fixes
+   > ### 📚 Documentation
    >
    > - _Curated highlights from release notes_
+   >
    >
    > For all the details, you can
    > [read the full release notes on GitHub](https://github.com/SonarSource/ci-github-actions/releases/tag/1.y.z).


### PR DESCRIPTION
Added more categories to the template for the announce on Slack:
<img width="642" height="451" alt="image" src="https://github.com/user-attachments/assets/5d29fe39-e2e4-488a-87ce-81b99021f9b8" />

For instance:
<img width="831" height="470" alt="image" src="https://github.com/user-attachments/assets/e1332ad0-1737-4875-92ef-9977885a0898" />
