### PR TITLE
BUILD-9566 Add support for working-directory for gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ jobs:
           run-shadow-scans: false                              # Run SonarQube scans on all 3 platforms (next, sqc-eu, sqc-us)
 ```
 
-## Inputs
+### Inputs
 
 | Input                       | Description                                                                                                                                                                                   | Default                                                                                               |
 |-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
@@ -468,9 +468,27 @@ jobs:
 | `repox-url`                 | URL for Repox                                                                             | `https://repox.jfrog.io`                                                                    |
 | `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)               | (optional)                                                                                  |
 | `sonar-platform`            | SonarQube variant - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans | `next`                                                                                      |
+| `working-directory`         | Relative path under github.workspace to execute the build in                              | `.`                                                                                         |
 | `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding)            | `false`                                                                                     |
 | `cache-paths`               | Custom cache paths (multiline).                                                           | `~/.gradle/caches`<br>`~/.gradle/wrapper`                                                   |
 | `disable-caching`           | Whether to disable Gradle caching entirely                                                | `false`                                                                                     |
+
+> [!TIP]
+> When using `working-directory`, Java must be available at root due to a limitation
+> of [setup-gradle](https://github.com/gradle/actions/tree/main/setup-gradle).
+> For instance, if the `mise.toml` file is in the working directory, and not at root.
+>
+> ```yaml
+>      - name: Workaround for setup-gradle which has no working-directory input
+>        run: |
+>          cp <working-directory>/mise.toml mise.toml
+>      - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
+>        with:
+>          version: 2025.7.12
+>      - uses: SonarSource/ci-github-actions/build-gradle@v1
+>        with:
+>          working-directory: <working-directory>
+> ```
 
 ### Outputs
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -43,6 +43,9 @@ inputs:
   sonar-platform:
     description: SonarQube variant (next, sqc-eu, sqc-us, or none). Use 'none' to skip sonar scans.
     default: next
+  working-directory:
+    description: Relative path under github.workspace to execute the build in
+    default: .
   run-shadow-scans:
     description: If true, run sonar scanner on all 3 platforms using the provided URL and token.
      If false, run on the platform provided by SONAR_PLATFORM.
@@ -136,6 +139,7 @@ runs:
     - name: Generate Gradle Cache Key
       if: ${{ inputs.disable-caching != 'true' }}
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: |
         /usr/bin/find . \( -name '*.gradle' -o -name '*.gradle.kts' \) -type f -exec md5sum {} \; > gradle-md5-sums.txt
         md5sum gradle/libs.versions.toml gradle/wrapper/gradle-wrapper.properties 2>/dev/null >> gradle-md5-sums.txt || true
@@ -179,6 +183,7 @@ runs:
     - name: Build, analyze and deploy
       id: build
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       env:
         # GitHub context
         PULL_REQUEST: ${{ github.event.pull_request.number || '' }}


### PR DESCRIPTION
[BUILD-9566](https://sonarsource.atlassian.net/browse/BUILD-9566)

Tested with: 
- https://github.com/SonarSource/sonarcloud-domain-template/actions/runs/19138133049?pr=373
- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/309

Warning: gradle/actions/setup-gradle used by build-gradle does not honor the working directory. As a consequence, Java must be available at root. This impacts for instance mise install if the mise.toml file is in the working directory.

```
      - name: Workaround for setup-gradle which has no working-directory input
        run: |
          cp <working-directory>/mise.toml mise.toml
      - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
        with:
          version: 2025.7.12
```

[BUILD-9566]: https://sonarsource.atlassian.net/browse/BUILD-9566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ