### PR TITLE
PREQ-2322 backward compliance and warning about DEVELOCITY_ACCESS_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,23 +204,6 @@ steps:
 
 See also [`get-build-number`](#get-build-number) output environment variables.
 
-### Environment Variables Set
-
-After running this action, the following environment variables are available:
-
-- `ARTIFACTORY_ACCESS_TOKEN`: Access token for Artifactory authentication
-- `ARTIFACTORY_ACCESS_USERNAME`: Deprecated alias for `ARTIFACTORY_USERNAME`
-- `ARTIFACTORY_PASSWORD`: Deprecated alias for `ARTIFACTORY_ACCESS_TOKEN`
-- `ARTIFACTORY_URL`: Artifactory (Repox) URL. E.x.: `https://repox.jfrog.io/artifactory`
-- `ARTIFACTORY_USERNAME`: Username for Artifactory authentication
-- `BASH_ENV`: Path to the bash profile with mvn function for adding common flags to Maven calls
-- `BUILD_NUMBER`: The current build number
-- `CURRENT_VERSION`: The original project version from pom.xml
-- `DEVELOCITY_ACCESS_KEY`: The Develocity access key when use-develicty is true
-- `MAVEN_OPTS`: JVM options for Maven execution. Defaults to `-Xmx1536m -Xms128m` by default
-- `PROJECT_VERSION`: The project version with build number appended
-- `SONARSOURCE_REPOSITORY_URL`: URL for SonarSource Artifactory root virtual repository is set to [`sonarsource-qa`](https://repox.jfrog.io/artifactory/sonarsource-qa)
-
 ## `build-maven`
 
 Call [`config-maven`](#config-maven).

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -82,16 +82,22 @@ runs:
           format('{0}/artifactory', inputs.repox-url) }}
         ARTIFACTORY_USERNAME: ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME || '' }}
         ARTIFACTORY_ACCESS_TOKEN: ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN || '' }}
-        DEVELOCITY_ACCESS_KEY: ${{ inputs.use-develocity == 'true' && steps.secrets.outputs.vault &&
+        DEVELOCITY_TOKEN: ${{ inputs.use-develocity == 'true' && steps.secrets.outputs.vault &&
           fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN || '' }}
       run: |
+        if [[ "${DEVELOCITY_ACCESS_KEY:-}" == "develocity.sonar.build=" ]]; then
+          echo "::warning title=Found invalid DEVELOCITY_ACCESS_KEY::DEVELOCITY_ACCESS_KEY should not be set manually in the environment."
+          echo "[WARNING] DEVELOCITY_ACCESS_KEY is set in the environment with an empty token. This is a deprecated configuration." \
+          "The Develocity token is configured by config-maven. Please remove external configuration of DEVELOCITY_ACCESS_KEY."
+        fi
+
         echo "ARTIFACTORY_URL=$ARTIFACTORY_URL" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_USERNAME=$ARTIFACTORY_USERNAME" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_ACCESS_USERNAME=$ARTIFACTORY_USERNAME" >> "$GITHUB_ENV"  # deprecated, backward compliance
         echo "ARTIFACTORY_ACCESS_TOKEN=$ARTIFACTORY_ACCESS_TOKEN" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_PASSWORD=$ARTIFACTORY_ACCESS_TOKEN" >> "$GITHUB_ENV"  # deprecated, backward compliance
-        if [ "$DEVELOCITY_ACCESS_KEY" != "" ]; then
-          echo "DEVELOCITY_ACCESS_KEY=develocity.sonar.build=$DEVELOCITY_ACCESS_KEY" >> "$GITHUB_ENV"
+        if [ "DEVELOCITY_TOKEN" != "" ]; then
+          echo "DEVELOCITY_ACCESS_KEY=develocity.sonar.build=$DEVELOCITY_TOKEN" >> "$GITHUB_ENV"
         fi
 
     - name: Configure Maven settings and set repository URL


### PR DESCRIPTION
[PREQ-2322](https://sonarsource.atlassian.net/browse/PREQ-2322)

Old usage is now breaking due to injecting an empty token:
```
      - uses: SonarSource/ci-github-actions/build-maven@v1
        env:
          DEVELOCITY_ACCESS_KEY: develocity.sonar.build=${{ env.DEVELOCITY_TOKEN }}
        with:
          use-develocity: true
```

The code is updated to emit a warning and use another env variable to avoid the conflict (DEVELOCITY_TOKEN).


[PREQ-2322]: https://sonarsource.atlassian.net/browse/PREQ-2322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ