### PR TITLE
PREQ-2689 Respect PROJECT_VERSION env variable in promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,9 +897,12 @@ The GitHub status check is named `repox-${GITHUB_REF_NAME}`.
 Required properties in the build info:
 
 - `buildInfo.env.ARTIFACTORY_DEPLOY_REPO`: Repository to deploy to (e.g. `sonarsource-deploy-qa`). It can also be set as an input.
-- `buildInfo.env.PROJECT_VERSION`: Version of the project (e.g. 1.2.3).
+- `buildInfo.env.PROJECT_VERSION`: Version of the project (e.g. 1.2.3). Can also be set as an environment variable to override the build
+  info value.
 
 ### Usage
+
+**Basic usage (version from JFrog build info):**
 
 ```yaml
 promote:
@@ -913,6 +916,29 @@ promote:
   steps:
     - uses: SonarSource/ci-github-actions/promote@v1
 ```
+
+**With custom project version:**
+
+```yaml
+promote:
+  needs:
+    - build
+  runs-on: sonar-xs  # Private repos default; use github-ubuntu-latest-s for public repos
+  name: Promote
+  permissions:
+    id-token: write
+    contents: write
+  env:
+    PROJECT_VERSION: '2.0.0-custom'  # Override version from JFrog build info
+  steps:
+    - uses: SonarSource/ci-github-actions/promote@v1
+```
+
+### Input Environment Variables
+
+| Environment Variable | Description                                                                                                               |
+|----------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `PROJECT_VERSION`    | Version of the project (e.g. 1.2.3). If set, it takes precedence over the version from JFrog build info.                 |
 
 ### Inputs
 

--- a/promote/promote.sh
+++ b/promote/promote.sh
@@ -18,6 +18,7 @@
 # - MULTI_REPO_PROMOTE: If true, promotes to multiple repositories (default: false)
 # - ARTIFACTORY_DEPLOY_REPO: Repository to deploy to. If not set, it will be retrieved from the build info.
 # - ARTIFACTORY_TARGET_REPO: Target repository for the promotion. If not set, it will be determined based on the branch type.
+# - PROJECT_VERSION: Version of the project (e.g. 1.2.3). If not set, it will be retrieved from the build info.
 #
 # Required properties in the JFrog build info:
 # - buildInfo.env.ARTIFACTORY_DEPLOY_REPO: Repository to deploy to (e.g. sonarsource-deploy-qa)
@@ -145,7 +146,7 @@ promote_mono() {
 
 github_notify_promotion() {
   local project_version longDescription shortDescription buildUrl githubApiUrl
-  project_version=$(get_build_info_property PROJECT_VERSION)
+  project_version="$PROJECT_VERSION"
   longDescription="Latest promoted build of '${project_version}' from branch '${GITHUB_REF}'"
   shortDescription=${longDescription:0:140} # required for GH API endpoint (max 140 chars)
   buildUrl="${ARTIFACTORY_URL%/*}/ui/builds/${BUILD_NAME}/${BUILD_NUMBER}/"
@@ -167,7 +168,7 @@ jfrog_promote() {
   fi
 
   export PROJECT_VERSION
-  PROJECT_VERSION=$(get_build_info_property PROJECT_VERSION)
+  : "${PROJECT_VERSION:=$(get_build_info_property PROJECT_VERSION)}"
 
   if [[ "${MULTI_REPO_PROMOTE}" == "true" ]]; then
     local targetRepo1 targetRepo2


### PR DESCRIPTION
[PREQ-2689](https://sonarsource.atlassian.net/browse/PREQ-2689)

PROJECT_VERSION not set - https://github.com/SonarSource/sonar-dummy/actions/runs/19097825400/job/54562808764
PROJECT_VERSION set - https://github.com/SonarSource/sonar-dummy/actions/runs/19098138132/job/54563918270#step:2:298

[PREQ-2689]: https://sonarsource.atlassian.net/browse/PREQ-2689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ