### PR TITLE
BUILD-9252 fix npx parameters parsing

### DIFF
--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -94,9 +94,7 @@ sonar_scanner_implementation() {
     if [ -n "${SONAR_REGION:-}" ]; then
         scanner_args+=("-Dsonar.region=${SONAR_REGION}")
     fi
-
-    scanner_args+=("${additional_params[@]+\"${additional_params[@]}\"}")
-
+    scanner_args+=("${additional_params[@]+${additional_params[@]}}")
     echo "npx command: npx -- @sonar/scan@$SQ_SCANNER_VERSION ${scanner_args[*]}"
     npx -- "@sonar/scan@$SQ_SCANNER_VERSION" "${scanner_args[@]}"
 }

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -97,8 +97,8 @@ sonar_scanner_implementation() {
 
     scanner_args+=("${additional_params[@]+\"${additional_params[@]}\"}")
 
-    echo "npx command: npx @sonar/scan@$SQ_SCANNER_VERSION ${scanner_args[*]}"
-    npx "@sonar/scan@$SQ_SCANNER_VERSION" "${scanner_args[@]}"
+    echo "npx command: npx -- @sonar/scan@$SQ_SCANNER_VERSION ${scanner_args[*]}"
+    npx -- "@sonar/scan@$SQ_SCANNER_VERSION" "${scanner_args[@]}"
 }
 
 jfrog_npm_publish() {

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -155,8 +155,8 @@ sonar_scanner_implementation() {
 
     scanner_args+=("${additional_params[@]+\"${additional_params[@]}\"}")
 
-    echo "npx command: npx @sonar/scan@$SQ_SCANNER_VERSION ${scanner_args[*]}"
-    npx "@sonar/scan@$SQ_SCANNER_VERSION" "${scanner_args[@]}"
+    echo "npx command: npx -- @sonar/scan@$SQ_SCANNER_VERSION ${scanner_args[*]}"
+    npx -- "@sonar/scan@$SQ_SCANNER_VERSION" "${scanner_args[@]}"
 }
 
 jfrog_yarn_publish() {

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -153,7 +153,7 @@ sonar_scanner_implementation() {
         scanner_args+=("-Dsonar.region=${SONAR_REGION}")
     fi
 
-    scanner_args+=("${additional_params[@]+\"${additional_params[@]}\"}")
+    scanner_args+=("${additional_params[@]+${additional_params[@]}}")
 
     echo "npx command: npx -- @sonar/scan@$SQ_SCANNER_VERSION ${scanner_args[*]}"
     npx -- "@sonar/scan@$SQ_SCANNER_VERSION" "${scanner_args[@]}"

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -157,7 +157,7 @@ Describe 'build_npm()'
     The status should be success
     The output should include "======= Building main branch ======="
     The output should include "Installing npm dependencies..."
-    The output should include "npx @sonar/scan"
+    The output should include "npx -- @sonar/scan"
     The output should include "Building project..."
   End
 
@@ -197,7 +197,7 @@ Describe 'build_npm()'
     The output should include "======= Building pull request ======="
     The output should include "======= no deploy ======="
     The output should include "Installing npm dependencies..."
-    The output should include "npx @sonar/scan"
+    The output should include "npx -- @sonar/scan"
     The output should not include "DEBUG: JFrog operations"
   End
 
@@ -235,7 +235,7 @@ Describe 'build_npm()'
     The status should be success
     The output should include "======= Build long-lived feature branch ======="
     The output should include "Installing npm dependencies..."
-    The output should include "npx @sonar/scan"
+    The output should include "npx -- @sonar/scan"
     The output should not include "DEBUG: JFrog operations"
   End
 
@@ -277,7 +277,7 @@ Describe 'sonar_scanner_implementation()'
     export GITHUB_REPOSITORY="test/repo"
     When call sonar_scanner_implementation
     The status should be success
-    The output should include "npx @sonar/scan"
+    The output should include "npx -- @sonar/scan"
     The output should include "-Dsonar.host.url=https://sonar.example.com"
     The output should include "-Dsonar.token=test-token"
     The output should include "-Dsonar.analysis.buildNumber=42"

--- a/spec/build-yarn_spec.sh
+++ b/spec/build-yarn_spec.sh
@@ -199,7 +199,7 @@ Describe 'build-yarn/build.sh'
       When call run_standard_pipeline
       The output should include "Installing yarn dependencies..."
       The output should include "Running tests..."
-      The output should include "npx @sonar/scan"
+      The output should include "npx -- @sonar/scan"
       The output should include "Building project..."
       The output should not include "::debug::JFrog operations completed successfully"
     End
@@ -259,7 +259,7 @@ Describe 'build-yarn/build.sh'
       export CURRENT_VERSION="1.2.3"
       When call sonar_scanner_implementation
       The status should be success
-      The output should include "npx @sonar/scan"
+      The output should include "npx -- @sonar/scan"
       The output should include "-Dsonar.host.url=https://sonar.example.com"
       The output should include "-Dsonar.token=test-token"
       The output should include "-Dsonar.analysis.buildNumber=42"


### PR DESCRIPTION
[BUILD-9252](https://sonarsource.atlassian.net/browse/BUILD-9252)

- Use -- flag
- Remove additional double quotes failing the parsing of command parameters

Tested with https://github.com/SonarSource/sonar-dummy-js/pull/98

[BUILD-9252]: https://sonarsource.atlassian.net/browse/BUILD-9252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ