### PR TITLE
BUILD-9447 Generation attestation for build actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,14 +894,13 @@ jobs:
 
 The build actions in this repository can automatically generate SLSA build provenance
 attestations for produced artifacts when the build is considered deployable. This feature is
-powered by GitHub's `actions/attest-build-provenance` action. See the upstream documentation:
-[`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance).
+powered by [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance).
 
-Attestations identify the artifact(s) that serve as the subject of the attestation. Our actions
+Attestations identify the artifact(s) that serve as the subject of the attestation. The `build-*` actions
 attempt to discover these subjects automatically using conventional build output locations and
-common file types for each ecosystem. Discovery is only performed when the current context is
-deployable (the same gating used for publication), and the generation is skipped for
-non-deployable contexts.
+common file types for each ecosystem. Automatic discovery runs only when deployment is enabled.
+The attestation step runs when `provenance` parameter is enabled and artifact paths are available (either via
+`provenance-artifact-paths` or from the build output); otherwise, it is skipped.
 
 ### Ecosystem assumptions (automatic discovery)
 
@@ -929,27 +928,27 @@ non-deployable contexts.
   - File types: `*.tgz`
 
 These assumptions are based on widely-used industry conventions and on how artifacts are currently
-published to our Artifactory. They should cover most repositories, but they are not exhaustive.
+published to our Artifactory. They should cover most repositories, but they are not exhaustive. If
+needed, you can customize the paths via the `provenance-artifact-paths` input.
 
-### Strong recommendation: manually specify subjects when needed
+### Manually specify subjects when needed
 
-For complete accuracy, we strongly recommend explicitly specifying the artifacts to attest using
-the `provenance-subject-path` input. This mirrors the upstream `subject-path` input from
-`actions/attest-build-provenance` and may contain a glob pattern or a list of paths (total subject
-count cannot exceed 1024). See upstream docs for details and more examples:
-[`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance).
+For complete accuracy, we recommend explicitly specifying the artifacts to attest using the
+`provenance-artifact-paths` input. Repository owners know best what their build produces, so
+providing explicit paths might be sometimes preferable. `provenance-artifact-paths` is passed to
+`actions/attest-build-provenance` as the `subject-path` input. It may be a glob pattern or a
+newline-separated list of paths (total subject count cannot exceed 1024). See upstream docs for
+details and more examples: [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance).
 
 Example with a build action (same idea applies to other actions):
 
 ```yaml
 - uses: SonarSource/ci-github-actions/build-maven@v1
   with:
-    provenance-subject-path: |
+    provenance-artifact-paths: |
       target/*.jar
       target/*bom.json
 ```
-
-If `provenance-subject-path` is not provided, the automatic discovery described above will be used.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -890,68 +890,6 @@ jobs:
 - Support for different branch types (default, maintenance, PR, dogfood, long-lived feature)
 - Comprehensive build logging and error handling
 
-## Provenance Attestation
-
-The build actions in this repository can automatically generate SLSA build provenance
-attestations for produced artifacts when the build is considered deployable. This feature is
-powered by [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance).
-
-Attestations identify the artifact(s) that serve as the subject of the attestation. The `build-*` actions
-attempt to discover these subjects automatically using conventional build output locations and
-common file types for each ecosystem. Automatic discovery runs only when deployment is enabled.
-The attestation step runs when `provenance` parameter is enabled and artifact paths are available (either via
-`provenance-artifact-paths` or from the build output); otherwise, it is skipped.
-
-### Ecosystem assumptions (automatic discovery)
-
-- Gradle
-  - Locations: `**/build/libs/**`, `**/build/distributions/**`, `**/build/reports/**` (for SBOM JSONs)
-  - File types: `*.jar`, `*.war`, `*.ear`, `*.zip`, `*.tar.gz`, `*.tar`, `*.json`
-  - Exclusions: `*-sources.jar`, `*-javadoc.jar`, `*-tests.jar`
-
-- Maven
-  - Location: `**/<project.build.directory>/**` (queried via Maven); falls back to `target/`
-  - File types: `*.jar`, `*.war`, `*.ear`, `*.zip`, `*.tar.gz`, `*.tar`, `*.pom`, `*.json`
-  - Exclusions: `*-sources.jar`, `*-javadoc.jar`, `*-tests.jar`
-  - Skip rule: if `maven.deploy.skip=true` is effective, attestation is skipped for that module
-
-- Poetry (Python)
-  - Location: `dist/`
-  - File types: `*.whl`, `*.tar.gz`, `*.json`
-
-- NPM
-  - Location: `.attestation-artifacts/`
-  - File types: `*.tgz`
-
-- Yarn
-  - Location: `.attestation-artifacts/`
-  - File types: `*.tgz`
-
-These assumptions are based on widely-used industry conventions and on how artifacts are currently
-published to our Artifactory. They should cover most repositories, but they are not exhaustive. If
-needed, you can customize the paths via the `provenance-artifact-paths` input.
-
-### Manually specify subjects when needed
-
-For complete accuracy, we recommend explicitly specifying the artifacts to attest using the
-`provenance-artifact-paths` input. Repository owners know best what their build produces, so
-providing explicit paths might be sometimes preferable. `provenance-artifact-paths` is passed to
-`actions/attest-build-provenance` as the `subject-path` input. It may be a glob pattern or a
-newline-separated list of paths (total subject count cannot exceed 1024). See upstream docs for
-details and more examples: [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance).
-
-Example with a build action (same idea applies to other actions):
-
-```yaml
-- uses: SonarSource/ci-github-actions/build-maven@v1
-  with:
-    provenance-artifact-paths: |
-      target/*.jar
-      target/*bom.json
-```
-
----
-
 ## `promote`
 
 This action promotes a build in JFrog Artifactory and updates the GitHub status check accordingly.
@@ -1213,6 +1151,68 @@ After running this action, the following environment variables are available:
 - **Unified Caching Strategy**: Single cache key for both smctl and jsign tools to optimize cache efficiency
 - **Smart Cache Management**: Caches smctl installation directory and jsign .deb package for faster subsequent runs
 - **Automatic Setup**: Handles all DigiCert authentication and environment configuration
+
+## Provenance Attestation
+
+The build actions in this repository can automatically generate SLSA build provenance
+attestations for produced artifacts when the build is considered deployable. This feature is
+powered by [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance).
+
+Attestations identify the artifact(s) that serve as the subject of the attestation. The `build-*` actions
+attempt to discover these subjects automatically using conventional build output locations and
+common file types for each ecosystem. Automatic discovery runs only when deployment is enabled.
+The attestation step runs when `provenance` parameter is enabled and artifact paths are available (either via
+`provenance-artifact-paths` or from the build output); otherwise, it is skipped.
+
+### Ecosystem assumptions (automatic discovery)
+
+- Gradle
+  - Locations: `**/build/libs/**`, `**/build/distributions/**`, `**/build/reports/**` (for SBOM JSONs)
+  - File types: `*.jar`, `*.war`, `*.ear`, `*.zip`, `*.tar.gz`, `*.tar`, `*.json`
+  - Exclusions: `*-sources.jar`, `*-javadoc.jar`, `*-tests.jar`
+
+- Maven
+  - Location: `**/<project.build.directory>/**` (queried via Maven); falls back to `target/`
+  - File types: `*.jar`, `*.war`, `*.ear`, `*.zip`, `*.tar.gz`, `*.tar`, `*.pom`, `*.json`
+  - Exclusions: `*-sources.jar`, `*-javadoc.jar`, `*-tests.jar`
+  - Skip rule: if `maven.deploy.skip=true` is effective, attestation is skipped for that module
+
+- Poetry (Python)
+  - Location: `dist/`
+  - File types: `*.whl`, `*.tar.gz`, `*.json`
+
+- NPM
+  - Location: `.attestation-artifacts/`
+  - File types: `*.tgz`
+
+- Yarn
+  - Location: `.attestation-artifacts/`
+  - File types: `*.tgz`
+
+These assumptions are based on widely-used industry conventions and on how artifacts are currently
+published to our Artifactory. They should cover most repositories, but they are not exhaustive. If
+needed, you can customize the paths via the `provenance-artifact-paths` input.
+
+### Manually specify subjects when needed
+
+For complete accuracy, we recommend explicitly specifying the artifacts to attest using the
+`provenance-artifact-paths` input. Repository owners know best what their build produces, so
+providing explicit paths might be sometimes preferable. `provenance-artifact-paths` is passed to
+`actions/attest-build-provenance` as the `subject-path` input. It may be a glob pattern or a
+newline-separated list of paths (total subject count cannot exceed 1024). See upstream docs for
+details and more examples: [`actions/attest-build-provenance`](https://github.com/actions/attest-build-provenance).
+
+Example with a build action (same idea applies to other actions):
+
+```yaml
+- uses: SonarSource/ci-github-actions/build-maven@v1
+  with:
+    provenance-artifact-paths: |
+      target/*.jar
+      target/*bom.json
+```
+
+---
 
 ## Release
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -244,13 +244,10 @@ runs:
         name: problems-report-${{ github.job }}${{ strategy.job-index }}
         path: build/reports/problems/problems-report.html
         if-no-files-found: ignore
-
     - name: Generate provenance attestation
-      if: |
-        ${{
-          inputs.provenance == 'true' &&
-          (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '')
-        }}
+      if: >-
+        ${{ inputs.provenance == 'true' && steps.build.outputs.deployed == 'true' &&
+            (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '') }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
         subject-path: >-

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -58,6 +58,15 @@ inputs:
   disable-caching:
     description: Whether to disable Gradle caching entirely
     default: 'false'
+  generate-provenance:
+    description: Whether to generate provenance attestation for built artifacts
+    default: 'false'
+  provenance-on-pr:
+    description: Developer mode - Allow provenance generation on PRs/branches (bypass master-only restriction)
+    default: 'false'
+  provenance-subject-path:
+    description: Override the default subject-path for provenance attestation (glob pattern)
+    default: ''
 
 outputs:
   project-version:
@@ -230,6 +239,17 @@ runs:
         name: problems-report-${{ github.job }}${{ strategy.job-index }}
         path: build/reports/problems/problems-report.html
         if-no-files-found: ignore
+
+    - name: Generate provenance attestation
+      if: |
+        ${{
+          inputs.generate-provenance == 'true' &&
+          steps.build.outputs.should-deploy == 'true' &&
+          (github.ref_name == github.event.repository.default_branch || inputs.provenance-on-pr == 'true')
+        }}
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: ${{ inputs.provenance-subject-path != '' && inputs.provenance-subject-path || steps.build.outputs.artifact-paths }}
 
     - name: Generate workflow summary
       if: always()

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -58,14 +58,16 @@ inputs:
   disable-caching:
     description: Whether to disable Gradle caching entirely
     default: 'false'
-  generate-provenance:
+  provenance:
     description: Whether to generate provenance attestation for built artifacts
     default: 'false'
-  provenance-on-pr:
-    description: Developer mode - Allow provenance generation on PRs/branches (bypass master-only restriction)
+  provenance-pull-request:
+    description: Whether to generate provenance attestation on pull requests (similar to deploy-pull-request)
     default: 'false'
-  provenance-subject-path:
-    description: Override the default subject-path for provenance attestation (glob pattern)
+  provenance-artifact-paths:
+    description: >-
+      Relative paths of the artifacts for which to generate a provenance attestation (glob pattern).
+      Default is collected from '*/build/libs/*', '*/build/distributions/*', and '*/build/reports/*'
     default: ''
 
 outputs:
@@ -246,12 +248,14 @@ runs:
     - name: Generate provenance attestation
       if: |
         ${{
-          inputs.generate-provenance == 'true' &&
-          (inputs.provenance-subject-path != '' || steps.build.outputs.artifact-paths != '')
+          inputs.provenance == 'true' &&
+          (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '')
         }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
-        subject-path: ${{ inputs.provenance-subject-path != '' && inputs.provenance-subject-path || steps.build.outputs.artifact-paths }}
+        subject-path: >-
+          ${{ inputs.provenance-artifact-paths != '' && inputs.provenance-artifact-paths || steps.build.outputs.artifact-paths }}
+        show-summary: true
 
     - name: Generate workflow summary
       if: always()

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -78,6 +78,9 @@ outputs:
   deployed:
     description: Whether artifacts were deployed
     value: ${{ steps.build.outputs.deployed }}
+  artifact-paths:
+    description: Newline-separated list of artifact paths for provenance attestation
+    value: ${{ steps.build.outputs.artifact-paths }}
 
 runs:
   using: composite
@@ -244,8 +247,7 @@ runs:
       if: |
         ${{
           inputs.generate-provenance == 'true' &&
-          steps.build.outputs.should-deploy == 'true' &&
-          (github.ref_name == github.event.repository.default_branch || inputs.provenance-on-pr == 'true')
+          (inputs.provenance-subject-path != '' || steps.build.outputs.artifact-paths != '')
         }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:

--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -227,6 +227,7 @@ gradle_build_and_analyze() {
   "$GRADLE_CMD" "${gradle_args[@]}"
   if should_deploy; then
     echo "deployed=true" >> "$GITHUB_OUTPUT"
+    export_built_artifacts
   fi
 }
 
@@ -292,7 +293,6 @@ main() {
   set_build_env
   set_project_version
   gradle_build
-  export_built_artifacts
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -263,7 +263,7 @@ export_built_artifacts() {
 
   # Find all built artifacts, excluding sources/javadoc/tests JARs
   local artifacts
-  artifacts=$(find . \( -path '*/build/libs/*' -o -path '*/build/distributions/*' -o -path '*/build/reports/*' \) \
+  artifacts=$(/usr/bin/find . \( -path '*/build/libs/*' -o -path '*/build/distributions/*' -o -path '*/build/reports/*' \) \
     \( -name '*.jar' -o -name '*.war' -o -name '*.ear' -o -name '*.zip' -o -name '*.tar.gz' -o -name '*.tar' -o -name '*.json' \) \
     ! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*-tests.jar' \
     -type f 2>/dev/null | sort -u || true)

--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -259,7 +259,7 @@ export_built_artifacts() {
     return 0
   fi
 
-  echo "=== Capturing built artifacts for attestation ==="
+  echo "::group::Capturing built artifacts for attestation"
 
   # Find all built artifacts, excluding sources/javadoc/tests JARs
   local artifacts
@@ -268,7 +268,11 @@ export_built_artifacts() {
     ! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*-tests.jar' \
     -type f 2>/dev/null | sort -u || true)
 
-  [[ -z "$artifacts" ]] && echo "No artifacts found for attestation" && return 0
+  if [[ -z "$artifacts" ]]; then
+    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
+    echo "::endgroup::"
+    return 0
+  fi
 
   echo "Found artifacts for attestation:"
   echo "$artifacts"
@@ -278,6 +282,8 @@ export_built_artifacts() {
     echo "$artifacts"
     echo "EOF"
   } >> "$GITHUB_OUTPUT"
+
+  echo "::endgroup::"
 }
 
 main() {

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -176,11 +176,9 @@ runs:
         /usr/bin/find "$MAVEN_CONFIG/repository" -name resolver-status.properties -delete
 
     - name: Generate provenance attestation
-      if: |
-        ${{
-          inputs.provenance == 'true' &&
-          (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '')
-        }}
+      if: >-
+        ${{ inputs.provenance == 'true' && steps.build.outputs.deployed == 'true' &&
+            (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '') }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
         subject-path: >-

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -74,6 +74,9 @@ outputs:
   deployed:
     description: Whether artifacts were deployed
     value: ${{ steps.build.outputs.deployed }}
+  artifact-paths:
+    description: Newline-separated list of artifact paths for provenance attestation
+    value: ${{ steps.build.outputs.artifact-paths }}
 
 runs:
   using: composite
@@ -174,8 +177,7 @@ runs:
       if: |
         ${{
           inputs.generate-provenance == 'true' &&
-          steps.build.outputs.should-deploy == 'true' &&
-          (github.ref_name == github.event.repository.default_branch || inputs.provenance-on-pr == 'true')
+          (inputs.provenance-subject-path != '' || steps.build.outputs.artifact-paths != '')
         }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -58,14 +58,16 @@ inputs:
   disable-caching:
     description: Whether to disable Maven caching entirely
     default: 'false'
-  generate-provenance:
+  provenance:
     description: Whether to generate provenance attestation for built artifacts
     default: 'false'
-  provenance-on-pr:
-    description: Developer mode - Allow provenance generation on PRs/branches (bypass master-only restriction)
+  provenance-pull-request:
+    description: Whether to generate provenance attestation on pull requests (similar to deploy-pull-request)
     default: 'false'
-  provenance-subject-path:
-    description: Override the default subject-path for provenance attestation (glob pattern)
+  provenance-artifact-paths:
+    description: >-
+      Relative paths of the artifacts for which to generate a provenance attestation (glob pattern).
+      Default is collected from '*/target/*' (or custom build directory from pom.xml)
     default: ''
 outputs:
   BUILD_NUMBER:
@@ -176,12 +178,14 @@ runs:
     - name: Generate provenance attestation
       if: |
         ${{
-          inputs.generate-provenance == 'true' &&
-          (inputs.provenance-subject-path != '' || steps.build.outputs.artifact-paths != '')
+          inputs.provenance == 'true' &&
+          (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '')
         }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
-        subject-path: ${{ inputs.provenance-subject-path != '' && inputs.provenance-subject-path || steps.build.outputs.artifact-paths }}
+        subject-path: >-
+          ${{ inputs.provenance-artifact-paths != '' && inputs.provenance-artifact-paths || steps.build.outputs.artifact-paths }}
+        show-summary: true
 
     - name: Generate workflow summary
       if: always()

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -58,6 +58,15 @@ inputs:
   disable-caching:
     description: Whether to disable Maven caching entirely
     default: 'false'
+  generate-provenance:
+    description: Whether to generate provenance attestation for built artifacts
+    default: 'false'
+  provenance-on-pr:
+    description: Developer mode - Allow provenance generation on PRs/branches (bypass master-only restriction)
+    default: 'false'
+  provenance-subject-path:
+    description: Override the default subject-path for provenance attestation (glob pattern)
+    default: ''
 outputs:
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
@@ -160,6 +169,17 @@ runs:
         rm -rf "$MAVEN_CONFIG/repository/org/sonarsource/"
         rm -rf "$MAVEN_CONFIG/repository/com/sonarsource/"
         /usr/bin/find "$MAVEN_CONFIG/repository" -name resolver-status.properties -delete
+
+    - name: Generate provenance attestation
+      if: |
+        ${{
+          inputs.generate-provenance == 'true' &&
+          steps.build.outputs.should-deploy == 'true' &&
+          (github.ref_name == github.event.repository.default_branch || inputs.provenance-on-pr == 'true')
+        }}
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: ${{ inputs.provenance-subject-path != '' && inputs.provenance-subject-path || steps.build.outputs.artifact-paths }}
 
     - name: Generate workflow summary
       if: always()

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -174,6 +174,7 @@ build_maven() {
 
   if should_deploy; then
     echo "deployed=true" >> "$GITHUB_OUTPUT"
+    export_built_artifacts
   fi
 
   # Execute SonarQube analysis if enabled
@@ -237,5 +238,4 @@ export_built_artifacts() {
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   build_maven "$@"
-  export_built_artifacts
 fi

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -203,11 +203,20 @@ export_built_artifacts() {
   echo "Scanning for artifacts in: */${build_dir}/*"
 
   # Find all built artifacts (excluding sources, javadoc, tests)
-  local artifacts
-  artifacts=$(/usr/bin/find . -path "*/${build_dir}/*" \
+  local artifacts find_bin
+  find_bin="/bin/find"
+  if [[ ! -x "$find_bin" ]]; then
+    find_bin="/usr/bin/find"
+  fi
+  artifacts=$("$find_bin" . -path "*/${build_dir}/*" \
     \( -name '*.jar' -o -name '*.war' -o -name '*.ear' -o -name '*.zip' -o -name '*.tar.gz' -o -name '*.tar' -o -name '*.pom' -o -name '*.asc' -o -name '*.json' \) \
     ! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*-tests.jar' \
-    -type f 2>/dev/null | sort -u || true)
+    -type f 2>/dev/null)
+
+  # Sort and deduplicate (avoid Windows sort.exe)
+  if [[ -n "$artifacts" ]]; then
+    artifacts=$(echo "$artifacts" | /usr/bin/sort -u)
+  fi
 
   if [[ -z "$artifacts" ]]; then
     echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -212,7 +212,7 @@ export_built_artifacts() {
 
   # Find all built artifacts (excluding sources, javadoc, tests)
   local artifacts
-  artifacts=$(find . -path "*/${build_dir}/*" \
+  artifacts=$(/usr/bin/find . -path "*/${build_dir}/*" \
     \( -name '*.jar' -o -name '*.war' -o -name '*.ear' -o -name '*.zip' -o -name '*.tar.gz' -o -name '*.tar' -o -name '*.pom' -o -name '*.asc' -o -name '*.json' \) \
     ! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*-tests.jar' \
     -type f 2>/dev/null || true)

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -197,15 +197,6 @@ export_built_artifacts() {
 
   echo "::group::Capturing built artifacts for attestation"
 
-  # Check if maven.deploy.skip is set to true (modules not meant for deployment)
-  local deploy_skip
-  deploy_skip=$(mvn help:evaluate -Dexpression=maven.deploy.skip -q -DforceStdout 2>/dev/null || echo "false")
-  if [[ "$deploy_skip" == "true" ]]; then
-    echo "maven.deploy.skip=true detected - skipping attestation for non-deployable module"
-    echo "::endgroup::"
-    return 0
-  fi
-
   # Query Maven for build directory name, fallback to 'target'
   local build_dir
   build_dir=$(mvn help:evaluate -Dexpression=project.build.directory -q -DforceStdout 2>/dev/null | xargs basename 2>/dev/null || echo "target")
@@ -216,7 +207,7 @@ export_built_artifacts() {
   artifacts=$(/usr/bin/find . -path "*/${build_dir}/*" \
     \( -name '*.jar' -o -name '*.war' -o -name '*.ear' -o -name '*.zip' -o -name '*.tar.gz' -o -name '*.tar' -o -name '*.pom' -o -name '*.asc' -o -name '*.json' \) \
     ! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*-tests.jar' \
-    -type f 2>/dev/null || true)
+    -type f 2>/dev/null | sort -u || true)
 
   if [[ -z "$artifacts" ]]; then
     echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -190,9 +190,9 @@ build_maven() {
 }
 
 export_built_artifacts() {
-  local should_deploy
-  should_deploy=$(grep "should-deploy=" "$GITHUB_OUTPUT" 2>/dev/null | cut -d= -f2)
-  [[ "$should_deploy" != "true" ]] && return 0
+  local deployed
+  deployed=$(grep "deployed=" "$GITHUB_OUTPUT" 2>/dev/null | cut -d= -f2)
+  [[ "$deployed" != "true" ]] && return 0
 
   echo "=== Capturing built artifacts for attestation ==="
 

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -62,6 +62,12 @@ outputs:
   project-version:
     description: The project version with build number (after replacement). Also set as environment variable PROJECT_VERSION.
     value: ${{ steps.config.outputs.project-version }}
+  deployed:
+    description: Whether artifacts were deployed
+    value: ${{ steps.build.outputs.deployed }}
+  artifact-paths:
+    description: Newline-separated list of artifact paths for provenance attestation
+    value: ${{ steps.build.outputs.artifact-paths }}
 
 runs:
   using: composite
@@ -166,8 +172,7 @@ runs:
       if: |
         ${{
           inputs.generate-provenance == 'true' &&
-          steps.build.outputs.should-deploy == 'true' &&
-          (github.ref_name == github.event.repository.default_branch || inputs.provenance-on-pr == 'true')
+          (inputs.provenance-subject-path != '' || steps.build.outputs.artifact-paths != '')
         }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -171,11 +171,9 @@ runs:
         if-no-files-found: ignore
 
     - name: Generate provenance attestation
-      if: |
-        ${{
-          inputs.provenance == 'true' &&
-          (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '')
-        }}
+      if: >-
+        ${{ inputs.provenance == 'true' && steps.build.outputs.deployed == 'true' &&
+            (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '') }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
         subject-path: >-

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -42,6 +42,15 @@ inputs:
   build-name:
     description: Name of the build to publish. Defaults to the repository name.
     default: ''
+  generate-provenance:
+    description: Whether to generate provenance attestation for built artifacts
+    default: 'false'
+  provenance-on-pr:
+    description: Developer mode - Allow provenance generation on PRs/branches (bypass master-only restriction)
+    default: 'false'
+  provenance-subject-path:
+    description: Override the default subject-path for provenance attestation (glob pattern)
+    default: ''
 
 outputs:
   BUILD_NUMBER:
@@ -152,6 +161,17 @@ runs:
         name: npm-logs-${{ github.job }}${{ strategy.job-index }}
         path: ~/.npm/_logs/
         if-no-files-found: ignore
+
+    - name: Generate provenance attestation
+      if: |
+        ${{
+          inputs.generate-provenance == 'true' &&
+          steps.build.outputs.should-deploy == 'true' &&
+          (github.ref_name == github.event.repository.default_branch || inputs.provenance-on-pr == 'true')
+        }}
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: ${{ inputs.provenance-subject-path != '' && inputs.provenance-subject-path || steps.build.outputs.artifact-paths }}
 
     - name: Generate workflow summary
       if: always()

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -42,14 +42,16 @@ inputs:
   build-name:
     description: Name of the build to publish. Defaults to the repository name.
     default: ''
-  generate-provenance:
+  provenance:
     description: Whether to generate provenance attestation for built artifacts
     default: 'false'
-  provenance-on-pr:
-    description: Developer mode - Allow provenance generation on PRs/branches (bypass master-only restriction)
+  provenance-pull-request:
+    description: Whether to generate provenance attestation on pull requests (similar to deploy-pull-request)
     default: 'false'
-  provenance-subject-path:
-    description: Override the default subject-path for provenance attestation (glob pattern)
+  provenance-artifact-paths:
+    description: >-
+      Relative paths of the artifacts for which to generate a provenance attestation (glob pattern).
+      Default is collected from '.attestation-artifacts/' directory
     default: ''
 
 outputs:
@@ -171,12 +173,14 @@ runs:
     - name: Generate provenance attestation
       if: |
         ${{
-          inputs.generate-provenance == 'true' &&
-          (inputs.provenance-subject-path != '' || steps.build.outputs.artifact-paths != '')
+          inputs.provenance == 'true' &&
+          (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '')
         }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
-        subject-path: ${{ inputs.provenance-subject-path != '' && inputs.provenance-subject-path || steps.build.outputs.artifact-paths }}
+        subject-path: >-
+          ${{ inputs.provenance-artifact-paths != '' && inputs.provenance-artifact-paths || steps.build.outputs.artifact-paths }}
+        show-summary: true
 
     - name: Generate workflow summary
       if: always()

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -176,7 +176,9 @@ get_build_config() {
     enable_deploy=false
   fi
 
-  echo "should-deploy=$enable_deploy" >> "$GITHUB_OUTPUT"
+  if [ "$enable_deploy" = "true" ]; then
+    echo "deployed=true" >> "$GITHUB_OUTPUT"
+  fi
   # Export the configuration for use by run_standard_pipeline
   export BUILD_ENABLE_SONAR="$enable_sonar"
   export BUILD_ENABLE_DEPLOY="$enable_deploy"
@@ -223,9 +225,9 @@ build_npm() {
 }
 
 export_built_artifacts() {
-  local should_deploy
-  should_deploy=$(grep "should-deploy=" "$GITHUB_OUTPUT" 2>/dev/null | cut -d= -f2)
-  [[ "$should_deploy" != "true" ]] && return 0
+  local deployed
+  deployed=$(grep "deployed=" "$GITHUB_OUTPUT" 2>/dev/null | cut -d= -f2)
+  [[ "$deployed" != "true" ]] && return 0
 
   echo "=== Capturing built artifacts for attestation ==="
 

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -232,7 +232,7 @@ export_built_artifacts() {
   echo "::group::Capturing built artifacts for attestation"
 
   local artifacts
-  artifacts=$(find .attestation-artifacts -name '*.tgz' -type f 2>/dev/null || true)
+  artifacts=$(/usr/bin/find .attestation-artifacts -name '*.tgz' -type f 2>/dev/null || true)
 
   if [[ -z "$artifacts" ]]; then
     echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -232,8 +232,12 @@ export_built_artifacts() {
 
   echo "::group::Capturing built artifacts for attestation"
 
-  local artifacts
-  artifacts=$(/usr/bin/find .attestation-artifacts -name '*.tgz' -type f 2>/dev/null || true)
+  local artifacts find_bin
+  find_bin="/bin/find"
+  if [[ ! -x "$find_bin" ]]; then
+    find_bin="/usr/bin/find"
+  fi
+  artifacts=$("$find_bin" .attestation-artifacts -name '*.tgz' -type f 2>/dev/null || true)
 
   if [[ -z "$artifacts" ]]; then
     echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -171,12 +171,12 @@ get_build_config() {
   fi
 
   # Disable deployment when shadow scans are enabled to prevent duplicate artifacts
-  if [ "${RUN_SHADOW_SCANS}" = "true" ]; then
+  if [[ "${RUN_SHADOW_SCANS}" = "true" ]]; then
     echo "======= Shadow scans enabled - disabling deployment to prevent duplicate artifacts ======="
     enable_deploy=false
   fi
 
-  if [ "$enable_deploy" = "true" ]; then
+  if [[ "$enable_deploy" = "true" ]]; then
     echo "deployed=true" >> "$GITHUB_OUTPUT"
   fi
   # Export the configuration for use by run_standard_pipeline

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -208,6 +208,7 @@ run_standard_pipeline() {
 
   if [ "${BUILD_ENABLE_DEPLOY}" = "true" ]; then
     jfrog_npm_publish
+    export_built_artifacts
   fi
 }
 
@@ -260,7 +261,6 @@ main() {
   git_fetch_unshallow
   echo "::group::Build"
   build_npm
-  export_built_artifacts
   echo "::endgroup::"
 }
 

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -229,12 +229,16 @@ export_built_artifacts() {
   deployed=$(grep "deployed=" "$GITHUB_OUTPUT" 2>/dev/null | cut -d= -f2)
   [[ "$deployed" != "true" ]] && return 0
 
-  echo "=== Capturing built artifacts for attestation ==="
+  echo "::group::Capturing built artifacts for attestation"
 
   local artifacts
   artifacts=$(find .attestation-artifacts -name '*.tgz' -type f 2>/dev/null || true)
 
-  [[ -z "$artifacts" ]] && echo "No artifacts found for attestation" && return 0
+  if [[ -z "$artifacts" ]]; then
+    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
+    echo "::endgroup::"
+    return 0
+  fi
 
   echo "Found artifact(s) for attestation:"
   echo "$artifacts"
@@ -243,6 +247,8 @@ export_built_artifacts() {
     echo "$artifacts"
     echo "EOF"
   } >> "$GITHUB_OUTPUT"
+
+  echo "::endgroup::"
 }
 
 main() {

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -60,6 +60,12 @@ outputs:
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
     value: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
+  deployed:
+    description: Whether artifacts were deployed
+    value: ${{ steps.build.outputs.deployed }}
+  artifact-paths:
+    description: Newline-separated list of artifact paths for provenance attestation
+    value: ${{ steps.build.outputs.artifact-paths }}
 
 runs:
   using: composite
@@ -159,8 +165,7 @@ runs:
       if: |
         ${{
           inputs.generate-provenance == 'true' &&
-          steps.build.outputs.should-deploy == 'true' &&
-          (github.ref_name == github.event.repository.default_branch || inputs.provenance-on-pr == 'true')
+          (inputs.provenance-subject-path != '' || steps.build.outputs.artifact-paths != '')
         }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -43,14 +43,16 @@ inputs:
   working-directory:
     description: Relative path under github.workspace to execute the build in
     default: .
-  generate-provenance:
+  provenance:
     description: Whether to generate provenance attestation for built artifacts
     default: 'false'
-  provenance-on-pr:
-    description: Developer mode - Allow provenance generation on PRs/branches (bypass master-only restriction)
+  provenance-pull-request:
+    description: Whether to generate provenance attestation on pull requests (similar to deploy-pull-request)
     default: 'false'
-  provenance-subject-path:
-    description: Override the default subject-path for provenance attestation (glob pattern)
+  provenance-artifact-paths:
+    description: >-
+      Relative paths of the artifacts for which to generate a provenance attestation (glob pattern).
+      Default is collected from 'dist/' directory
     default: ''
 
 outputs:
@@ -164,12 +166,14 @@ runs:
     - name: Generate provenance attestation
       if: |
         ${{
-          inputs.generate-provenance == 'true' &&
-          (inputs.provenance-subject-path != '' || steps.build.outputs.artifact-paths != '')
+          inputs.provenance == 'true' &&
+          (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '')
         }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
-        subject-path: ${{ inputs.provenance-subject-path != '' && inputs.provenance-subject-path || steps.build.outputs.artifact-paths }}
+        subject-path: >-
+          ${{ inputs.provenance-artifact-paths != '' && inputs.provenance-artifact-paths || steps.build.outputs.artifact-paths }}
+        show-summary: true
 
     - name: Generate workflow summary
       if: always()

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -164,11 +164,9 @@ runs:
         "$ACTION_PATH_BUILD_POETRY/build.sh"
 
     - name: Generate provenance attestation
-      if: |
-        ${{
-          inputs.provenance == 'true' &&
-          (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '')
-        }}
+      if: >-
+        ${{ inputs.provenance == 'true' && steps.build.outputs.deployed == 'true' &&
+            (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '') }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
         subject-path: >-

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -43,6 +43,15 @@ inputs:
   working-directory:
     description: Relative path under github.workspace to execute the build in
     default: .
+  generate-provenance:
+    description: Whether to generate provenance attestation for built artifacts
+    default: 'false'
+  provenance-on-pr:
+    description: Developer mode - Allow provenance generation on PRs/branches (bypass master-only restriction)
+    default: 'false'
+  provenance-subject-path:
+    description: Override the default subject-path for provenance attestation (glob pattern)
+    default: ''
 
 outputs:
   project-version:
@@ -145,6 +154,17 @@ runs:
       run: |
         cd "${{ inputs.working-directory }}"
         "$ACTION_PATH_BUILD_POETRY/build.sh"
+
+    - name: Generate provenance attestation
+      if: |
+        ${{
+          inputs.generate-provenance == 'true' &&
+          steps.build.outputs.should-deploy == 'true' &&
+          (github.ref_name == github.event.repository.default_branch || inputs.provenance-on-pr == 'true')
+        }}
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: ${{ inputs.provenance-subject-path != '' && inputs.provenance-subject-path || steps.build.outputs.artifact-paths }}
 
     - name: Generate workflow summary
       if: always()

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -308,7 +308,7 @@ export_built_artifacts() {
   echo "::group::Capturing built artifacts for attestation"
 
   local artifacts
-  artifacts=$(find dist -type f \( -name '*.tar.gz' -o -name '*.whl' -o -name '*.json' \) 2>/dev/null || true)
+  artifacts=$(/usr/bin/find dist -type f \( -name '*.tar.gz' -o -name '*.whl' -o -name '*.json' \) 2>/dev/null || true)
 
   if [[ -z "$artifacts" ]]; then
     echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -305,12 +305,16 @@ export_built_artifacts() {
   deployed=$(grep "deployed=" "$GITHUB_OUTPUT" 2>/dev/null | cut -d= -f2)
   [[ "$deployed" != "true" ]] && return 0
 
-  echo "=== Capturing built artifacts for attestation ==="
+  echo "::group::Capturing built artifacts for attestation"
 
   local artifacts
   artifacts=$(find dist -type f \( -name '*.tar.gz' -o -name '*.whl' -o -name '*.json' \) 2>/dev/null || true)
 
-  [[ -z "$artifacts" ]] && echo "No artifacts found for attestation" && return 0
+  if [[ -z "$artifacts" ]]; then
+    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
+    echo "::endgroup::"
+    return 0
+  fi
 
   echo "Found artifacts for attestation:"
   echo "$artifacts"
@@ -320,6 +324,8 @@ export_built_artifacts() {
     echo "$artifacts"
     echo "EOF"
   } >> "$GITHUB_OUTPUT"
+
+  echo "::endgroup::"
 }
 
 main() {

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -246,7 +246,9 @@ get_build_config() {
   # Export the configuration for use by build_poetry
   export BUILD_ENABLE_SONAR="$enable_sonar"
   export BUILD_ENABLE_DEPLOY="$enable_deploy"
-  echo "should-deploy=$enable_deploy" >> "$GITHUB_OUTPUT"
+  if [ "$enable_deploy" = "true" ]; then
+    echo "deployed=true" >> "$GITHUB_OUTPUT"
+  fi
   export BUILD_SONAR_ARGS="${sonar_args[*]:-}"
 }
 
@@ -299,9 +301,9 @@ build_poetry() {
 }
 
 export_built_artifacts() {
-  local should_deploy
-  should_deploy=$(grep "should-deploy=" "$GITHUB_OUTPUT" 2>/dev/null | cut -d= -f2)
-  [[ "$should_deploy" != "true" ]] && return 0
+  local deployed
+  deployed=$(grep "deployed=" "$GITHUB_OUTPUT" 2>/dev/null | cut -d= -f2)
+  [[ "$deployed" != "true" ]] && return 0
 
   echo "=== Capturing built artifacts for attestation ==="
 

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -295,6 +295,7 @@ build_poetry() {
 
   if [ "${BUILD_ENABLE_DEPLOY}" = "true" ]; then
     jfrog_poetry_publish
+    export_built_artifacts
   fi
 
   echo "=== Build completed successfully ==="
@@ -336,7 +337,6 @@ main() {
 
   set_build_env
   build_poetry
-  export_built_artifacts
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -246,7 +246,7 @@ get_build_config() {
   # Export the configuration for use by build_poetry
   export BUILD_ENABLE_SONAR="$enable_sonar"
   export BUILD_ENABLE_DEPLOY="$enable_deploy"
-  if [ "$enable_deploy" = "true" ]; then
+  if [[ "$enable_deploy" = "true" ]]; then
     echo "deployed=true" >> "$GITHUB_OUTPUT"
   fi
   export BUILD_SONAR_ARGS="${sonar_args[*]:-}"

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -308,8 +308,12 @@ export_built_artifacts() {
 
   echo "::group::Capturing built artifacts for attestation"
 
-  local artifacts
-  artifacts=$(/usr/bin/find dist -type f \( -name '*.tar.gz' -o -name '*.whl' -o -name '*.json' \) 2>/dev/null || true)
+  local artifacts find_bin
+  find_bin="/bin/find"
+  if [[ ! -x "$find_bin" ]]; then
+    find_bin="/usr/bin/find"
+  fi
+  artifacts=$("$find_bin" dist -type f \( -name '*.tar.gz' -o -name '*.whl' -o -name '*.json' \) 2>/dev/null || true)
 
   if [[ -z "$artifacts" ]]; then
     echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -40,6 +40,15 @@ inputs:
      If false, run on the platform provided by SONAR_PLATFORM.
     default: 'false'
 
+  generate-provenance:
+    description: Whether to generate provenance attestation for built artifacts
+    default: 'false'
+  provenance-on-pr:
+    description: Developer mode - Allow provenance generation on PRs/branches (bypass master-only restriction)
+    default: 'false'
+  provenance-subject-path:
+    description: Override the default subject-path for provenance attestation (glob pattern)
+    default: ''
 outputs:
   project-version:
     description: The project version from package.json
@@ -145,6 +154,17 @@ runs:
         RUN_SHADOW_SCANS: ${{ inputs.run-shadow-scans }}
       run: $ACTION_PATH_BUILD_YARN/build.sh
 
+
+    - name: Generate provenance attestation
+      if: |
+        ${{
+          inputs.generate-provenance == 'true' &&
+          steps.build.outputs.should-deploy == 'true' &&
+          (github.ref_name == github.event.repository.default_branch || inputs.provenance-on-pr == 'true')
+        }}
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+      with:
+        subject-path: ${{ inputs.provenance-subject-path != '' && inputs.provenance-subject-path || steps.build.outputs.artifact-paths }}
     - name: Generate workflow summary
       if: always()
       shell: bash

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -56,6 +56,12 @@ outputs:
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
     value: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
+  deployed:
+    description: Whether artifacts were deployed
+    value: ${{ steps.build.outputs.deployed }}
+  artifact-paths:
+    description: Newline-separated list of artifact paths for provenance attestation
+    value: ${{ steps.build.outputs.artifact-paths }}
 
 runs:
   using: composite
@@ -159,8 +165,7 @@ runs:
       if: |
         ${{
           inputs.generate-provenance == 'true' &&
-          steps.build.outputs.should-deploy == 'true' &&
-          (github.ref_name == github.event.repository.default_branch || inputs.provenance-on-pr == 'true')
+          (inputs.provenance-subject-path != '' || steps.build.outputs.artifact-paths != '')
         }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -39,15 +39,16 @@ inputs:
     description: If true, run sonar scanner on all 3 platforms using the provided URL and token.
      If false, run on the platform provided by SONAR_PLATFORM.
     default: 'false'
-
-  generate-provenance:
+  provenance:
     description: Whether to generate provenance attestation for built artifacts
     default: 'false'
-  provenance-on-pr:
-    description: Developer mode - Allow provenance generation on PRs/branches (bypass master-only restriction)
+  provenance-pull-request:
+    description: Whether to generate provenance attestation on pull requests (similar to deploy-pull-request)
     default: 'false'
-  provenance-subject-path:
-    description: Override the default subject-path for provenance attestation (glob pattern)
+  provenance-artifact-paths:
+    description: >-
+      Relative paths of the artifacts for which to generate a provenance attestation (glob pattern).
+      Default is collected from '.attestation-artifacts/' directory
     default: ''
 outputs:
   project-version:
@@ -164,12 +165,14 @@ runs:
     - name: Generate provenance attestation
       if: |
         ${{
-          inputs.generate-provenance == 'true' &&
-          (inputs.provenance-subject-path != '' || steps.build.outputs.artifact-paths != '')
+          inputs.provenance == 'true' &&
+          (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '')
         }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
-        subject-path: ${{ inputs.provenance-subject-path != '' && inputs.provenance-subject-path || steps.build.outputs.artifact-paths }}
+        subject-path: >-
+          ${{ inputs.provenance-artifact-paths != '' && inputs.provenance-artifact-paths || steps.build.outputs.artifact-paths }}
+        show-summary: true
     - name: Generate workflow summary
       if: always()
       shell: bash

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -160,14 +160,10 @@ runs:
         SONAR_PLATFORM: ${{ inputs.sonar-platform }}
         RUN_SHADOW_SCANS: ${{ inputs.run-shadow-scans }}
       run: $ACTION_PATH_BUILD_YARN/build.sh
-
-
     - name: Generate provenance attestation
-      if: |
-        ${{
-          inputs.provenance == 'true' &&
-          (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '')
-        }}
+      if: >-
+        ${{ inputs.provenance == 'true' && steps.build.outputs.deployed == 'true' &&
+            (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '') }}
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
         subject-path: >-

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -228,12 +228,12 @@ get_build_config() {
   fi
 
   # Disable deployment when shadow scans are enabled to prevent duplicate artifacts
-  if [ "${RUN_SHADOW_SCANS}" = "true" ]; then
+  if [[ "${RUN_SHADOW_SCANS}" = "true" ]]; then
     echo "======= Shadow scans enabled - disabling deployment to prevent duplicate artifacts ======="
     enable_deploy=false
   fi
 
-  if [ "$enable_deploy" = "true" ]; then
+  if [[ "$enable_deploy" = "true" ]]; then
     echo "deployed=true" >> "$GITHUB_OUTPUT"
   fi
   # Export the configuration for use by run_standard_pipeline

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -233,7 +233,9 @@ get_build_config() {
     enable_deploy=false
   fi
 
-  echo "should-deploy=$enable_deploy" >> "$GITHUB_OUTPUT"
+  if [ "$enable_deploy" = "true" ]; then
+    echo "deployed=true" >> "$GITHUB_OUTPUT"
+  fi
   # Export the configuration for use by run_standard_pipeline
   export BUILD_ENABLE_SONAR="$enable_sonar"
   export BUILD_ENABLE_DEPLOY="$enable_deploy"
@@ -283,9 +285,9 @@ build_yarn() {
 }
 
 export_built_artifacts() {
-  local should_deploy
-  should_deploy=$(grep "should-deploy=" "$GITHUB_OUTPUT" 2>/dev/null | cut -d= -f2)
-  [[ "$should_deploy" != "true" ]] && return 0
+  local deployed
+  deployed=$(grep "deployed=" "$GITHUB_OUTPUT" 2>/dev/null | cut -d= -f2)
+  [[ "$deployed" != "true" ]] && return 0
 
   echo "=== Capturing built artifacts for attestation ==="
 

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -265,6 +265,7 @@ run_standard_pipeline() {
 
   if [ "${BUILD_ENABLE_DEPLOY}" = "true" ]; then
     jfrog_yarn_publish
+    export_built_artifacts
   fi
 }
 
@@ -317,7 +318,6 @@ main() {
   check_tool yarn --version
   set_build_env
   build_yarn
-  export_built_artifacts
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -292,7 +292,7 @@ export_built_artifacts() {
   echo "::group::Capturing built artifacts for attestation"
 
   local artifacts
-  artifacts=$(find .attestation-artifacts -name '*.tgz' -type f 2>/dev/null || true)
+  artifacts=$(/usr/bin/find .attestation-artifacts -name '*.tgz' -type f 2>/dev/null || true)
 
   if [[ -z "$artifacts" ]]; then
     echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -289,12 +289,16 @@ export_built_artifacts() {
   deployed=$(grep "deployed=" "$GITHUB_OUTPUT" 2>/dev/null | cut -d= -f2)
   [[ "$deployed" != "true" ]] && return 0
 
-  echo "=== Capturing built artifacts for attestation ==="
+  echo "::group::Capturing built artifacts for attestation"
 
   local artifacts
   artifacts=$(find .attestation-artifacts -name '*.tgz' -type f 2>/dev/null || true)
 
-  [[ -z "$artifacts" ]] && echo "No artifacts found for attestation" && return 0
+  if [[ -z "$artifacts" ]]; then
+    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
+    echo "::endgroup::"
+    return 0
+  fi
 
   echo "Found artifact(s) for attestation:"
   echo "$artifacts"
@@ -303,6 +307,8 @@ export_built_artifacts() {
     echo "$artifacts"
     echo "EOF"
   } >> "$GITHUB_OUTPUT"
+
+  echo "::endgroup::"
 }
 
 main() {

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -292,8 +292,12 @@ export_built_artifacts() {
 
   echo "::group::Capturing built artifacts for attestation"
 
-  local artifacts
-  artifacts=$(/usr/bin/find .attestation-artifacts -name '*.tgz' -type f 2>/dev/null || true)
+  local artifacts find_bin
+  find_bin="/bin/find"
+  if [[ ! -x "$find_bin" ]]; then
+    find_bin="/usr/bin/find"
+  fi
+  artifacts=$("$find_bin" .attestation-artifacts -name '*.tgz' -type f 2>/dev/null || true)
 
   if [[ -z "$artifacts" ]]; then
     echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -407,6 +407,7 @@ Describe 'sonar_scanner_implementation()'
   It 'runs gradle with sonar for current platform'
     export GRADLE_ARGS=""
     export SONAR_HOST_URL="https://next.sonarqube.com"
+    export DEPLOY="false"
     Mock build_gradle_args
       echo "--no-daemon build sonar"
     End
@@ -442,10 +443,13 @@ Describe 'export_built_artifacts()'
 
     When call export_built_artifacts
     The status should be success
-    The output should include "Capturing built artifacts for attestation"
-    The output should include "Found artifacts for attestation:"
-    The output should include "build/libs/app-1.0.jar"
-    The output should include "build/distributions/app-1.0.zip"
+    The lines of stdout should equal 6
+    The line 1 should equal "::group::Capturing built artifacts for attestation"
+    The line 2 should equal "Found artifacts for attestation:"
+    The line 3 should equal "./build/distributions/app-1.0.zip"
+    The line 4 should equal "./build/libs/app-1.0.jar"
+    The line 5 should equal "./build/reports/dependency-check.json"
+    The line 6 should equal "::endgroup::"
     The contents of file "$GITHUB_OUTPUT" should include "artifact-paths<<EOF"
     The contents of file "$GITHUB_OUTPUT" should include "build/libs/app-1.0.jar"
     The contents of file "$GITHUB_OUTPUT" should include "build/distributions/app-1.0.zip"

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -398,7 +398,7 @@ Describe 'gradle_build'
     The output should include "Gradle executed with:"
     The output should not include "=== ORCHESTRATOR:"
 
-    # Cleanup
+
     rm -f gradle-mock gradle.properties
   End
 End
@@ -429,7 +429,7 @@ Describe 'export_built_artifacts()'
     The status should be success
     The output should be blank
 
-    # Cleanup
+
     rm -rf build
   End
 
@@ -454,7 +454,7 @@ Describe 'export_built_artifacts()'
     The contents of file "$GITHUB_OUTPUT" should include "build/libs/app-1.0.jar"
     The contents of file "$GITHUB_OUTPUT" should include "build/distributions/app-1.0.zip"
 
-    # Cleanup
+
     rm -rf build
   End
 End

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -147,21 +147,24 @@ Describe 'export_built_artifacts()'
         *) echo "mvn $*" ;;
       esac
     End
+    # Ensure should-deploy is detected regardless of file parsing quirks
+    Mock grep
+      echo "should-deploy=true"
+    End
 
     mkdir -p target
     touch target/app-1.0.jar
-    touch target/app-1.0.zip
-    touch target/dependency-check.json
 
     When call export_built_artifacts
     The status should be success
-    The output should include "Capturing built artifacts for attestation"
-    The output should include "Found artifacts for attestation:"
-    The output should include "target/app-1.0.jar"
-    The output should include "target/app-1.0.zip"
+    The lines of stdout should equal 5
+    The line 1 should equal "::group::Capturing built artifacts for attestation"
+    The line 2 should equal "Scanning for artifacts in: */target/*"
+    The line 3 should equal "Found artifacts for attestation:"
+    The line 4 should equal "./target/app-1.0.jar"
+    The line 5 should equal "::endgroup::"
     The contents of file "$GITHUB_OUTPUT" should include "artifact-paths<<EOF"
-    The contents of file "$GITHUB_OUTPUT" should include "target/app-1.0.jar"
-    The contents of file "$GITHUB_OUTPUT" should include "target/app-1.0.zip"
+    The contents of file "$GITHUB_OUTPUT" should include "./target/app-1.0.jar"
 
     rm -rf target "$GITHUB_OUTPUT"
   End

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -60,6 +60,9 @@ Describe 'build-maven/build.sh'
     export HOME
     mkdir -p "$HOME/.m2"
     touch "$HOME/.m2/settings.xml"
+    GITHUB_OUTPUT=$(mktemp)
+    export GITHUB_OUTPUT
+    echo "should-deploy=false" > "$GITHUB_OUTPUT"
     Mock git
       echo "git $*"
     End
@@ -69,6 +72,7 @@ Describe 'build-maven/build.sh'
     When run script build-maven/build.sh
     The status should be success
     The output should include "Maven command: mvn"
+    rm -f "$GITHUB_OUTPUT"
   End
 End
 
@@ -114,6 +118,52 @@ Describe 'build.sh'
       The line 5 should include "Build, no analysis, no deploy"
       The line 6 should include "Maven command: mvn verify"
       The line 7 should match pattern "mvn verify"
+  End
+End
+
+Describe 'export_built_artifacts()'
+  It 'skips silently when should-deploy=false'
+    GITHUB_OUTPUT=$(mktemp)
+    export GITHUB_OUTPUT
+    echo "should-deploy=false" > "$GITHUB_OUTPUT"
+
+    When call export_built_artifacts
+    The status should be success
+    The output should be blank
+
+    rm -f "$GITHUB_OUTPUT"
+  End
+
+  It 'captures artifacts when should-deploy=true and writes to GITHUB_OUTPUT'
+    GITHUB_OUTPUT=$(mktemp)
+    export GITHUB_OUTPUT
+    echo "should-deploy=true" > "$GITHUB_OUTPUT"
+
+    # Mock mvn evaluations used by export_built_artifacts
+    Mock mvn
+      case "$*" in
+        *"help:evaluate -Dexpression=maven.deploy.skip -q -DforceStdout"*) echo "false" ;;
+        *"help:evaluate -Dexpression=project.build.directory -q -DforceStdout"*) echo "target" ;;
+        *) echo "mvn $*" ;;
+      esac
+    End
+
+    mkdir -p target
+    touch target/app-1.0.jar
+    touch target/app-1.0.zip
+    touch target/dependency-check.json
+
+    When call export_built_artifacts
+    The status should be success
+    The output should include "Capturing built artifacts for attestation"
+    The output should include "Found artifacts for attestation:"
+    The output should include "target/app-1.0.jar"
+    The output should include "target/app-1.0.zip"
+    The contents of file "$GITHUB_OUTPUT" should include "artifact-paths<<EOF"
+    The contents of file "$GITHUB_OUTPUT" should include "target/app-1.0.jar"
+    The contents of file "$GITHUB_OUTPUT" should include "target/app-1.0.zip"
+
+    rm -rf target "$GITHUB_OUTPUT"
   End
 End
 

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -241,7 +241,7 @@ Describe 'check_settings_xml()'
     When call check_settings_xml
     The status should be success
     The output should be blank
-    # Cleanup
+
     rm -rf "$temp_home"
   End
 
@@ -254,7 +254,7 @@ Describe 'check_settings_xml()'
     The status should be failure
     The lines of output should equal 1
     The output should include "Missing Maven settings.xml::Maven settings.xml file not found at $HOME/.m2/settings.xml"
-    # Cleanup
+
     rm -rf "$temp_home"
   End
 
@@ -266,7 +266,7 @@ Describe 'check_settings_xml()'
     The status should be failure
     The lines of output should equal 1
     The output should include "Missing Maven settings.xml::Maven settings.xml file not found at $HOME/.m2/settings.xml"
-    # Cleanup
+
     rm -rf "$temp_home"
   End
 End

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -156,13 +156,15 @@ Describe 'export_built_artifacts()'
     rm -rf .attestation-artifacts
     mkdir -p .attestation-artifacts
     touch .attestation-artifacts/test-1.2.3.tgz
-    echo "should-deploy=true" >> "$GITHUB_OUTPUT"
+    echo "deployed=true" >> "$GITHUB_OUTPUT"
 
     When call export_built_artifacts
     The status should be success
-    The output should include "Capturing built artifacts for attestation"
-    The output should include "Found artifact(s) for attestation:"
-    The output should include ".attestation-artifacts/test-1.2.3.tgz"
+    The lines of stdout should equal 4
+    The line 1 should equal "::group::Capturing built artifacts for attestation"
+    The line 2 should equal "Found artifact(s) for attestation:"
+    The line 3 should equal ".attestation-artifacts/test-1.2.3.tgz"
+    The line 4 should equal "::endgroup::"
     The contents of file "$GITHUB_OUTPUT" should include "artifact-paths<<EOF"
     The contents of file "$GITHUB_OUTPUT" should include ".attestation-artifacts/test-1.2.3.tgz"
   End
@@ -173,7 +175,7 @@ Describe 'export_built_artifacts()'
     rm -rf .attestation-artifacts
     mkdir -p .attestation-artifacts
     touch .attestation-artifacts/ignored-1.0.0.tgz
-    echo "should-deploy=false" >> "$GITHUB_OUTPUT"
+    echo "deployed=false" >> "$GITHUB_OUTPUT"
 
     When call export_built_artifacts
     The status should be success

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -150,14 +150,18 @@ Describe 'export_built_artifacts()'
     GITHUB_OUTPUT=$(mktemp)
     export GITHUB_OUTPUT
     echo "should-deploy=true" >> "$GITHUB_OUTPUT"
-    touch dist/pkg-1.0.0.42.whl dist/pkg-1.0.0.42.tar.gz
+    touch dist/pkg-1.0.0.42.whl
+    Mock grep
+      echo "should-deploy=true"
+    End
 
     When call export_built_artifacts
     The status should be success
-    The output should include "=== Capturing built artifacts for attestation ==="
-    The output should include "Found artifacts for attestation:"
-    The output should include "dist/pkg-1.0.0.42.whl"
-    The output should include "dist/pkg-1.0.0.42.tar.gz"
+    The lines of stdout should equal 4
+    The line 1 should equal "::group::Capturing built artifacts for attestation"
+    The line 2 should equal "Found artifacts for attestation:"
+    The line 3 should equal "dist/pkg-1.0.0.42.whl"
+    The line 4 should equal "::endgroup::"
     The contents of file "$GITHUB_OUTPUT" should include "artifact-paths<<EOF"
     The contents of file "$GITHUB_OUTPUT" should include "dist/pkg-1.0.0.42.whl"
   End

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -40,6 +40,9 @@ export SQC_EU_URL="https://sonarcloud.io"
 export SQC_EU_TOKEN="sqc-eu-token"
 export RUN_SHADOW_SCANS="false"
 
+# Constant outputs (exported so mocks run in subshells can access it)
+export JQ_VERSION_OUTPUT="jq-1.8.1"
+
 Describe 'build-poetry/build.sh'
   It 'does not run build_poetry() if the script is sourced'
     When run source build-poetry/build.sh
@@ -58,6 +61,11 @@ Describe 'build-poetry/build.sh'
     Mock git
       echo "git $*"
     End
+    Mock jq
+      echo "$JQ_VERSION_OUTPUT"
+    End
+    GITHUB_OUTPUT=$(mktemp)
+    export GITHUB_OUTPUT
     When run script build-poetry/build.sh
       The status should be success
       The lines of stdout should equal 26
@@ -116,6 +124,54 @@ Describe 'set_build_env()'
     The line 1 should equal "PROJECT: my-repo"
     The line 2 should equal "Fetch main for SonarQube analysis..."
     The variable PROJECT should equal "my-repo"
+  End
+End
+
+Describe 'export_built_artifacts()'
+  setup() {
+    # shellcheck disable=SC2317
+    mkdir -p dist
+    # shellcheck disable=SC2317
+    return 0
+  }
+
+  cleanup() {
+    # shellcheck disable=SC2317
+    [[ -f "$GITHUB_OUTPUT" ]] && rm -f "$GITHUB_OUTPUT"
+    # shellcheck disable=SC2317
+    rm -rf dist
+    # shellcheck disable=SC2317
+    return 0
+  }
+  Before 'setup'
+  After 'cleanup'
+
+  It 'captures built artifacts when deployment is enabled'
+    GITHUB_OUTPUT=$(mktemp)
+    export GITHUB_OUTPUT
+    echo "should-deploy=true" >> "$GITHUB_OUTPUT"
+    touch dist/pkg-1.0.0.42.whl dist/pkg-1.0.0.42.tar.gz
+
+    When call export_built_artifacts
+    The status should be success
+    The output should include "=== Capturing built artifacts for attestation ==="
+    The output should include "Found artifacts for attestation:"
+    The output should include "dist/pkg-1.0.0.42.whl"
+    The output should include "dist/pkg-1.0.0.42.tar.gz"
+    The contents of file "$GITHUB_OUTPUT" should include "artifact-paths<<EOF"
+    The contents of file "$GITHUB_OUTPUT" should include "dist/pkg-1.0.0.42.whl"
+  End
+
+  It 'skips silently when deployment is disabled'
+    GITHUB_OUTPUT=$(mktemp)
+    export GITHUB_OUTPUT
+    echo "should-deploy=false" >> "$GITHUB_OUTPUT"
+    touch dist/ignored.whl
+
+    When call export_built_artifacts
+    The status should be success
+    The output should be blank
+    The contents of file "$GITHUB_OUTPUT" should not include "artifact-paths<<EOF"
   End
 End
 
@@ -225,10 +281,12 @@ End
 
 Describe 'build_poetry()'
   setup() {
+    # shellcheck disable=SC2317
     mkdir -p dist
   }
 
   cleanup() {
+    # shellcheck disable=SC2317
     rm -rf dist
   }
   Before 'setup'
@@ -441,7 +499,7 @@ Describe 'build_poetry()'
   Describe 'main()'
     It 'runs tool checks and calls build_poetry'
       Mock jq
-        echo "jq-1.8.1"
+        echo "$JQ_VERSION_OUTPUT"
       End
       Mock python
         echo "Python 3.11.0"
@@ -458,6 +516,8 @@ Describe 'build_poetry()'
           *) echo "git $*" ;;
         esac
       End
+      GITHUB_OUTPUT=$(mktemp)
+      export GITHUB_OUTPUT
       When run script build-poetry/build.sh
       The status should be success
       The output should include "jq-1.8.1"
@@ -470,7 +530,7 @@ Describe 'build_poetry()'
     It 'executes main when script is run directly'
       # This test ensures the conditional execution path is covered
       Mock jq
-        echo "jq-1.8.1"
+        echo "$JQ_VERSION_OUTPUT"
       End
       Mock python
         echo "Python 3.11.0"
@@ -487,6 +547,8 @@ Describe 'build_poetry()'
           *) echo "git $*" ;;
         esac
       End
+      GITHUB_OUTPUT=$(mktemp)
+      export GITHUB_OUTPUT
       When run script build-poetry/build.sh
       The status should be success
       The output should include "=== Poetry Build, Deploy, and Analyze ==="

--- a/spec/build-yarn_spec.sh
+++ b/spec/build-yarn_spec.sh
@@ -120,12 +120,17 @@ Describe 'build-yarn/build.sh'
       rm -rf .attestation-artifacts
       mkdir -p .attestation-artifacts
       touch .attestation-artifacts/test-1.2.3.tgz
+      Mock grep
+        echo "should-deploy=true"
+      End
 
       When call export_built_artifacts
       The status should be success
-      The output should include "Capturing built artifacts for attestation"
-      The output should include "Found artifact(s) for attestation:"
-      The output should include ".attestation-artifacts/test-1.2.3.tgz"
+      The lines of stdout should equal 4
+      The line 1 should equal "::group::Capturing built artifacts for attestation"
+      The line 2 should equal "Found artifact(s) for attestation:"
+      The line 3 should equal ".attestation-artifacts/test-1.2.3.tgz"
+      The line 4 should equal "::endgroup::"
       The contents of file "$GITHUB_OUTPUT" should include "artifact-paths<<EOF"
       The contents of file "$GITHUB_OUTPUT" should include ".attestation-artifacts/test-1.2.3.tgz"
     End

--- a/spec/build-yarn_spec.sh
+++ b/spec/build-yarn_spec.sh
@@ -114,6 +114,34 @@ Describe 'build-yarn/build.sh'
 
   End
 
+  Describe 'export_built_artifacts()'
+    It 'captures artifacts when should-deploy=true and writes to GITHUB_OUTPUT'
+      echo "should-deploy=true" >> "$GITHUB_OUTPUT"
+      rm -rf .attestation-artifacts
+      mkdir -p .attestation-artifacts
+      touch .attestation-artifacts/test-1.2.3.tgz
+
+      When call export_built_artifacts
+      The status should be success
+      The output should include "Capturing built artifacts for attestation"
+      The output should include "Found artifact(s) for attestation:"
+      The output should include ".attestation-artifacts/test-1.2.3.tgz"
+      The contents of file "$GITHUB_OUTPUT" should include "artifact-paths<<EOF"
+      The contents of file "$GITHUB_OUTPUT" should include ".attestation-artifacts/test-1.2.3.tgz"
+    End
+
+    It 'skips silently when should-deploy=false'
+      echo "should-deploy=false" >> "$GITHUB_OUTPUT"
+      rm -rf .attestation-artifacts
+      mkdir -p .attestation-artifacts
+      touch .attestation-artifacts/ignored-1.0.0.tgz
+
+      When call export_built_artifacts
+      The status should be success
+      The output should be blank
+    End
+  End
+
   Describe 'git_fetch_unshallow()'
     It 'fetches unshallow when shallow'
       unset GITHUB_BASE_REF
@@ -219,15 +247,17 @@ Describe 'build-yarn/build.sh'
       export PROJECT="test"
       When call jfrog_yarn_publish
       The status should be success
-      The lines of output should equal 8
+      The lines of output should equal 10
       The line 1 should include "Configuring JFrog"
       The line 2 should include "jf config"
       The line 3 should include "jf npm-config"
-      The line 4 should include "Publishing Yarn"
-      The line 5 should include "jf npm publish"
-      The line 6 should include "jf rt build-collect-env"
-      The line 7 should include "Publishing build info"
-      The line 8 should include "jf rt build-publish"
+      The line 4 should include "Creating local tarball for attestation"
+      The line 5 should include "yarn pack"
+      The line 6 should include "Publishing Yarn package"
+      The line 7 should include "jf npm publish"
+      The line 8 should include "jf rt build-collect-env"
+      The line 9 should include "Publishing build info"
+      The line 10 should include "jf rt build-publish"
     End
   End
 


### PR DESCRIPTION
### BUILD-9447: Introduce automatic provenance attestation across build actions

#### Overview
This PR introduces automatic SLSA provenance attestation generation across Gradle, Maven, NPM, Poetry, and Yarn build actions. Our goal is to cover ~80% of repositories without requiring teams to specify artifact names manually.

#### What's included
- New attestation step in each build action via `export_built_artifacts`, using ecosystem-appropriate filesystem discovery with standard exclusions (e.g., skip sources/javadoc/tests JARs).
- Attestation gated behind deployability checks (`should_deploy`) to avoid noise on non-deploy branches/PRs.
- Maven: honor `maven.deploy.skip=true` to skip attestation for non-deployable modules.
- ShellSpec tests updated to validate the new behavior with minimal setup.
- No changes to existing build or publish behavior; this only adds attestation generation.

#### Assumptions (by design)
These are industry-standard conventions intended to cover most cases:
- Gradle: artifacts live under `build/libs`, `build/distributions`, optionally `build/reports` (SBOMs).
- Maven: artifacts under `target/` (with support for `project.build.directory`).
- Poetry: built distributions under `dist/`.
- File types: we focus on the most common ones we publish today (e.g., `*.jar`, `*.war`, `*.ear`, `*.zip`, `*.tar.gz`, `*.tar`, `*.json`; plus Maven `*.pom`/`*.asc`, Poetry `*.whl`/`*.tar.gz`, NPM/Yarn `*.tgz`).

These assumptions are deliberate trade‑offs to reach broad coverage quickly. Covering 100% of relevant artifacts would require stronger standardization across repositories (folder layouts, naming conventions, and artifact naming).

#### Recommended path for full accuracy
Teams that need precise control should explicitly provide the artifact paths via the `provenance-subject-path` input, listing the exact files to attest.

#### Validation on 6 repositories
The approach was validated across six repositories (multiple runs for some repos):
- sonar-dummy : https://github.com/SonarSource/sonar-dummy/pull/505
- sonar-dummy-gradle-oss: https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/306
- sonar-go-enterprise: https://github.com/SonarSource/sonar-go-enterprise/pull/575
- sonar-dummy-python-oss: https://github.com/SonarSource/sonar-dummy-python-oss/pull/69
- sonar-dummy-yarn: https://github.com/SonarSource/sonar-dummy-yarn/pull/33
- sonar-dummy-js: https://github.com/SonarSource/sonar-dummy-js/pull/108

Together, these validate Gradle, Maven, Python/Poetry, NPM, and Yarn flows, including default artifact discovery and attestation gating.

