### PR TITLE
BUILD-9379 also pass maven-args to sonar execution

### DIFF
--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -178,7 +178,7 @@ build_maven() {
   # Execute SonarQube analysis if enabled
   if [ "$enable_sonar" = true ]; then
     # This will call back to shared sonar_scanner_implementation() function
-    orchestrate_sonar_platforms "${sonar_args[@]+"${sonar_args[@]}"}"
+    orchestrate_sonar_platforms "${sonar_args[@]+"${sonar_args[@]}"}" "$@"
   fi
 }
 


### PR DESCRIPTION
BUILD-9379
Sonar scan was initially triggered with the Maven build, in the same Maven command.
Since the split between build and scan, the scan command is missing the custom Maven arguments.
Even in case of later need for improvement with distinct parameters between build and scan, this PR is fixing the regression bug.