### PR TITLE
BUILD-9445 archive unique name in matrix

### DIFF
--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -198,7 +198,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: problems-report-${{ github.job }}
+        name: problems-report-${{ github.job }}${{ strategy.job-index }}
         path: build/reports/problems/problems-report.html
         if-no-files-found: ignore
 

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -132,7 +132,7 @@ runs:
       if: failure()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: npm-logs-${{ github.job }}
+        name: npm-logs-${{ github.job }}${{ strategy.job-index }}
         path: ~/.npm/_logs/
         if-no-files-found: ignore
 


### PR DESCRIPTION
[BUILD-9445](https://sonarsource.atlassian.net/browse/BUILD-9445)

When used in a matrix, there is a conflict due to multiple artifacts with the same name. The strategy id should be unique.

Tested with:
- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/305
```
Run actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
  with:
    name: problems-report-build0
```

[BUILD-9445]: https://sonarsource.atlassian.net/browse/BUILD-9445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ