### PR TITLE
BUILD-9519 BUILD-9520 Add a parameter to disable artifact deployment for maven and gradle builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,24 +256,26 @@ See also [`config-maven`](#config-maven) input environment variables.
 | `artifactory-deploy-repo`   | Deployment repository                                                                                                      | `sonarsource-private-qa` for private repositories, `sonarsource-public-qa` for public repos |
 | `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                                                            | `private-reader` for private repos, `public-reader` for public repos                        |
 | `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                                                          | `qa-deployer` for private repos, `public-deployer` for public repos                         |
-| `deploy-pull-request`       | Whether to deploy pull request artifacts                                                                                   | `false`                                                                                     |
+| `deploy`                    | Whether to deploy on master, maintenance, dogfood and long-lived branches                                                  | `true`                                                                                      |
+| `deploy-pull-request`       | Whether to also deploy for pull requests. If deploy is false, this has no effect.                                          | `false`                                                                                     |
 | `maven-args`                | Additional arguments to pass to Maven                                                                                      | (optional)                                                                                  |
 | `scanner-java-opts`         | Additional Java options for the Sonar scanner (`SONAR_SCANNER_JAVA_OPTS`)                                                  | `-Xmx512m`                                                                                  |
 | `repox-url`                 | URL for Repox                                                                                                              | `https://repox.jfrog.io`                                                                    |
 | `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                | (optional)                                                                                  |
 | `use-develocity`            | Whether to use Develocity for build tracking                                                                               | `false`                                                                                     |
 | `develocity-url`            | URL for Develocity                                                                                                         | `https://develocity.sonar.build/`                                                           |
-| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans                        | `next`                                                                                      |
+| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans                         | `next`                                                                                      |
 | `working-directory`         | Relative path under github.workspace to execute the build in                                                               | `.`                                                                                         |
 | `run-shadow-scans`          | If true, run SonarQube analysis on all 3 platforms (next, sqc-eu, sqc-us); if false, only on the selected `sonar-platform` | `false`                                                                                     |
-| `cache-paths`                 | Custom cache paths (multiline). Overrides default `~/.m2/repository`.                        | (optional)                                                           |
-| `disable-caching`             | Whether to disable Maven caching entirely                                                                                  | `false`                                                              |
+| `cache-paths`               | Custom cache paths (multiline). Overrides default `~/.m2/repository`.                                                      | (optional)                                                                                  |
+| `disable-caching`           | Whether to disable Maven caching entirely                                                                                  | `false`                                                                                     |
 
 ### Outputs
 
 | Output         | Description                                                               |
 |----------------|---------------------------------------------------------------------------|
 | `BUILD_NUMBER` | The current build number. Also set as environment variable `BUILD_NUMBER` |
+| `WAS_DEPLOYED` | Whether the build was deployed (`true` or `false`)                        |
 
 ### Output Environment Variables
 
@@ -457,7 +459,8 @@ jobs:
 | `artifactory-deploy-repo`   | Deployment repository                                                                     | `sonarsource-private-qa` for private repositories, `sonarsource-public-qa` for public repos |
 | `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                           | `private-reader` for private repos, `public-reader` for public repos                        |
 | `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                         | `qa-deployer` for private repos, `public-deployer` for public repos                         |
-| `deploy-pull-request`       | Whether to deploy pull request artifacts                                                  | `false`                                                                                     |
+| `deploy`                    | Whether to deploy on master, maintenance, dogfood and long-lived branches                 | `true`                                                                                      |
+| `deploy-pull-request`       | Whether to also deploy for pull requests. If deploy is false, this has no effect.         | `false`                                                                                     |
 | `skip-tests`                | Whether to skip running tests                                                             | `false`                                                                                     |
 | `use-develocity`            | Whether to use Develocity for build tracking                                              | `false`                                                                                     |
 | `gradle-args`               | Additional arguments to pass to Gradle                                                    | (optional)                                                                                  |
@@ -471,9 +474,11 @@ jobs:
 
 ### Outputs
 
-| Output            | Description                                |
-|-------------------|--------------------------------------------|
-| `project-version` | The project version from gradle.properties |
+| Output            | Description                                                               |
+|-------------------|---------------------------------------------------------------------------|
+| `project-version` | The project version from gradle.properties                                |
+| `BUILD_NUMBER`    | The current build number. Also set as environment variable `BUILD_NUMBER` |
+| `WAS_DEPLOYED`    | Whether the build was deployed (`true` or `false`)                        |
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ See also [`config-maven`](#config-maven) input environment variables.
 | Output         | Description                                                               |
 |----------------|---------------------------------------------------------------------------|
 | `BUILD_NUMBER` | The current build number. Also set as environment variable `BUILD_NUMBER` |
-| `WAS_DEPLOYED` | Whether the build was deployed (`true` or `false`)                        |
+| `deployed`     | `true` if the build succeed and was supposed to deploy                    |
 
 ### Output Environment Variables
 
@@ -478,7 +478,7 @@ jobs:
 |-------------------|---------------------------------------------------------------------------|
 | `project-version` | The project version from gradle.properties                                |
 | `BUILD_NUMBER`    | The current build number. Also set as environment variable `BUILD_NUMBER` |
-| `WAS_DEPLOYED`    | Whether the build was deployed (`true` or `false`)                        |
+| `deployed`     | `true` if the build succeed and was supposed to deploy                    |
 
 ### Features
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -19,8 +19,11 @@ inputs:
     default: ''
   gradle-args:
     description: Additional arguments to pass to Gradle
+  deploy:
+    description: Whether to deploy on master, maintenance, dogfood and long-lived branches.
+    default: 'true'
   deploy-pull-request:
-    description: Whether to deploy pull request artifacts
+    description: Whether to also deploy pull request artifacts. If deploy is 'false', this has no effect.
     default: 'false'
   skip-tests:
     description: Whether to skip running tests
@@ -60,6 +63,9 @@ outputs:
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
     value: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
+  WAS_DEPLOYED:
+    description: Whether artifacts were deployed
+    value: ${{ steps.build.outputs.should-deploy }}
 
 runs:
   using: composite
@@ -195,6 +201,7 @@ runs:
         ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
         ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }} # used in parent POM
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
+        DEPLOYMENT: ${{ inputs.deploy }}
         SKIP_TESTS: ${{ inputs.skip-tests }}
         GRADLE_ARGS: ${{ inputs.gradle-args }}
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -63,9 +63,9 @@ outputs:
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
     value: ${{ steps.get_build_number.outputs.BUILD_NUMBER }}
-  WAS_DEPLOYED:
+  deployed:
     description: Whether artifacts were deployed
-    value: ${{ steps.build.outputs.should-deploy }}
+    value: ${{ steps.build.outputs.deployed }}
 
 runs:
   using: composite
@@ -200,8 +200,8 @@ runs:
         ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
         ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
         ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }} # used in parent POM
+        DEPLOY: ${{ inputs.deploy }}
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
-        DEPLOYMENT: ${{ inputs.deploy }}
         SKIP_TESTS: ${{ inputs.skip-tests }}
         GRADLE_ARGS: ${{ inputs.gradle-args }}
 
@@ -250,7 +250,7 @@ runs:
         echo "- **Branch**: \`${GITHUB_REF}\`" >> $GITHUB_STEP_SUMMARY
         echo "- **Commit**: \`$GITHUB_SHA\`" >> $GITHUB_STEP_SUMMARY
 
-        if [[ "${{ steps.build.outputs.should-deploy }}" == true ]]; then
+        if [[ "${{ steps.build.outputs.deployed }}" == true ]]; then
           echo "### 🚀 Deployment" >> $GITHUB_STEP_SUMMARY
           ARTIFACTORY_BROWSE_URL="${ARTIFACTORY_URL%/*}/ui/builds/$build_name/$BUILD_NUMBER"
           echo "🔗 **[Browse artifacts in Artifactory](${ARTIFACTORY_BROWSE_URL})**" >> $GITHUB_STEP_SUMMARY

--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -104,18 +104,18 @@ set_project_version() {
 
 should_deploy() {
   # Disable deployment when explicitly requested
-  if [[ "${DEPLOYMENT}" == "false" ]]; then
+  if [[ "${DEPLOYMENT}" = "false" ]]; then
     return 1
   fi
 
   # Disable deployment when shadow scans are enabled to prevent duplicate artifacts
-  if [[ "${RUN_SHADOW_SCANS}" == "true" ]]; then
+  if [[ "${RUN_SHADOW_SCANS}" = "true" ]]; then
     return 1
   fi
 
   if is_pull_request; then
     # For pull requests, deploy only if explicitly enabled
-    [[ "$DEPLOY_PULL_REQUEST" == "true" ]]
+    [[ "$DEPLOY_PULL_REQUEST" = "true" ]]
   else
     is_default_branch || \
     is_maintenance_branch || \

--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -33,6 +33,7 @@
 # - GITHUB_BASE_REF: Base branch for pull requests (only during pull_request events)
 #
 # Optional user customization:
+# - DEPLOYMENT: Whether to deploy (default: true)
 # - DEPLOY_PULL_REQUEST: Whether to deploy pull request artifacts (default: false)
 # - SKIP_TESTS: Whether to skip running tests (default: false)
 # - GRADLE_ARGS: Additional arguments to pass to Gradle
@@ -55,8 +56,9 @@ if [[ "${SONAR_PLATFORM:?}" != "none" ]]; then
   : "${NEXT_URL:?}" "${NEXT_TOKEN:?}" "${SQC_US_URL:?}" "${SQC_US_TOKEN:?}" "${SQC_EU_URL:?}" "${SQC_EU_TOKEN:?}"
 fi
 : "${ORG_GRADLE_PROJECT_signingKey:?}" "${ORG_GRADLE_PROJECT_signingPassword:?}" "${ORG_GRADLE_PROJECT_signingKeyId:?}"
-: "${DEPLOY_PULL_REQUEST:=false}" "${SKIP_TESTS:=false}"
-export DEPLOY_PULL_REQUEST
+: "${DEPLOY_PULL_REQUEST:=false}" "${DEPLOYMENT:=true}"
+export DEPLOY_PULL_REQUEST DEPLOYMENT
+: "${SKIP_TESTS:=false}"
 : "${GRADLE_ARGS:=}"
 
 git_fetch_unshallow() {
@@ -101,6 +103,11 @@ set_project_version() {
 }
 
 should_deploy() {
+  # Disable deployment when explicitly requested
+  if [[ "${DEPLOYMENT}" == "false" ]]; then
+    return 1
+  fi
+
   # Disable deployment when shadow scans are enabled to prevent duplicate artifacts
   if [[ "${RUN_SHADOW_SCANS}" == "true" ]]; then
     return 1

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -10,8 +10,11 @@ inputs:
     description: Deployment repository. Defaults to `sonarsource-private-qa` for private repositories, and `sonarsource-public-qa` for
       public repositories.
     default: ''
+  deploy:
+    description: Whether to deploy on master, maintenance, dogfood and long-lived branches.
+    default: 'true'
   deploy-pull-request:
-    description: Whether to deploy pull request artifacts.
+    description: Whether to also deploy pull request artifacts. If deploy is 'false', this has no effect.
     default: 'false'
   maven-args:
     description: Additional Maven arguments to pass to the build script.
@@ -59,6 +62,9 @@ outputs:
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
     value: ${{ steps.config.outputs.BUILD_NUMBER }}
+  WAS_DEPLOYED:
+    description: Whether artifacts were deployed
+    value: ${{ steps.build.outputs.should-deploy }}
 
 runs:
   using: composite
@@ -139,6 +145,7 @@ runs:
         SONAR_PLATFORM: ${{ inputs.sonar-platform }}
         RUN_SHADOW_SCANS: ${{ inputs.run-shadow-scans }}
         PGP_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).PGP_PASSPHRASE }}
+        DEPLOYMENT: ${{ inputs.deploy }}
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
         PULL_REQUEST: ${{ github.event.pull_request.number || '' }}
         PULL_REQUEST_SHA: ${{ github.event.pull_request.base.sha || '' }}

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -62,9 +62,9 @@ outputs:
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
     value: ${{ steps.config.outputs.BUILD_NUMBER }}
-  WAS_DEPLOYED:
+  deployed:
     description: Whether artifacts were deployed
-    value: ${{ steps.build.outputs.should-deploy }}
+    value: ${{ steps.build.outputs.deployed }}
 
 runs:
   using: composite
@@ -145,7 +145,7 @@ runs:
         SONAR_PLATFORM: ${{ inputs.sonar-platform }}
         RUN_SHADOW_SCANS: ${{ inputs.run-shadow-scans }}
         PGP_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).PGP_PASSPHRASE }}
-        DEPLOYMENT: ${{ inputs.deploy }}
+        DEPLOY: ${{ inputs.deploy }}
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
         PULL_REQUEST: ${{ github.event.pull_request.number || '' }}
         PULL_REQUEST_SHA: ${{ github.event.pull_request.base.sha || '' }}
@@ -179,7 +179,7 @@ runs:
         echo "- **Branch**: \`${GITHUB_REF}\`" >> $GITHUB_STEP_SUMMARY
         echo "- **Commit**: \`$GITHUB_SHA\`" >> $GITHUB_STEP_SUMMARY
 
-        if [[ "${{ steps.build.outputs.should-deploy }}" == true ]]; then
+        if [[ "${{ steps.build.outputs.deployed }}" == true ]]; then
           echo "### 🚀 Deployment" >> $GITHUB_STEP_SUMMARY
           ARTIFACTORY_BROWSE_URL="${ARTIFACTORY_URL%/*}/ui/builds/$build_name/$BUILD_NUMBER"
           echo "🔗 **[Browse artifacts in Artifactory](${ARTIFACTORY_BROWSE_URL})**" >> $GITHUB_STEP_SUMMARY

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -120,16 +120,16 @@ build_maven() {
   local sonar_args=()
 
   # Determine if deployment should be skipped
-  if [ "${RUN_SHADOW_SCANS}" = "true" ]; then
+  if [[ "${RUN_SHADOW_SCANS}" = "true" ]]; then
     echo "Shadow scans enabled - disabling deployment"
     deployment=false
-  elif [ "${DEPLOYMENT}" = "false" ]; then
+  elif [[ "${DEPLOYMENT}" = "false" ]]; then
     echo "DEPLOYMENT is false - disabling deployment"
     deployment=false
   fi
 
   if is_default_branch || is_maintenance_branch; then
-    if [ "$deployment" != "true" ]; then
+    if [[ "$deployment" != "true" ]]; then
       echo "======= Build and analyze $GITHUB_REF_NAME ======="
       maven_command_args=("install" "-Pcoverage,release,sign")
     else
@@ -145,7 +145,7 @@ build_maven() {
     sonar_args+=("-Dsonar.pullrequest.branch=$GITHUB_HEAD_REF")
     sonar_args+=("-Dsonar.pullrequest.base=$GITHUB_BASE_REF")
 
-    if [ "$deployment" = "true" ] && [ "$DEPLOY_PULL_REQUEST" = "true" ]; then
+    if [[ "$deployment" = "true" ]] && [[ "$DEPLOY_PULL_REQUEST" = "true" ]]; then
       echo "======= with deploy ======="
       maven_command_args=("deploy" "-Pcoverage,deploy-sonarsource")
       should_deploy=true
@@ -156,7 +156,7 @@ build_maven() {
     enable_sonar=true
 
   elif is_dogfood_branch; then
-    if [ "$deployment" != "true" ]; then
+    if [[ "$deployment" != "true" ]]; then
       echo "======= Build dogfood branch $GITHUB_REF_NAME ======="
       maven_command_args=("install" "-Prelease")
     else

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -28,11 +28,15 @@ Mock sed
   echo "sed $*"
 End
 
+readonly GITHUB_EVENT_NAME_PR="pull_request"
+readonly GITHUB_REF_NAME_PR="123/merge"
+
 # Environment setup
 export ARTIFACTORY_URL="https://dummy.repox/artifactory"
 export DEFAULT_BRANCH="master"
 export PULL_REQUEST=""
 export PULL_REQUEST_SHA=""
+export GITHUB_EVENT_NAME="push"
 export GITHUB_REF_NAME="master"
 export BUILD_NUMBER="42"
 export GITHUB_RUN_ID="123456"
@@ -53,11 +57,10 @@ export SQC_EU_TOKEN="sqc-eu-token"
 export ORG_GRADLE_PROJECT_signingKey="signing-key"
 export ORG_GRADLE_PROJECT_signingPassword="signing-pass"
 export ORG_GRADLE_PROJECT_signingKeyId="signing-id"
-export DEPLOYMENT="true"
+export DEPLOY="true"
 export DEPLOY_PULL_REQUEST="false"
 export SKIP_TESTS="false"
 export GRADLE_ARGS=""
-export GITHUB_EVENT_NAME="push"
 export GITHUB_OUTPUT=/dev/null
 # Duplicate environment variables removed
 GITHUB_EVENT_PATH=$(mktemp)
@@ -100,7 +103,8 @@ Describe 'set_build_env'
   End
 
   It 'handles pull request'
-    export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME_PR"
+    export GITHUB_REF_NAME="$GITHUB_REF_NAME_PR"
     export PULL_REQUEST="123"
     export PULL_REQUEST_SHA="base123"
     echo '{"number": 123, "pull_request": {"base": {"sha": "base123"}}}' > "$GITHUB_EVENT_PATH"
@@ -180,51 +184,48 @@ End
 
 Describe 'should_deploy'
   It 'does not deploy when deployment is disabled'
-    export DEPLOYMENT="false"
-    export GITHUB_EVENT_NAME="push"
-    export GITHUB_REF_NAME="master"
+    export DEPLOY="false"
     When call should_deploy
     The status should be failure
   End
 
   It 'deploys for master branch'
-    export GITHUB_REF_NAME="master"
-    export GITHUB_EVENT_NAME="push"
     When call should_deploy
     The status should be success
   End
 
   It 'deploys for maintenance branch'
     export GITHUB_REF_NAME="branch-1.0"
-    export GITHUB_EVENT_NAME="push"
     When call should_deploy
     The status should be success
   End
 
   It 'does not deploy for feature branch'
     export GITHUB_REF_NAME="feature/test"
-    export GITHUB_EVENT_NAME="push"
     When call should_deploy
     The status should be failure
   End
 
   It 'does not deploy for PR by default'
-    export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME_PR"
+    export GITHUB_REF_NAME="$GITHUB_REF_NAME_PR"
     export DEPLOY_PULL_REQUEST="false"
     When call should_deploy
     The status should be failure
   End
 
   It 'deploys for PR when enabled'
-    export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME_PR"
+    export GITHUB_REF_NAME="$GITHUB_REF_NAME_PR"
     export DEPLOY_PULL_REQUEST="true"
     When call should_deploy
     The status should be success
   End
 
   It 'does not deploy when deployment is disabled and pr is enabled'
-    export DEPLOYMENT="false"
-    export GITHUB_EVENT_NAME="pull_request"
+    export DEPLOY="false"
+    export GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME_PR"
+    export GITHUB_REF_NAME="$GITHUB_REF_NAME_PR"
     export DEPLOY_PULL_REQUEST="true"
     When call should_deploy
     The status should be failure
@@ -232,10 +233,10 @@ Describe 'should_deploy'
 
   It 'does not deploy when shadow scans enabled'
     export RUN_SHADOW_SCANS="true"
-    export GITHUB_EVENT_NAME="push"
-    export GITHUB_REF_NAME="master"
     When call should_deploy
     The status should be failure
+    The lines of stdout should equal 1
+    The line 1 should equal "Shadow scans enabled - disabling deployment"
   End
 End
 
@@ -260,8 +261,6 @@ Describe 'build_gradle_args'
 
   It 'includes deployment for master'
     export GRADLE_ARGS=""
-    export GITHUB_REF_NAME="master"
-    export GITHUB_EVENT_NAME="push"
     When call build_gradle_args
     The output should include "artifactoryPublish"
   End
@@ -275,8 +274,6 @@ Describe 'build_gradle_args'
 
   It 'includes sonar args for master branch'
     export GRADLE_ARGS=""
-    export GITHUB_REF_NAME="master"
-    export GITHUB_EVENT_NAME="push"
     export SONAR_HOST_URL="https://sonar.example.com"
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
@@ -287,7 +284,6 @@ Describe 'build_gradle_args'
   It 'includes sonar args for maintenance branch'
     export GRADLE_ARGS=""
     export GITHUB_REF_NAME="branch-1.0"
-    export GITHUB_EVENT_NAME="push"
     export SONAR_HOST_URL="https://sonar.example.com"
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
@@ -296,7 +292,8 @@ Describe 'build_gradle_args'
 
   It 'includes sonar args for PR'
     export GRADLE_ARGS=""
-    export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME_PR"
+    export GITHUB_REF_NAME="$GITHUB_REF_NAME_PR"
     export PULL_REQUEST="123"
     export PULL_REQUEST_SHA="base123"
     export SONAR_HOST_URL="https://sonar.example.com"
@@ -308,7 +305,6 @@ Describe 'build_gradle_args'
   It 'includes sonar args for long-lived feature branch'
     export GRADLE_ARGS=""
     export GITHUB_REF_NAME="feature/long/my-feature"
-    export GITHUB_EVENT_NAME="push"
     export SONAR_HOST_URL="https://sonar.example.com"
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
@@ -326,42 +322,37 @@ End
 
 Describe 'get_build_type'
   It 'returns default branch for master'
-    export GITHUB_REF_NAME="master"
-    export GITHUB_EVENT_NAME="push"
     When call get_build_type
     The output should equal "default branch"
   End
 
   It 'returns maintenance branch'
     export GITHUB_REF_NAME="branch-1.0"
-    export GITHUB_EVENT_NAME="push"
     When call get_build_type
     The output should equal "maintenance branch"
   End
 
   It 'returns pull request'
-    export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME_PR"
+    export GITHUB_REF_NAME="$GITHUB_REF_NAME_PR"
     When call get_build_type
     The output should equal "pull request"
   End
 
   It 'returns dogfood branch'
     export GITHUB_REF_NAME="dogfood-on-main"
-    export GITHUB_EVENT_NAME="push"
     When call get_build_type
     The output should equal "dogfood branch"
   End
 
   It 'returns long-lived feature branch'
     export GITHUB_REF_NAME="feature/long/my-feature"
-    export GITHUB_EVENT_NAME="push"
     When call get_build_type
     The output should equal "long-lived feature branch"
   End
 
   It 'returns regular build for other branches'
     export GITHUB_REF_NAME="feature/test"
-    export GITHUB_EVENT_NAME="push"
     When call get_build_type
     The output should equal "regular build"
   End

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -53,6 +53,7 @@ export SQC_EU_TOKEN="sqc-eu-token"
 export ORG_GRADLE_PROJECT_signingKey="signing-key"
 export ORG_GRADLE_PROJECT_signingPassword="signing-pass"
 export ORG_GRADLE_PROJECT_signingKeyId="signing-id"
+export DEPLOYMENT="true"
 export DEPLOY_PULL_REQUEST="false"
 export SKIP_TESTS="false"
 export GRADLE_ARGS=""
@@ -178,6 +179,14 @@ Describe 'set_project_version'
 End
 
 Describe 'should_deploy'
+  It 'does not deploy when deployment is disabled'
+    export DEPLOYMENT="false"
+    export GITHUB_EVENT_NAME="push"
+    export GITHUB_REF_NAME="master"
+    When call should_deploy
+    The status should be failure
+  End
+
   It 'deploys for master branch'
     export GITHUB_REF_NAME="master"
     export GITHUB_EVENT_NAME="push"
@@ -211,6 +220,14 @@ Describe 'should_deploy'
     export DEPLOY_PULL_REQUEST="true"
     When call should_deploy
     The status should be success
+  End
+
+  It 'does not deploy when deployment is disabled and pr is enabled'
+    export DEPLOYMENT="false"
+    export GITHUB_EVENT_NAME="pull_request"
+    export DEPLOY_PULL_REQUEST="true"
+    When call should_deploy
+    The status should be failure
   End
 
   It 'does not deploy when shadow scans enabled'

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -228,6 +228,7 @@ Describe 'git_fetch_unshallow()'
 
   It 'fallbacks and fetches base branch for pull request'
     export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_REF_NAME="123/merge"
     export GITHUB_BASE_REF="def_main"
     Mock git
       case "$*" in
@@ -270,24 +271,23 @@ Describe 'build_maven()'
     It 'builds, deploys and analyzes main branch'
       When call build_maven
       The lines of stdout should equal 4
-      The line 1 should include "Build, deploy and analyze def_main"
+      The line 1 should include "Build and analyze def_main"
       The line 2 should start with "Maven command: mvn deploy"
       The line 3 should start with "mvn deploy"
-      The line 3 should include "-Pcoverage,deploy-sonarsource,release,sign"
+      The line 3 should include "-Pdeploy-sonarsource -Pcoverage -Prelease,sign"
       The line 4 should start with "orchestrate_sonar_platforms"
     End
 
-    It 'builds and analyzes main branch when DEPLOYMENT is false'
-      export DEPLOYMENT="false"
+    It 'builds and analyzes main branch when DEPLOY is false'
+      export DEPLOY="false"
 
       When call build_maven
-      The lines of stdout should equal 5
-      The line 1 should include "DEPLOYMENT is false - disabling deployment"
-      The line 2 should include "Build and analyze def_main"
-      The line 3 should start with "Maven command: mvn install"
-      The line 4 should start with "mvn install"
-      The line 4 should include "-Pcoverage,release,sign"
-      The line 5 should start with "orchestrate_sonar_platforms"
+      The lines of stdout should equal 4
+      The line 1 should include "Build and analyze def_main"
+      The line 2 should start with "Maven command: mvn install"
+      The line 3 should start with "mvn install"
+      The line 3 should include "-Pcoverage -Prelease,sign"
+      The line 4 should start with "orchestrate_sonar_platforms"
     End
   End
 
@@ -297,21 +297,20 @@ Describe 'build_maven()'
     It 'builds, deploys and analyzes maintenance branch'
       When call build_maven
       The lines of stdout should equal 4
-      The line 1 should include "Build, deploy and analyze branch-1.2"
+      The line 1 should include "Build and analyze branch-1.2"
       The line 3 should start with "mvn deploy"
       The line 4 should start with "orchestrate_sonar_platforms"
     End
 
-    It 'builds and analyzes main branch when DEPLOYMENT is false'
-      export DEPLOYMENT="false"
+    It 'builds and analyzes main branch when DEPLOY is false'
+      export DEPLOY="false"
 
       When call build_maven
-      The lines of stdout should equal 5
-      The line 1 should include "DEPLOYMENT is false - disabling deployment"
-      The line 2 should include "Build and analyze branch-1.2"
-      The line 3 should start with "Maven command: mvn install"
-      The line 4 should start with "mvn install"
-      The line 5 should start with "orchestrate_sonar_platforms"
+      The lines of stdout should equal 4
+      The line 1 should include "Build and analyze branch-1.2"
+      The line 2 should start with "Maven command: mvn install"
+      The line 3 should start with "mvn install"
+      The line 4 should start with "orchestrate_sonar_platforms"
     End
   End
 
@@ -324,47 +323,43 @@ Describe 'build_maven()'
 
     It 'builds, analyzes pull request with no deploy by default'
       When call build_maven
-      The lines of stdout should equal 5
+      The lines of stdout should equal 4
       The line 1 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
-      The line 2 should include "no deploy"
-      The line 3 should start with "Maven command: mvn install"
-      The line 4 should start with "mvn install"
-      The line 4 should include "-Pcoverage"
-      The line 5 should start with "orchestrate_sonar_platforms"
-      The line 5 should include "-Dsonar.pullrequest.key=123"
-      The line 5 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
-      The line 5 should include "-Dsonar.pullrequest.base=def_main"
+      The line 2 should start with "Maven command: mvn install"
+      The line 3 should start with "mvn install"
+      The line 3 should include "-Pcoverage"
+      The line 4 should start with "orchestrate_sonar_platforms"
+      The line 4 should include "-Dsonar.pullrequest.key=123"
+      The line 4 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
+      The line 4 should include "-Dsonar.pullrequest.base=def_main"
     End
 
     It 'builds, analyzes pull request with deploy when DEPLOY_PULL_REQUEST is true'
       export DEPLOY_PULL_REQUEST="true"
       When call build_maven
-      The lines of stdout should equal 5
+      The lines of stdout should equal 4
       The line 1 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
-      The line 2 should include "with deploy"
-      The line 3 should start with "Maven command: mvn deploy"
-      The line 4 should start with "mvn deploy"
-      The line 4 should include "-Pcoverage,deploy-sonarsource"
-      The line 5 should start with "orchestrate_sonar_platforms"
-      The line 5 should include "-Dsonar.pullrequest.key=123"
-      The line 5 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
-      The line 5 should include "-Dsonar.pullrequest.base=def_main"
+      The line 2 should start with "Maven command: mvn deploy"
+      The line 3 should start with "mvn deploy"
+      The line 3 should include "-Pdeploy-sonarsource -Pcoverage"
+      The line 4 should start with "orchestrate_sonar_platforms"
+      The line 4 should include "-Dsonar.pullrequest.key=123"
+      The line 4 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
+      The line 4 should include "-Dsonar.pullrequest.base=def_main"
     End
-    It 'builds, analyzes pull request with no deploy when DEPLOY_PULL_REQUEST is true and DEPLOYMENT is false'
+    It 'builds, analyzes pull request with no deploy when DEPLOY_PULL_REQUEST is true and DEPLOY is false'
       export DEPLOY_PULL_REQUEST="true"
-      export DEPLOYMENT="false"
+      export DEPLOY="false"
       When call build_maven
-      The lines of stdout should equal 6
-      The line 1 should include "DEPLOYMENT is false - disabling deployment"
-      The line 2 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
-      The line 3 should include "no deploy"
-      The line 4 should start with "Maven command: mvn install"
-      The line 5 should start with "mvn install"
-      The line 5 should include "-Pcoverage"
-      The line 6 should start with "orchestrate_sonar_platforms"
-      The line 6 should include "-Dsonar.pullrequest.key=123"
-      The line 6 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
-      The line 6 should include "-Dsonar.pullrequest.base=def_main"
+      The lines of stdout should equal 4
+      The line 1 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
+      The line 2 should start with "Maven command: mvn install"
+      The line 3 should start with "mvn install"
+      The line 3 should include "-Pcoverage"
+      The line 4 should start with "orchestrate_sonar_platforms"
+      The line 4 should include "-Dsonar.pullrequest.key=123"
+      The line 4 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
+      The line 4 should include "-Dsonar.pullrequest.base=def_main"
     End
   End
 
@@ -374,34 +369,33 @@ Describe 'build_maven()'
     It 'builds and deploy'
       When call build_maven
       The lines of stdout should equal 3
-      The line 1 should include "Build, and deploy dogfood branch dogfood-on-something"
+      The line 1 should include "Build dogfood branch dogfood-on-something"
       The line 2 should start with "Maven command: mvn deploy"
       The line 3 should start with "mvn deploy"
-      The line 3 should include "-Pdeploy-sonarsource,release"
+      The line 3 should include "-Pdeploy-sonarsource -Prelease"
     End
 
-    It 'builds when DEPLOYMENT is false'
-      export DEPLOYMENT="false"
+    It 'builds when DEPLOY is false'
+      export DEPLOY="false"
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "DEPLOYMENT is false - disabling deployment"
-      The line 2 should include "Build dogfood branch dogfood-on-something"
-      The line 3 should start with "Maven command: mvn install"
-      The line 4 should start with "mvn install"
-      The line 4 should include "-Prelease"
+      The lines of stdout should equal 3
+      The line 1 should include "Build dogfood branch dogfood-on-something"
+      The line 2 should start with "Maven command: mvn install"
+      The line 3 should start with "mvn install"
+      The line 3 should include "-Prelease"
     End
   End
 
   Describe 'is_feature_branch'
     export GITHUB_REF_NAME="feature/long/some-feature"
 
-    It 'builds and analyzes long lived feature branch'
+    It 'builds, deploys and analyzes long lived feature branch'
       When call build_maven
       The lines of stdout should equal 4
       The line 1 should include "Build and analyze long lived feature branch feature/long/some-feature"
-      The line 2 should start with "Maven command: mvn install"
-      The line 3 should start with "mvn install"
-      The line 3 should include "-Pcoverage"
+      The line 2 should start with "Maven command: mvn deploy"
+      The line 3 should start with "mvn deploy"
+      The line 3 should include "-Pdeploy-sonarsource -Pcoverage"
       The line 4 should start with "orchestrate_sonar_platforms"
     End
   End

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -276,6 +276,19 @@ Describe 'build_maven()'
       The line 3 should include "-Pcoverage,deploy-sonarsource,release,sign"
       The line 4 should start with "orchestrate_sonar_platforms"
     End
+
+    It 'builds and analyzes main branch when DEPLOYMENT is false'
+      export DEPLOYMENT="false"
+
+      When call build_maven
+      The lines of stdout should equal 5
+      The line 1 should include "DEPLOYMENT is false - disabling deployment"
+      The line 2 should include "Build and analyze def_main"
+      The line 3 should start with "Maven command: mvn install"
+      The line 4 should start with "mvn install"
+      The line 4 should include "-Pcoverage,release,sign"
+      The line 5 should start with "orchestrate_sonar_platforms"
+    End
   End
 
   Describe 'is_maintenance_branch'
@@ -287,6 +300,18 @@ Describe 'build_maven()'
       The line 1 should include "Build, deploy and analyze branch-1.2"
       The line 3 should start with "mvn deploy"
       The line 4 should start with "orchestrate_sonar_platforms"
+    End
+
+    It 'builds and analyzes main branch when DEPLOYMENT is false'
+      export DEPLOYMENT="false"
+
+      When call build_maven
+      The lines of stdout should equal 5
+      The line 1 should include "DEPLOYMENT is false - disabling deployment"
+      The line 2 should include "Build and analyze branch-1.2"
+      The line 3 should start with "Maven command: mvn install"
+      The line 4 should start with "mvn install"
+      The line 5 should start with "orchestrate_sonar_platforms"
     End
   End
 
@@ -325,18 +350,45 @@ Describe 'build_maven()'
       The line 5 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
       The line 5 should include "-Dsonar.pullrequest.base=def_main"
     End
+    It 'builds, analyzes pull request with no deploy when DEPLOY_PULL_REQUEST is true and DEPLOYMENT is false'
+      export DEPLOY_PULL_REQUEST="true"
+      export DEPLOYMENT="false"
+      When call build_maven
+      The lines of stdout should equal 6
+      The line 1 should include "DEPLOYMENT is false - disabling deployment"
+      The line 2 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
+      The line 3 should include "no deploy"
+      The line 4 should start with "Maven command: mvn install"
+      The line 5 should start with "mvn install"
+      The line 5 should include "-Pcoverage"
+      The line 6 should start with "orchestrate_sonar_platforms"
+      The line 6 should include "-Dsonar.pullrequest.key=123"
+      The line 6 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
+      The line 6 should include "-Dsonar.pullrequest.base=def_main"
+    End
   End
 
   Describe 'is_dogfood_branch'
     export GITHUB_REF_NAME="dogfood-on-something"
 
-    It 'builds'
+    It 'builds and deploy'
       When call build_maven
       The lines of stdout should equal 3
       The line 1 should include "Build, and deploy dogfood branch dogfood-on-something"
       The line 2 should start with "Maven command: mvn deploy"
       The line 3 should start with "mvn deploy"
       The line 3 should include "-Pdeploy-sonarsource,release"
+    End
+
+    It 'builds when DEPLOYMENT is false'
+      export DEPLOYMENT="false"
+      When call build_maven
+      The lines of stdout should equal 4
+      The line 1 should include "DEPLOYMENT is false - disabling deployment"
+      The line 2 should include "Build dogfood branch dogfood-on-something"
+      The line 3 should start with "Maven command: mvn install"
+      The line 4 should start with "mvn install"
+      The line 4 should include "-Prelease"
     End
   End
 

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -124,6 +124,7 @@ Describe 'git_fetch_unshallow()'
 
   It 'fallbacks and fetches base branch for pull request'
     export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_REF_NAME="123/merge"
     export GITHUB_BASE_REF="def_main"
     Mock git
       case "$*" in
@@ -147,11 +148,12 @@ Describe 'git_fetch_unshallow()'
 End
 
 Describe 'build_npm()'
+  export PROJECT="test-project"
+
   It 'builds main branch correctly'
     export GITHUB_REF_NAME="main"
     export DEFAULT_BRANCH="main"
     export GITHUB_EVENT_NAME="push"
-    export PROJECT="test-project"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -164,7 +166,6 @@ Describe 'build_npm()'
   It 'builds maintenance branch with SNAPSHOT version'
     export GITHUB_REF_NAME="branch-1.2"
     export GITHUB_EVENT_NAME="push"
-    export PROJECT="test-project"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -177,7 +178,6 @@ Describe 'build_npm()'
     export PROJECT_VERSION="1.2.3" # No SNAPSHOT suffix, valid semantic version
     export GITHUB_REF_NAME="branch-1.2"
     export GITHUB_EVENT_NAME="push"
-    export PROJECT="test-project"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -186,11 +186,10 @@ Describe 'build_npm()'
   End
 
   It 'builds pull request without deploy'
-    export GITHUB_REF_NAME="feature/test"
     export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_REF_NAME="123/merge"
     export DEPLOY_PULL_REQUEST="false"
     export PULL_REQUEST="123"
-    export PROJECT="test-project"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -202,11 +201,10 @@ Describe 'build_npm()'
   End
 
   It 'builds pull request with deploy when enabled'
-    export GITHUB_REF_NAME="feature/test"
     export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_REF_NAME="123/merge"
     export DEPLOY_PULL_REQUEST="true"
     export PULL_REQUEST="123"
-    export PROJECT="test-project"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -217,7 +215,6 @@ Describe 'build_npm()'
   It 'builds dogfood branch without sonar'
     export GITHUB_REF_NAME="dogfood-on-feature"
     export GITHUB_EVENT_NAME="push"
-    export PROJECT="test-project"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -229,7 +226,6 @@ Describe 'build_npm()'
   It 'builds long-lived feature branch without deploy'
     export GITHUB_REF_NAME="feature/long/test-feature"
     export GITHUB_EVENT_NAME="push"
-    export PROJECT="test-project"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -242,7 +238,6 @@ Describe 'build_npm()'
   It 'builds other branches without sonar or deploy'
     export GITHUB_REF_NAME="feature/test"
     export GITHUB_EVENT_NAME="push"
-    export PROJECT="test-project"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -257,7 +252,6 @@ Describe 'build_npm()'
     export GITHUB_REF_NAME="main"
     export DEFAULT_BRANCH="main"
     export GITHUB_EVENT_NAME="push"
-    export PROJECT="test-project"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -314,7 +308,6 @@ Describe 'sonar_scanner_implementation()'
     The output should include "-Dsonar.branch.name=feature"
   End
 End
-
 
 Describe 'get_build_config()'
   It 'disables deployment when shadow scans enabled on main branch'

--- a/spec/promote_spec.sh
+++ b/spec/promote_spec.sh
@@ -84,6 +84,7 @@ Describe 'promote/promote.sh'
   It 'runs promote() on pull_request when promotion is enabled'
     export ARTIFACTORY_TARGET_REPO="artifactory-target"
     export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_REF_NAME="123/merge"
     export PROMOTE_PULL_REQUEST="true"
     When run script promote/promote.sh
     The status should be success
@@ -104,6 +105,7 @@ Describe 'promote/promote.sh'
 
   It 'skips promotion on pull_request when promotion is disabled'
     export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_REF_NAME="123/merge"
     export PROMOTE_PULL_REQUEST="false"
     When run script promote/promote.sh
     The status should be success
@@ -125,6 +127,7 @@ Describe 'check_branch()'
   # merge queue branches use case is handled in promote.sh, due to the exit 0 in check_branch
   It 'allows pull requests when promotion is enabled'
     export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_REF_NAME="123/merge"
     export PROMOTE_PULL_REQUEST="true"
     When call check_branch
     The status should be success
@@ -168,6 +171,7 @@ End
 Describe 'get_target_repos()'
   It 'returns target repositories for pull requests'
     export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_REF_NAME="123/merge"
     When call get_target_repos
     The status should be success
     The variable targetRepo1 should equal "sonarsource-private-dev"
@@ -233,6 +237,7 @@ End
 Describe 'get_target_repo()'
   It 'returns the target repository for pull requests'
     export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_REF_NAME="123/merge"
     When call get_target_repo
     The status should be success
     The output should equal "ARTIFACTORY_DEPLOY_REPO=sonarsource-deploy-qa"
@@ -271,6 +276,7 @@ End
 Describe 'jfrog_promote()'
   It 'sets the status for pull requests then promotes with version display'
     export GITHUB_EVENT_NAME="pull_request"
+    export GITHUB_REF_NAME="123/merge"
     export ARTIFACTORY_DEPLOY_REPO="artifactory-deploy-repo-qa"
     When call jfrog_promote
     The status should be success

--- a/spec/shared-functions_spec.sh
+++ b/spec/shared-functions_spec.sh
@@ -148,6 +148,7 @@ Describe 'shared/common-functions.sh'
 
     It 'detects pull request'
       export GITHUB_EVENT_NAME="pull_request"
+      export GITHUB_REF_NAME="123/merge"
       When call is_pull_request
       The status should be success
     End


### PR DESCRIPTION
[BUILD-9519](https://sonarsource.atlassian.net/browse/BUILD-9519)
[BUILD-9520](https://sonarsource.atlassian.net/browse/BUILD-9520)

In `build-gradle` and `build-maven`:
- new `deploy` input to enable or disable artifact deployment
- new `deployed` output

Changed behavior:
- In `build-maven`, the long lived feature branches are now deployed by default, as in `build-gradle`.

Tested with:
- https://github.com/SonarSource/sonar-dummy/pull/507
- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/308

Refactor and cleanup:
- reuse `deployed` instead of `should-deploy`
- new functions `should_deploy()` and `should_scan()` in `build-maven`
- simplified logic ; removed a bit of custom output to make it more simpler and readable
- fix detection of PR in tests, instead of testing impossible combinations in `build-gradle` (like `is_default_branch && ! is_pull_request`)

[BUILD-9519]: https://sonarsource.atlassian.net/browse/BUILD-9519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-9520]: https://sonarsource.atlassian.net/browse/BUILD-9520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ