### PR TITLE
BUILD-9365 Fix default for config-maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ steps:
 | `repox-artifactory-url`   | URL for Repox Artifactory API (overrides repox-url/artifactory if provided) | (optional)                                                                                                              |
 | `use-develocity`          | Whether to use Develocity for build tracking                                | `false`                                                                                                                 |
 | `develocity-url`          | URL for Develocity                                                          | `https://develocity.sonar.build/`                                                                                                         |
-| `cache-paths`             | Custom cache paths (multiline). Overrides default `~/.m2/repository`. | (optional)                                                  |
+| `cache-paths`             | Custom cache paths (multiline).                                             | (optional)                                                  |
 | `disable-caching`         | Whether to disable Maven caching entirely                                   | `false`                                                                                                                 |
 
 ### Outputs

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -47,8 +47,7 @@ inputs:
     default: https://develocity.sonar.build/
   cache-paths:
     description: Cache paths to use (multiline). If provided, overrides the default ~/.m2/repository
-    default: |-
-      ~/.m2/repository
+    default: ~/.m2/repository
   disable-caching:
     description: Whether to disable Maven caching entirely
     default: 'false'

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -26,7 +26,7 @@ inputs:
     default: https://develocity.sonar.build/
   cache-paths:
     description: Cache paths to use (multiline). If provided, overrides the default ~/.m2/repository
-    default: ''
+    default: ~/.m2/repository
   disable-caching:
     description: Whether to disable Maven caching entirely
     default: 'false'


### PR DESCRIPTION
[BUILD-9365](https://sonarsource.atlassian.net/browse/BUILD-9365)



[BUILD-9365]: https://sonarsource.atlassian.net/browse/BUILD-9365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ