### PR TITLE
BUILD-9065 - ignore unshallow error

### DIFF
--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -93,7 +93,7 @@ git_fetch_unshallow() {
 
   if git rev-parse --is-shallow-repository --quiet >/dev/null 2>&1; then
     echo "Fetch Git references for SonarQube analysis..."
-    git fetch --unshallow
+    git fetch --unshallow || true # Ignore errors like "fatal: --unshallow on a complete repository does not make sense"
   elif is_pull_request; then
     echo "Fetch ${GITHUB_BASE_REF:?} for SonarQube analysis..."
     git fetch origin "${GITHUB_BASE_REF}"

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -63,7 +63,7 @@ git_fetch_unshallow() {
 
   if git rev-parse --is-shallow-repository --quiet >/dev/null 2>&1; then
     echo "Fetch Git references for SonarQube analysis..."
-    git fetch --unshallow
+    git fetch --unshallow || true # Ignore errors like "fatal: --unshallow on a complete repository does not make sense"
   elif [ -n "${GITHUB_BASE_REF:-}" ]; then
     echo "Fetch ${GITHUB_BASE_REF} for SonarQube analysis..."
     git fetch origin "${GITHUB_BASE_REF}"

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -65,7 +65,7 @@ git_fetch_unshallow() {
 
   if git rev-parse --is-shallow-repository --quiet >/dev/null 2>&1; then
     echo "Fetch Git references for SonarQube analysis..."
-    git fetch --unshallow
+    git fetch --unshallow || true # Ignore errors like "fatal: --unshallow on a complete repository does not make sense"
   elif [ -n "${GITHUB_BASE_REF:-}" ]; then
     echo "Fetch ${GITHUB_BASE_REF} for SonarQube analysis..."
     git fetch origin "${GITHUB_BASE_REF}"

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -63,7 +63,7 @@ git_fetch_unshallow() {
 
   if git rev-parse --is-shallow-repository --quiet >/dev/null 2>&1; then
     echo "Fetch Git references for SonarQube analysis..."
-    git fetch --unshallow
+    git fetch --unshallow || true # Ignore errors like "fatal: --unshallow on a complete repository does not make sense"
   elif [ -n "${GITHUB_BASE_REF:-}" ]; then
     echo "Fetch ${GITHUB_BASE_REF} for SonarQube analysis..."
     git fetch origin "${GITHUB_BASE_REF}"


### PR DESCRIPTION
[BUILD-9065](https://sonarsource.atlassian.net/browse/BUILD-9065)

For some reason, the `git rev-parse --is-shallow-repository` test is not enough to avoid failing call to `git fetch --unshallow`.
Ignore the error to avoid failing the build on this.

[BUILD-9065]: https://sonarsource.atlassian.net/browse/BUILD-9065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ