### PR TITLE
BUILD-9216 custom deploy repository

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -11,3 +11,7 @@ MD024: # Multiple headings with the same content
 MD031: # Fenced code blocks should be surrounded by blank lines
   # Disable for list_items to create a tight list containing a code fence
   list_items: false
+
+MD033: # Inline HTML
+  allowed_elements:
+    - br

--- a/README.md
+++ b/README.md
@@ -458,22 +458,23 @@ jobs:
 
 ### Inputs
 
-| Input                       | Description                                                                    | Default                                                                                     |
-|-----------------------------|--------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `public`                    | Deprecated                                                                     | Repository visibility                                                                       |
-| `artifactory-deploy-repo`   | Deployment repository                                                          | `sonarsource-private-qa` for private repositories, `sonarsource-public-qa` for public repos |
-| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                | `private-reader` for private repos, `public-reader` for public repos                        |
-| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                              | `qa-deployer` for private repos, `public-deployer` for public repos                         |
-| `deploy-pull-request`       | Whether to deploy pull request artifacts                                       | `false`                                                                                     |
-| `skip-tests`                | Whether to skip running tests                                                  | `false`                                                                                     |
-| `use-develocity`            | Whether to use Develocity for build tracking                                   | `false`                                                                                     |
-| `gradle-args`               | Additional arguments to pass to Gradle                                         | (optional)                                                                                  |
-| `develocity-url`            | URL for Develocity                                                             | `https://develocity.sonar.build/`                                                           |
-| `repox-url`                 | URL for Repox                                                                  | `https://repox.jfrog.io`                                                                    |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)    | (optional)                                                                                  |
+| Input                       | Description                                                                               | Default                                                                                     |
+|-----------------------------|-------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `public`                    | Deprecated                                                                                | Repository visibility                                                                       |
+| `artifactory-deploy-repo`   | Deployment repository                                                                     | `sonarsource-private-qa` for private repositories, `sonarsource-public-qa` for public repos |
+| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                           | `private-reader` for private repos, `public-reader` for public repos                        |
+| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                         | `qa-deployer` for private repos, `public-deployer` for public repos                         |
+| `deploy-pull-request`       | Whether to deploy pull request artifacts                                                  | `false`                                                                                     |
+| `skip-tests`                | Whether to skip running tests                                                             | `false`                                                                                     |
+| `use-develocity`            | Whether to use Develocity for build tracking                                              | `false`                                                                                     |
+| `gradle-args`               | Additional arguments to pass to Gradle                                                    | (optional)                                                                                  |
+| `develocity-url`            | URL for Develocity                                                                        | `https://develocity.sonar.build/`                                                           |
+| `repox-url`                 | URL for Repox                                                                             | `https://repox.jfrog.io`                                                                    |
+| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)               | (optional)                                                                                  |
 | `sonar-platform`            | SonarQube variant - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans | `next`                                                                                      |
-| `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                                                     || `cache-paths`               | Custom cache paths (multiline).  | (optional)                                                          |
-| `disable-caching`           | Whether to disable Gradle caching entirely                                     | `false`                                                              |
+| `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding)            | `false`                                                                                     |
+| `cache-paths`               | Custom cache paths (multiline).                                                           | `~/.gradle/caches`<br>`~/.gradle/wrapper`                                                   |
+| `disable-caching`           | Whether to disable Gradle caching entirely                                                | `false`                                                                                     |
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -265,20 +265,22 @@ See also [`config-maven`](#config-maven) input environment variables.
 
 ### Inputs
 
-| Input                         | Description                                                                                                                | Default                                                              |
-|-------------------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
-| `artifactory-reader-role`     | Suffix for the Artifactory reader role in Vault                                                                            | `private-reader` for private repos, `public-reader` for public repos |
-| `artifactory-deployer-role`   | Suffix for the Artifactory deployer role in Vault                                                                          | `qa-deployer` for private repos, `public-deployer` for public repos  |
-| `deploy-pull-request`         | Whether to deploy pull request artifacts                                                                                   | `false`                                                              |
-| `maven-args`                  | Additional arguments to pass to Maven                                                                                      | (optional)                                                           |
-| `scanner-java-opts`           | Additional Java options for the Sonar scanner (`SONAR_SCANNER_JAVA_OPTS`)                                                  | `-Xmx512m`                                                           |
-| `repox-url`                   | URL for Repox                                                                                                              | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`       | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                | (optional)                                                           |
-| `use-develocity`              | Whether to use Develocity for build tracking                                                                               | `false`                                                              |
-| `develocity-url`              | URL for Develocity                                                                                                         | `https://develocity.sonar.build/`                                    |
-| `sonar-platform`              | SonarQube primary platform - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans                        | `next`                                                               |
-| `working-directory`           | Relative path under github.workspace to execute the build in                                                               | `.`                                                                  |
-| `run-shadow-scans`            | If true, run SonarQube analysis on all 3 platforms (next, sqc-eu, sqc-us); if false, only on the selected `sonar-platform` | `false`                                                              |
+| Input                       | Description                                                                                                                | Default                                                                                     |
+|-----------------------------|----------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `public`                    | Deprecated                                                                                                                 | Repository visibility                                                                       |
+| `artifactory-deploy-repo`   | Deployment repository                                                                                                      | `sonarsource-private-qa` for private repositories, `sonarsource-public-qa` for public repos |
+| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                                                            | `private-reader` for private repos, `public-reader` for public repos                        |
+| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                                                          | `qa-deployer` for private repos, `public-deployer` for public repos                         |
+| `deploy-pull-request`       | Whether to deploy pull request artifacts                                                                                   | `false`                                                                                     |
+| `maven-args`                | Additional arguments to pass to Maven                                                                                      | (optional)                                                                                  |
+| `scanner-java-opts`         | Additional Java options for the Sonar scanner (`SONAR_SCANNER_JAVA_OPTS`)                                                  | `-Xmx512m`                                                                                  |
+| `repox-url`                 | URL for Repox                                                                                                              | `https://repox.jfrog.io`                                                                    |
+| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                | (optional)                                                                                  |
+| `use-develocity`            | Whether to use Develocity for build tracking                                                                               | `false`                                                                                     |
+| `develocity-url`            | URL for Develocity                                                                                                         | `https://develocity.sonar.build/`                                                           |
+| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans                        | `next`                                                                                      |
+| `working-directory`         | Relative path under github.workspace to execute the build in                                                               | `.`                                                                                         |
+| `run-shadow-scans`          | If true, run SonarQube analysis on all 3 platforms (next, sqc-eu, sqc-us); if false, only on the selected `sonar-platform` | `false`                                                                                     |
 | `cache-paths`                 | Custom cache paths (multiline). Overrides default `~/.m2/repository`.                        | (optional)                                                           |
 | `disable-caching`             | Whether to disable Maven caching entirely                                                                                  | `false`                                                              |
 
@@ -370,21 +372,22 @@ jobs:
           run-shadow-scans: false                              # Run SonarQube scans on all 3 platforms (next, sqc-eu, sqc-us)
 ```
 
-### Inputs
+## Inputs
 
-| Input                       | Description                                                                                                                                                                                   | Default                                                              |
-|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
-| `public`                    | Whether to build and deploy with/to public repositories                                                                                                                                       | Auto-detected from repository visibility                             |
-| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                                                                                                                               | `private-reader` for private repos, `public-reader` for public repos |
-| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                                                                                                                             | `qa-deployer` for private repos, `public-deployer` for public repos  |
-| `deploy-pull-request`       | Whether to deploy pull request artifacts                                                                                                                                                      | `false`                                                              |
-| `poetry-virtualenvs-path`   | Path to the Poetry virtual environments, relative to GitHub workspace                                                                                                                         | `.cache/pypoetry/virtualenvs`                                        |
-| `poetry-cache-dir`          | Path to the Poetry cache directory, relative to GitHub workspace                                                                                                                              | `.cache/pypoetry`                                                    |
-| `repox-url`                 | URL for Repox                                                                                                                                                                                 | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                                                                                   | (optional)                                                           |
-| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', sqc-us, or 'none'. Use 'none' to skip sonar scans                                                                                              | `next`                                                               |
-| `run-shadow-scans`          | If true, run sonar scanner on all 3 platforms using the provided URL and token. If false, run on the platform provided by sonar-platform. When enabled, the sonar-platform setting is ignored | `false`                                                              |
-| `working-directory`         | Relative path under github.workspace to execute the build in                                                                                                                                  | `.`                                                                  |
+| Input                       | Description                                                                                                                                                                                   | Default                                                                                               |
+|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| `public`                    | Deprecated                                                                                                                                                                                    | Repository visibility                                                                                 |
+| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                                                                                                                               | `private-reader` for private repos, `public-reader` for public repos                                  |
+| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                                                                                                                             | `qa-deployer` for private repos, `public-deployer` for public repos                                   |
+| `artifactory-deploy-repo`   | Deployment repository                                                                                                                                                                         | `sonarsource-pypi-private-qa` for private repositories, `sonarsource-pypi-public-qa` for public repos |
+| `deploy-pull-request`       | Whether to deploy pull request artifacts                                                                                                                                                      | `false`                                                                                               |
+| `poetry-virtualenvs-path`   | Path to the Poetry virtual environments, relative to GitHub workspace                                                                                                                         | `.cache/pypoetry/virtualenvs`                                                                         |
+| `poetry-cache-dir`          | Path to the Poetry cache directory, relative to GitHub workspace                                                                                                                              | `.cache/pypoetry`                                                                                     |
+| `repox-url`                 | URL for Repox                                                                                                                                                                                 | `https://repox.jfrog.io`                                                                              |
+| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                                                                                   | (optional)                                                                                            |
+| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', sqc-us, or 'none'. Use 'none' to skip sonar scans                                                                                              | `next`                                                                                                |
+| `run-shadow-scans`          | If true, run sonar scanner on all 3 platforms using the provided URL and token. If false, run on the platform provided by sonar-platform. When enabled, the sonar-platform setting is ignored | `false`                                                                                               |
+| `working-directory`         | Relative path under github.workspace to execute the build in                                                                                                                                  | `.`                                                                                                   |
 
 ### Outputs
 
@@ -418,7 +421,7 @@ Build and publish a Gradle project with SonarQube analysis and Artifactory deplo
 **Gradle**: Not pre-installed in the runner image. We recommend including the Gradle wrapper (`gradlew`) in your repository, which will be
 used automatically. If the Gradle wrapper is not available, you can install Gradle using `mise` in your pipeline.
 
-**Additional Configuration**: The Gradle Artifactory plugin configuration is required in your `build.gradle` file.
+**Additional Configuration**: The Gradle Artifactory plugin configuration is required in `build.gradle` file.
 
 ### Usage
 
@@ -455,22 +458,21 @@ jobs:
 
 ### Inputs
 
-| Input                       | Description                                                                    | Default                                                              |
-|-----------------------------|--------------------------------------------------------------------------------|----------------------------------------------------------------------|
-| `public`                    | Whether to build and deploy with/to public repositories                        | Auto-detected from repository visibility                             |
-| `artifactory-deploy-repo`   | Name of deployment repository                                                  | Auto-detected based on repository visibility                         |
-| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                | `private-reader` for private repos, `public-reader` for public repos |
-| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                              | `qa-deployer` for private repos, `public-deployer` for public repos  |
-| `deploy-pull-request`       | Whether to deploy pull request artifacts                                       | `false`                                                              |
-| `skip-tests`                | Whether to skip running tests                                                  | `false`                                                              |
-| `use-develocity`            | Whether to use Develocity for build tracking                                   | `false`                                                              |
-| `gradle-args`               | Additional arguments to pass to Gradle                                         | (optional)                                                           |
-| `develocity-url`            | URL for Develocity                                                             | `https://develocity.sonar.build/`                                    |
-| `repox-url`                 | URL for Repox                                                                  | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)    | (optional)                                                           |
-| `sonar-platform`            | SonarQube variant - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans | `next`                                                     |
-| `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                              |
-| `cache-paths`               | Custom cache paths (multiline).  | (optional)                                                          |
+| Input                       | Description                                                                    | Default                                                                                     |
+|-----------------------------|--------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `public`                    | Deprecated                                                                     | Repository visibility                                                                       |
+| `artifactory-deploy-repo`   | Deployment repository                                                          | `sonarsource-private-qa` for private repositories, `sonarsource-public-qa` for public repos |
+| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                | `private-reader` for private repos, `public-reader` for public repos                        |
+| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                              | `qa-deployer` for private repos, `public-deployer` for public repos                         |
+| `deploy-pull-request`       | Whether to deploy pull request artifacts                                       | `false`                                                                                     |
+| `skip-tests`                | Whether to skip running tests                                                  | `false`                                                                                     |
+| `use-develocity`            | Whether to use Develocity for build tracking                                   | `false`                                                                                     |
+| `gradle-args`               | Additional arguments to pass to Gradle                                         | (optional)                                                                                  |
+| `develocity-url`            | URL for Develocity                                                             | `https://develocity.sonar.build/`                                                           |
+| `repox-url`                 | URL for Repox                                                                  | `https://repox.jfrog.io`                                                                    |
+| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)    | (optional)                                                                                  |
+| `sonar-platform`            | SonarQube variant - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans | `next`                                                                                      |
+| `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                                                     || `cache-paths`               | Custom cache paths (multiline).  | (optional)                                                          |
 | `disable-caching`           | Whether to disable Gradle caching entirely                                     | `false`                                                              |
 
 ### Outputs
@@ -660,20 +662,22 @@ See also [`config-npm`](#config-npm) input environment variables.
 
 ### Inputs
 
-| Input                       | Description                                                                    | Default                                                              |
-|-----------------------------|--------------------------------------------------------------------------------|----------------------------------------------------------------------|
-| `working-directory`         | Relative path under github.workspace to execute the build in                   | `.`                                                                  |
-| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                | `private-reader` for private repos, `public-reader` for public repos |
-| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                              | `qa-deployer` for private repos, `public-deployer` for public repos  |
-| `artifactory-deploy-repo`   | Name of deployment repository                                                  | Auto-detected based on repository visibility                         |
-| `deploy-pull-request`       | Whether to deploy pull request artifacts                                       | `false`                                                              |
-| `skip-tests`                | Whether to skip running tests                                                  | `false`                                                              |
-| `cache-npm`                 | Whether to cache NPM dependencies                                              | `true`                                                               |
-| `repox-url`                 | URL for Repox                                                                  | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)    | (optional)                                                           |
-| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us'                     | `next`                                                               |
-| `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                              |
-| `build-name`                | Name of the JFrog build to publish.                                            | `<Repository name>`                                                  |
+| Input                       | Description                                                                    | Default                                                                                      |
+|-----------------------------|--------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| `working-directory`         | Relative path under github.workspace to execute the build in                   | `.`                                                                                          |
+| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                | `private-reader` for private repos, `public-reader` for public repos                         |
+| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                              | `qa-deployer` for private repos, `public-deployer` for public repos                          |
+| `artifactory-deploy-repo`   | Deployment repository                                                          | `sonarsource-private-qa` for private repositories, `sonarsource-public-qa` for public repos  |
+| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                | `private-reader` for private repos, `public-reader` for public repos                         |
+| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                              | `sonarsource-npm-private-qa` for private repos, `sonarsource-npm-public-qa` for public repos |
+| `deploy-pull-request`       | Whether to deploy pull request artifacts                                       | `false`                                                                                      |
+| `skip-tests`                | Whether to skip running tests                                                  | `false`                                                                                      |
+| `cache-npm`                 | Whether to cache NPM dependencies                                              | `true`                                                                                       |
+| `repox-url`                 | URL for Repox                                                                  | `https://repox.jfrog.io`                                                                     |
+| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)    | (optional)                                                                                   |
+| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us'                     | `next`                                                                                       |
+| `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding) | `false`                                                                                      |
+| `build-name`                | Name of the JFrog build to publish.                                            | `<Repository name>`                                                                          |
 
 ### Outputs
 
@@ -767,19 +771,19 @@ jobs:
 
 ### Inputs
 
-| Input                       | Description                                                                                        | Default                                                              |
-|-----------------------------|----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
-| `public`                    | Whether to build and deploy with/to public repositories                                            | Auto-detected from repository visibility                             |
-| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                                    | `private-reader` for private repos, `public-reader` for public repos |
-| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                                  | `qa-deployer` for private repos, `public-deployer` for public repos  |
-| `artifactory-deploy-repo`   | Name of deployment repository                                                                      | (optional)                                                           |
-| `deploy-pull-request`       | Whether to deploy pull request artifacts                                                           | `false`                                                              |
-| `skip-tests`                | Whether to skip running tests                                                                      | `false`                                                              |
-| `cache-yarn`                | Whether to cache Yarn dependencies                                                                 | `true`                                                               |
-| `repox-url`                 | URL for Repox                                                                                      | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                        | (optional)                                                           |
-| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans | `next`                                                               |
-| `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding)                     | `false`                                                              |
+| Input                       | Description                                                                                        | Default                                                                                     |
+|-----------------------------|----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `public`                    | Deprecated                                                                                         | Repository visibility                                                                       |
+| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                                    | `private-reader` for private repos, `public-reader` for public repos                        |
+| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                                  | `qa-deployer` for private repos, `public-deployer` for public repos                         |
+| `artifactory-deploy-repo`   | Deployment repository                                                                              | `sonarsource-private-qa` for private repositories, `sonarsource-public-qa` for public repos |
+| `deploy-pull-request`       | Whether to deploy pull request artifacts                                                           | `false`                                                                                     |
+| `skip-tests`                | Whether to skip running tests                                                                      | `false`                                                                                     |
+| `cache-yarn`                | Whether to cache Yarn dependencies                                                                 | `true`                                                                                      |
+| `repox-url`                 | URL for Repox                                                                                      | `https://repox.jfrog.io`                                                                    |
+| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                        | (optional)                                                                                  |
+| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans | `next`                                                                                      |
+| `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding)                     | `false`                                                                                     |
 
 ### Outputs
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -3,10 +3,11 @@ name: Build Gradle
 description: GitHub Action to build, analyze, and deploy a Gradle project with SonarQube integration
 inputs:
   public:
-    description: Whether to build and deploy with/to public repositories. Set to `true` for public repositories (OSS), `false` for private.
+    description: Deprecated. Use `artifactory-reader-role`, `artifactory-deployer-role`, and `artifactory-deploy-repo` instead.
     default: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}
   artifactory-deploy-repo:
-    description: Name of deployment repository
+    description: Deployment repository. Defaults to `sonarsource-private-qa` for private repositories, and `sonarsource-public-qa` for
+      public repositories.
     default: ''
   artifactory-reader-role:
     description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories,
@@ -67,9 +68,9 @@ runs:
       shell: bash
       env:
         ARTIFACTORY_READER_ROLE: ${{ inputs.artifactory-reader-role != '' && inputs.artifactory-reader-role ||
-          (inputs.public == 'true' && 'public-reader' || 'private-reader') }}
+          (github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader') }}
         ARTIFACTORY_DEPLOYER_ROLE: ${{ inputs.artifactory-deployer-role != '' && inputs.artifactory-deployer-role ||
-          (inputs.public == 'true' && 'public-deployer' || 'qa-deployer') }}
+          (github.event.repository.visibility == 'public' && 'public-deployer' || 'qa-deployer') }}
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
@@ -161,7 +162,7 @@ runs:
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }} # deprecated, backward compliance
         ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
-          (inputs.public == 'true' && 'sonarsource-public-qa' || 'sonarsource-private-qa') }}
+          github.event.repository.visibility == 'public' && 'sonarsource-public-qa' || 'sonarsource-private-qa' }}
         ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
         ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
         ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }} # used in parent POM

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Suffix for the Artifactory deployer role in Vault. Defaults to `qa-deployer` for private repositories, and
       `public-deployer` for public repositories.
     default: ''
+  artifactory-deploy-repo:
+    description: Deployment repository. Defaults to `sonarsource-private-qa` for private repositories, and `sonarsource-public-qa` for
+      public repositories.
+    default: ''
   deploy-pull-request:
     description: Whether to deploy pull request artifacts.
     default: 'false'
@@ -62,7 +66,7 @@ runs:
     - name: Set local action
       shell: bash
       run: |
-        mkdir ".actions"
+        mkdir -p ".actions"
         ln -s "${{github.action_path}}/../config-maven" .actions/config-maven
         ln -s "${{github.action_path}}/../shared" .actions/shared
     - uses: ./.actions/config-maven # TODO BUILD-9094
@@ -107,8 +111,8 @@ runs:
       id: build
       env:
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        ARTIFACTORY_DEPLOY_REPO:
-          ${{ github.event.repository.visibility == 'public' && 'sonarsource-public-qa' || 'sonarsource-private-qa' }}
+        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
+          github.event.repository.visibility == 'public' && 'sonarsource-public-qa' || 'sonarsource-private-qa' }}
         ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
         ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
         ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }} # used in parent POM

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -14,7 +14,8 @@ inputs:
       `public-deployer` for public repositories.
     default: ''
   artifactory-deploy-repo:
-    description: Name of deployment repository
+    description: Deployment repository. Defaults to `sonarsource-npm-public-qa` for private repositories, and `sonarsource-npm-public-qa`
+      for public repositories.
     default: ''
   deploy-pull-request:
     description: Whether to deploy pull request artifacts
@@ -67,7 +68,7 @@ runs:
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
         cp ${GITHUB_ACTION_PATH}/mise.local.toml mise.local.toml
-        mkdir ".actions"
+        mkdir -p ".actions"
         ln -s "${{github.action_path}}/../config-npm" .actions/config-npm
         ln -s "${{github.action_path}}/../shared" .actions/shared
 

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -3,7 +3,7 @@ name: Build Poetry
 description: GitHub Action to build, analyze, and deploy a Python project using Poetry with SonarQube integration
 inputs:
   public:
-    description: Whether to build and deploy with/to public repositories. Set to `true` for public repositories (OSS), `false` for private.
+    description: Deprecated. Use `artifactory-reader-role`, `artifactory-deployer-role`, and `artifactory-deploy-repo` instead.
     default: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}
   artifactory-reader-role:
     description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories, and `public-reader`
@@ -12,6 +12,10 @@ inputs:
   artifactory-deployer-role:
     description: Suffix for the Artifactory deployer role in Vault. Defaults to `qa-deployer` for private repositories, and
       `public-deployer` for public repositories.
+    default: ''
+  artifactory-deploy-repo:
+    description: Deployment repository. Defaults to `sonarsource-pypi-private-qa` for private repositories, and `sonarsource-pypi-public-qa`
+      for public repositories.
     default: ''
   deploy-pull-request:
     description: Whether to deploy pull request artifacts. Set to `false` if not using the promote action.
@@ -55,9 +59,9 @@ runs:
       shell: bash
       env:
         ARTIFACTORY_READER_ROLE: ${{ inputs.artifactory-reader-role != '' && inputs.artifactory-reader-role ||
-          (inputs.public == 'true' && 'public-reader' || 'private-reader') }}
+          (github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader') }}
         ARTIFACTORY_DEPLOYER_ROLE: ${{ inputs.artifactory-deployer-role != '' && inputs.artifactory-deployer-role ||
-          (inputs.public == 'true' && 'public-deployer' || 'qa-deployer') }}
+          (github.event.repository.visibility == 'public' && 'public-deployer' || 'qa-deployer') }}
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
@@ -102,7 +106,8 @@ runs:
           format('{0}/artifactory', inputs.repox-url) }}
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
         ARTIFACTORY_PYPI_REPO: ${{ inputs.public == 'true' && 'sonarsource-pypi' || 'sonarsource-pypi' }} # FIXME: sonarsource-pypi-public
-        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.public == 'true' && 'sonarsource-pypi-public-qa' || 'sonarsource-pypi-private-qa' }}
+        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
+          github.event.repository.visibility == 'public' && 'sonarsource-pypi-public-qa' || 'sonarsource-pypi-private-qa' }}
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
         POETRY_VIRTUALENVS_PATH: ${{ github.workspace }}/${{ inputs.poetry-virtualenvs-path }}

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -3,7 +3,7 @@ name: Build Yarn
 description: GitHub Action to build, analyze, and deploy a Yarn project with SonarQube integration
 inputs:
   public:
-    description: Whether to build and deploy with/to public repositories. Set to `true` for public repositories (OSS), `false` for private.
+    description: Deprecated. Use `artifactory-reader-role`, `artifactory-deployer-role`, and `artifactory-deploy-repo` instead.
     default: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}
   artifactory-reader-role:
     description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories, and `public-reader`
@@ -14,7 +14,8 @@ inputs:
       `public-deployer` for public repositories.
     default: ''
   artifactory-deploy-repo:
-    description: Name of deployment repository
+    description: Deployment repository. Defaults to `sonarsource-private-qa` for private repositories, and `sonarsource-public-qa` for
+      public repositories.
     default: ''
   deploy-pull-request:
     description: Whether to deploy pull request artifacts
@@ -54,9 +55,9 @@ runs:
       shell: bash
       env:
         ARTIFACTORY_READER_ROLE: ${{ inputs.artifactory-reader-role != '' && inputs.artifactory-reader-role ||
-          (inputs.public == 'true' && 'public-reader' || 'private-reader') }}
+          (github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader') }}
         ARTIFACTORY_DEPLOYER_ROLE: ${{ inputs.artifactory-deployer-role != '' && inputs.artifactory-deployer-role ||
-          (inputs.public == 'true' && 'public-deployer' || 'qa-deployer') }}
+          (github.event.repository.visibility == 'public' && 'public-deployer' || 'qa-deployer') }}
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
@@ -103,7 +104,7 @@ runs:
         ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
           format('{0}/artifactory', inputs.repox-url) }}
         ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
-          (inputs.public == 'true' && 'sonarsource-public-qa' || 'sonarsource-private-qa') }}
+          github.event.repository.visibility == 'public' && 'sonarsource-public-qa' || 'sonarsource-private-qa' }}
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}


### PR DESCRIPTION
BUILD-9216

build-gradle:
- use `github.event.repository.visibility` instead of `inputs.public`
- `inputs.public` is deprecated

build-maven:
- new `artifactory-deploy-repo` input to override `$ARTIFACTORY_DEPLOY_REPO`

build-poetrry:
 - use `github.event.repository.visibility` instead of `inputs.public`
- `inputs.public` is deprecated
- new `artifactory-deploy-repo` input to override `$ARTIFACTORY_DEPLOY_REPO`

build-yan:
- use `github.event.repository.visibility` instead of `inputs.public`
- `inputs.public` is deprecated
