### PR TITLE
BUILD-8810 promote action improvements, fail gradle build when version could not be retrieved

### DIFF
--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -82,6 +82,10 @@ set_build_env() {
 
 set_project_version() {
   current_version=$($GRADLE_CMD properties --no-scan --no-daemon --console plain | grep 'version:' | tr -d "[:space:]" | cut -d ":" -f 2)
+  if [[ -z "$current_version" || "$current_version" == "unspecified" ]]; then
+    echo "ERROR: Could not get valid version from Gradle properties. Got: '$current_version'" >&2
+    exit 1
+  fi
   export CURRENT_VERSION=$current_version
   release_version="${current_version/-SNAPSHOT/}"
   if [[ "${release_version}" =~ ^[0-9]+\.[0-9]+$ ]]; then

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -145,6 +145,36 @@ Describe 'set_project_version'
     The variable PROJECT_VERSION should equal "1.2.0.42"
     rm -f gradle.properties gradle.properties.bak
   End
+
+  It 'fails when version is empty'
+    echo "version=1.0-SNAPSHOT" > gradle.properties
+    Mock gradle
+      if [[ "$*" == "properties --no-scan --no-daemon --console plain" ]]; then
+        echo "version: "
+      else
+        echo "gradle $*"
+      fi
+    End
+    When run set_project_version
+    The status should be failure
+    The stderr should include "ERROR: Could not get valid version from Gradle properties"
+    rm -f gradle.properties gradle.properties.bak
+  End
+
+  It 'fails when version is unspecified'
+    echo "version=1.0-SNAPSHOT" > gradle.properties
+    Mock gradle
+      if [[ "$*" == "properties --no-scan --no-daemon --console plain" ]]; then
+        echo "version: unspecified"
+      else
+        echo "gradle $*"
+      fi
+    End
+    When run set_project_version
+    The status should be failure
+    The stderr should include "ERROR: Could not get valid version from Gradle properties. Got: 'unspecified'"
+    rm -f gradle.properties gradle.properties.bak
+  End
 End
 
 Describe 'should_deploy'

--- a/spec/promote_spec.sh
+++ b/spec/promote_spec.sh
@@ -43,6 +43,7 @@ export BUILD_NAME="dummy-project"
 export BUILD_NUMBER="42"
 export DEFAULT_BRANCH="main"
 export GITHUB_EVENT_NAME="push"
+export GITHUB_REF="refs/heads/dummy-branch"
 export GITHUB_REF_NAME="dummy-branch"
 export GITHUB_REPOSITORY="SonarSource/dummy-project"
 export GITHUB_SHA="abc123"
@@ -284,9 +285,11 @@ Describe 'jfrog_promote()'
 End
 
 Describe 'github_notify_promotion()'
-  It 'notifies GitHub about the promotion'
+  It 'calls gh api with correct parameters'
     When call github_notify_promotion
-    The line 1 should match pattern "gh api -X POST */repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA *"
+    The output should include "gh api -X POST -H X-GitHub-Api-Version: 2022-11-28"
+    The output should include "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA"
+    The output should include "-H Content-Type: application/json --input -"
   End
 End
 


### PR DESCRIPTION
[BUILD-8810](https://sonarsource.atlassian.net/browse/BUILD-8810)
- improvements to promote action outputs
- fail gradle build if version could not be retrieved - consistency change to follow the same behaviour as other builds


[BUILD-8810]: https://sonarsource.atlassian.net/browse/BUILD-8810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ