### PR TITLE
BUILD-9225 m2 settings path is not consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ steps:
 | `PROJECT_VERSION`             | The project version with build number (after replacement)                                                                                 |
 | `SONARSOURCE_REPOSITORY_URL`  | URL for SonarSource Artifactory root virtual repository (i.e.: `sonarsource-qa` for public builds or `sonarsource-qa` for private builds) |
 | `CONFIG_MAVEN_COMPLETED`      | For internal use. If set, the action is skipped                                                                                           |
+| `MAVEN_CONFIG`                | Path to m2 root `$HOME/.m2`                                                                                                               |
 
 See also [`get-build-number`](#get-build-number) output environment variables.
 

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -50,7 +50,7 @@ inputs:
     description: URL for Develocity
     default: https://develocity.sonar.build/
   cache-paths:
-    description: Cache paths to use (multiline). If provided, overrides the default ~/.m2/repository
+    description: Cache paths to use (multiline).
     default: ~/.m2/repository
   disable-caching:
     description: Whether to disable Maven caching entirely
@@ -150,9 +150,9 @@ runs:
     - name: Cleanup Maven repository before caching
       shell: bash
       run: |
-        rm -rf "$HOME/.m2/repository/org/sonarsource/"
-        rm -rf "$HOME/.m2/repository/repository/com/sonarsource/"
-        /usr/bin/find "$HOME/.m2/repository" -name resolver-status.properties -delete
+        rm -rf "$MAVEN_CONFIG/repository/org/sonarsource/"
+        rm -rf "$MAVEN_CONFIG/repository/repository/com/sonarsource/"
+        /usr/bin/find "$MAVEN_CONFIG/repository" -name resolver-status.properties -delete
 
     - name: Generate workflow summary
       if: always()

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: URL for Develocity
     default: https://develocity.sonar.build/
   cache-paths:
-    description: Cache paths to use (multiline). If provided, overrides the default ~/.m2/repository
+    description: Cache paths to use (multiline).
     default: ~/.m2/repository
   disable-caching:
     description: Whether to disable Maven caching entirely
@@ -133,11 +133,28 @@ runs:
       shell: bash
       run: |
         MAVEN_CONFIG="$HOME/.m2"
-        mkdir -p "$MAVEN_CONFIG"
-        cp "${ACTION_PATH_CONFIG_MAVEN}/resources/settings.xml" "$MAVEN_CONFIG/settings.xml"
-        echo "Copied Maven settings from ${ACTION_PATH_CONFIG_MAVEN}/resources/settings.xml to $MAVEN_CONFIG/settings.xml"
+        mkdir -p "$MAVEN_CONFIG/repository"
+        M2_SETTINGS="$MAVEN_CONFIG/settings.xml"
+        cp "${ACTION_PATH_CONFIG_MAVEN}/resources/settings.xml" "$M2_SETTINGS"
+        echo "Copied Maven settings from ${ACTION_PATH_CONFIG_MAVEN}/resources/settings.xml to $M2_SETTINGS"
         echo "MAVEN_CONFIG=$MAVEN_CONFIG" >> "$GITHUB_ENV"
         echo "SONARSOURCE_REPOSITORY_URL=$ARTIFACTORY_URL/sonarsource-qa" >> "$GITHUB_ENV"
+
+        # Maven retrieves the user home directory from the passwd database, that may differ from $HOME (e.g., in a container)
+        echo "HOME: $HOME"
+        if [ "$RUNNER_OS" != "Windows" ]; then
+          USER_HOME="$(getent passwd $(whoami) | cut -d: -f6)"
+          if [ "$USER_HOME" != "$HOME" ]; then
+            echo "::group::USER_HOME symlinks workaround for Maven when it differs from HOME"
+            echo "USER_HOME (from passwd): $USER_HOME"
+            mkdir -p "$USER_HOME/.m2"
+            ln -sf "$MAVEN_CONFIG/repository" "$USER_HOME/.m2/repository"
+            ln -sf "$M2_SETTINGS" "$USER_HOME/.m2/settings.xml"
+            echo "Created symlinks from $USER_HOME/.m2 to $HOME/.m2:"
+            ls -la "$USER_HOME/.m2/" "$HOME/.m2"
+            echo "::endgroup::"
+          fi
+        fi
 
     - name: Cache local Maven repository
       uses: ./.actions/cache
@@ -153,14 +170,7 @@ runs:
       if: steps.from-env.outputs.skip != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: |
-        echo "pwd: $(pwd)"
-        env|grep HOME
-        echo "user.home: $(mvn -q -Dexec.executable="echo" -Dexec.args="\${user.home}" \
-          --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)"
-        echo "env.HOME: $(mvn -q -Dexec.executable="echo" -Dexec.args="\${env.HOME}" \
-          --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)"
-        $ACTION_PATH_CONFIG_MAVEN/set_maven_project_version.sh
+      run: $ACTION_PATH_CONFIG_MAVEN/set_maven_project_version.sh
 
     - name: Deactivate UseContainerSupport on github-ubuntu-* runners
       if: runner.os == 'Linux' && runner.environment == 'github-hosted' && steps.from-env.outputs.skip != 'true'

--- a/config-maven/set_maven_project_version.sh
+++ b/config-maven/set_maven_project_version.sh
@@ -22,9 +22,10 @@ source "$(dirname "${BASH_SOURCE[0]}")/../shared/common-functions.sh"
 get_current_version() {
   local expression="project.version"
   if ! mvn --quiet --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec 2>/dev/null \
-    -Dexec.executable="echo" -Dexec.args="\${$expression}"; then
+      -Dexec.executable="echo" -Dexec.args="\${$expression}"; then
     echo "Failed to evaluate Maven expression '$expression'" >&2
-    mvn --debug -Dexec.executable="echo" -Dexec.args="\${$expression}" --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec
+    mvn --debug --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec \
+      -Dexec.executable="echo" -Dexec.args="\${$expression}"
     return 1
   fi
 }
@@ -67,7 +68,10 @@ set_project_version() {
   fi
   release_version="${release_version}.${BUILD_NUMBER}"
   echo "Replacing version ${current_version} with ${release_version}"
-  mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion="$release_version" -DgenerateBackupPoms=false --batch-mode --no-transfer-progress --errors
+  echo "Maven command: mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=$release_version" \
+    "-DgenerateBackupPoms=false --batch-mode --no-transfer-progress --errors"
+  mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion="$release_version" \
+    -DgenerateBackupPoms=false --batch-mode --no-transfer-progress --errors
   echo "project-version=$release_version" >> "$GITHUB_OUTPUT"
   echo "PROJECT_VERSION=$release_version" >> "$GITHUB_ENV"
   echo "PROJECT_VERSION=$release_version"

--- a/spec/set_maven_project_version_spec.sh
+++ b/spec/set_maven_project_version_spec.sh
@@ -67,11 +67,12 @@ Describe 'set_project_version()'
     The lines of contents of file "$GITHUB_ENV" should equal 2
     The line 1 of contents of file "$GITHUB_ENV" should equal "CURRENT_VERSION=1.2.3-SNAPSHOT"
     The line 2 of contents of file "$GITHUB_ENV" should equal "PROJECT_VERSION=1.2.3.999"
-    The lines of output should equal 4
+    The lines of output should equal 5
     The line 1 should equal "CURRENT_VERSION=1.2.3-SNAPSHOT (from pom.xml)"
     The line 2 should equal "Replacing version 1.2.3-SNAPSHOT with 1.2.3.999"
-    The line 3 should start with "mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=1.2.3.999"
-    The line 4 should equal "PROJECT_VERSION=1.2.3.999"
+    The line 3 should start with "Maven command: mvn"
+    The line 4 should start with "mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=1.2.3.999"
+    The line 5 should equal "PROJECT_VERSION=1.2.3.999"
   End
 
   It 'handles 1.2-SNAPSHOT version (adds .0)'
@@ -86,11 +87,12 @@ Describe 'set_project_version()'
     The lines of contents of file "$GITHUB_ENV" should equal 2
     The line 1 of contents of file "$GITHUB_ENV" should equal "CURRENT_VERSION=1.2-SNAPSHOT"
     The line 2 of contents of file "$GITHUB_ENV" should equal "PROJECT_VERSION=1.2.0.999"
-    The lines of output should equal 4
+    The lines of output should equal 5
     The line 1 should equal "CURRENT_VERSION=1.2-SNAPSHOT (from pom.xml)"
     The line 2 should equal "Replacing version 1.2-SNAPSHOT with 1.2.0.999"
-    The line 3 should start with "mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=1.2.0.999"
-    The line 4 should equal "PROJECT_VERSION=1.2.0.999"
+    The line 3 should start with "Maven command: mvn"
+    The line 4 should start with "mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=1.2.0.999"
+    The line 5 should equal "PROJECT_VERSION=1.2.0.999"
   End
 
   It 'handles 1-SNAPSHOT version (adds .0.0)'
@@ -105,11 +107,12 @@ Describe 'set_project_version()'
     The lines of contents of file "$GITHUB_ENV" should equal 2
     The line 1 of contents of file "$GITHUB_ENV" should equal "CURRENT_VERSION=1-SNAPSHOT"
     The line 2 of contents of file "$GITHUB_ENV" should equal "PROJECT_VERSION=1.0.0.999"
-    The lines of output should equal 4
+    The lines of output should equal 5
     The line 1 should equal "CURRENT_VERSION=1-SNAPSHOT (from pom.xml)"
     The line 2 should equal "Replacing version 1-SNAPSHOT with 1.0.0.999"
-    The line 3 should start with "mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=1.0.0.999"
-    The line 4 should equal "PROJECT_VERSION=1.0.0.999"
+    The line 3 should start with "Maven command: mvn"
+    The line 4 should start with "mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=1.0.0.999"
+    The line 5 should equal "PROJECT_VERSION=1.0.0.999"
   End
 
   It 'rejects version with too many digits'


### PR DESCRIPTION
[BUILD-9225](https://sonarsource.atlassian.net/browse/BUILD-9225)

- **BUILD-9225 use canonical home directory for m2 settings**

Maven retrieves the user home directory from the system database. In the case of a container, this may differ from `$HOME`.

Tested with https://github.com/SonarSource/sonar-dummy/pull/503

[BUILD-9225]: https://sonarsource.atlassian.net/browse/BUILD-9225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ