### PR TITLE
BUILD-9332 disable-cache and cache-paths options for Maven and Gradle, update docs

### DIFF
--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -44,8 +44,10 @@ inputs:
      If false, run on the platform provided by SONAR_PLATFORM.
     default: 'false'
   cache-paths:
-    description: Additional cache paths to include (multiline, one path per line)
-    default: ''
+    description: Cache paths to use (multiline). If provided, overrides the default Gradle cache directories
+    default: |-
+      ~/.gradle/caches
+      ~/.gradle/wrapper
   disable-caching:
     description: Whether to disable Gradle caching entirely
     default: 'false'
@@ -123,10 +125,7 @@ runs:
       uses: SonarSource/gh-action_cache@v1
       id: gradle-cache-restore
       with:
-        path: |
-          ${{ env.GRADLE_USER_HOME }}/caches
-          ${{ env.GRADLE_USER_HOME }}/wrapper
-          ${{ inputs.cache-paths }}
+        path: ${{ inputs.cache-paths }}
         key: gradle-${{ runner.os }}-${{ github.workflow }}-${{ env.GRADLE_CACHE_KEY }}
         restore-keys: |
           gradle-${{ runner.os }}-${{ github.workflow }}-

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -45,6 +45,13 @@ inputs:
   develocity-url:
     description: URL for Develocity
     default: https://develocity.sonar.build/
+  cache-paths:
+    description: Cache paths to use (multiline). If provided, overrides the default ~/.m2/repository
+    default: |-
+      ~/.m2/repository
+  disable-caching:
+    description: Whether to disable Maven caching entirely
+    default: 'false'
 outputs:
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
@@ -69,6 +76,8 @@ runs:
         repox-artifactory-url: ${{ inputs.repox-artifactory-url }}
         use-develocity: ${{ inputs.use-develocity }}
         develocity-url: ${{ inputs.develocity-url }}
+        cache-paths: ${{ inputs.cache-paths }}
+        disable-caching: ${{ inputs.disable-caching }}
     - name: Set build parameters
       shell: bash
       env:

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -24,6 +24,12 @@ inputs:
   develocity-url:
     description: URL for Develocity
     default: https://develocity.sonar.build/
+  cache-paths:
+    description: Cache paths to use (multiline). If provided, overrides the default ~/.m2/repository
+    default: ''
+  disable-caching:
+    description: Whether to disable Maven caching entirely
+    default: 'false'
 
 outputs:
   BUILD_NUMBER:
@@ -100,9 +106,10 @@ runs:
 
     - name: Cache local Maven repository
       uses: SonarSource/ci-github-actions/cache@v1
-      if: steps.from-env.outputs.skip != 'true'
+      if: steps.from-env.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
-        path: ~/.m2/repository
+        path: |-
+          ${{ inputs.cache-paths }}
         key: maven-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles(format('{0}/**/pom.xml', inputs.working-directory)) }}
         restore-keys: maven-${{ runner.os }}-${{ github.workflow }}-
 


### PR DESCRIPTION
[BUILD-9332](https://sonarsource.atlassian.net/browse/BUILD-9332)
Adds option to disable cache and customize cache paths for Maven
Adjust cache-paths for Gradle to have greater customizability


[BUILD-9332]: https://sonarsource.atlassian.net/browse/BUILD-9332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ