### PR TITLE
BUILD-9430 fix DEVELOCITY_TOKEN test

### DIFF
--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -96,7 +96,7 @@ runs:
         echo "ARTIFACTORY_ACCESS_USERNAME=$ARTIFACTORY_USERNAME" >> "$GITHUB_ENV"  # deprecated, backward compliance
         echo "ARTIFACTORY_ACCESS_TOKEN=$ARTIFACTORY_ACCESS_TOKEN" >> "$GITHUB_ENV"
         echo "ARTIFACTORY_PASSWORD=$ARTIFACTORY_ACCESS_TOKEN" >> "$GITHUB_ENV"  # deprecated, backward compliance
-        if [ "DEVELOCITY_TOKEN" != "" ]; then
+        if [[ -n "${DEVELOCITY_TOKEN:-}" ]]; then
           echo "DEVELOCITY_ACCESS_KEY=develocity.sonar.build=$DEVELOCITY_TOKEN" >> "$GITHUB_ENV"
         fi
 


### PR DESCRIPTION
[BUILD-9430](https://sonarsource.atlassian.net/browse/BUILD-9430)

The test was not correct, DEVELOCITY_ACCESS_KEY should not be set.

```
  if [ "DEVELOCITY_TOKEN" != "" ]; then
    echo "DEVELOCITY_ACCESS_KEY=develocity.sonar.build=$DEVELOCITY_TOKEN" >> "$GITHUB_ENV"
  fi
  env:
    DEVELOCITY_TOKEN: 
Run MAVEN_CONFIG="$HOME/.m2"
  env:
    DEVELOCITY_ACCESS_KEY: develocity.sonar.build=
```

Tested with https://github.com/SonarSource/sonar-dummy/pull/502

[BUILD-9430]: https://sonarsource.atlassian.net/browse/BUILD-9430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ