### PR TITLE
BUILD-9640 Remove '--info' from default build arguments

### DIFF
--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -129,7 +129,7 @@ build_gradle_args() {
   local args=()
 
   # Base arguments
-  args+=("--no-daemon" "--info" "--stacktrace" "--console" "plain")
+  args+=("--no-daemon" "--stacktrace" "--console" "plain")
 
   args+=("build")
 


### PR DESCRIPTION
[BUILD-9640](https://sonarsource.atlassian.net/browse/BUILD-9640)

### BUILD-9640 Remove '--info' from default build arguments

Removing the --info args from the default build arguments.

#### Why

This was much too verbose in job runs so removing. If users wish to set this they can in the gradle args input.

[BUILD-9640]: https://sonarsource.atlassian.net/browse/BUILD-9640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ