### PR TITLE
BUILD-9423 install artifacts for availability in later calls (scan)

### DIFF
--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -134,7 +134,7 @@ build_maven() {
       should_deploy=true
     else
       echo "======= no deploy ======="
-      maven_command_args=("verify" "-Pcoverage")
+      maven_command_args=("install" "-Pcoverage")
     fi
     enable_sonar=true
 
@@ -145,7 +145,7 @@ build_maven() {
 
   elif is_long_lived_feature_branch; then
     echo "======= Build and analyze long lived feature branch $GITHUB_REF_NAME ======="
-    maven_command_args=("verify" "-Pcoverage")
+    maven_command_args=("install" "-Pcoverage")
     enable_sonar=true
 
   else
@@ -156,9 +156,9 @@ build_maven() {
   # Disable deployment when running shadow scans
   if [ "${RUN_SHADOW_SCANS}" = "true" ]; then
     echo "Shadow scans enabled - disabling deployment"
-    # Replace deploy with verify to disable deployment
+    # Replace deploy with install to disable deployment
     if [[ "${maven_command_args[0]}" == "deploy" ]]; then
-      maven_command_args[0]="verify"
+      maven_command_args[0]="install"
       should_deploy=false
       # Remove deploy-specific profiles but keep others
       for i in "${!maven_command_args[@]}"; do

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -302,8 +302,8 @@ Describe 'build_maven()'
       The lines of stdout should equal 5
       The line 1 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
       The line 2 should include "no deploy"
-      The line 3 should start with "Maven command: mvn verify"
-      The line 4 should start with "mvn verify"
+      The line 3 should start with "Maven command: mvn install"
+      The line 4 should start with "mvn install"
       The line 4 should include "-Pcoverage"
       The line 5 should start with "orchestrate_sonar_platforms"
       The line 5 should include "-Dsonar.pullrequest.key=123"
@@ -347,8 +347,8 @@ Describe 'build_maven()'
       When call build_maven
       The lines of stdout should equal 4
       The line 1 should include "Build and analyze long lived feature branch feature/long/some-feature"
-      The line 2 should start with "Maven command: mvn verify"
-      The line 3 should start with "mvn verify"
+      The line 2 should start with "Maven command: mvn install"
+      The line 3 should start with "mvn install"
       The line 3 should include "-Pcoverage"
       The line 4 should start with "orchestrate_sonar_platforms"
     End
@@ -374,7 +374,7 @@ Describe 'build_maven()'
       When call build_maven
       The status should be success
       The output should include "Shadow scans enabled - disabling deployment"
-      The output should include "Maven command: mvn verify"
+      The output should include "Maven command: mvn install"
       The output should not include "Maven command: mvn deploy"
     End
   End


### PR DESCRIPTION
[BUILD-9423](https://sonarsource.atlassian.net/browse/BUILD-9423)

Verify goal is not enough: the artifacts are only available in the Maven reactor, then eventually missing for later calls like sonar scan.


[BUILD-9423]: https://sonarsource.atlassian.net/browse/BUILD-9423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ