### PR TITLE
BUILD-9723 mixed-privacy feature in build-maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,31 +260,59 @@ steps:
 
 ### Input Environment Variables
 
+| Environment Variable                | Description                                                                                 | Default                  |
+|-------------------------------------|---------------------------------------------------------------------------------------------|--------------------------|
+| `ARTIFACTORY_PRIVATE_DEPLOY_REPO`   | Only if `mixed-privacy == true`. Repository to deploy private artifacts.                    | `sonarsource-private-qa` |
+| `ARTIFACTORY_PRIVATE_DEPLOYER_ROLE` | Only if `mixed-privacy == true`. Suffix for the Artifactory private deployer role in Vault. | `qa-deployer`            |
+
 See also [`config-maven`](#config-maven) input environment variables.
 
 ### Inputs
 
-| Input                       | Description                                                                                                                | Default                                                                                     |
-|-----------------------------|----------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `public`                    | Deprecated                                                                                                                 | Repository visibility                                                                       |
-| `artifactory-deploy-repo`   | Deployment repository                                                                                                      | `sonarsource-private-qa` for private repositories, `sonarsource-public-qa` for public repos |
-| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                                                            | `private-reader` for private repos, `public-reader` for public repos                        |
-| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                                                          | `qa-deployer` for private repos, `public-deployer` for public repos                         |
-| `deploy`                    | Whether to deploy on master, maintenance, dogfood and long-lived branches                                                  | `true`                                                                                      |
-| `deploy-pull-request`       | Whether to also deploy for pull requests. If deploy is false, this has no effect.                                          | `false`                                                                                     |
-| `maven-args`                | Additional arguments to pass to Maven                                                                                      | (optional)                                                                                  |
-| `scanner-java-opts`         | Additional Java options for the Sonar scanner (`SONAR_SCANNER_JAVA_OPTS`)                                                  | `-Xmx512m`                                                                                  |
-| `repox-url`                 | URL for Repox                                                                                                              | `https://repox.jfrog.io`                                                                    |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                | (optional)                                                                                  |
-| `use-develocity`            | Whether to use Develocity for build tracking                                                                               | `false`                                                                                     |
-| `develocity-url`            | URL for Develocity                                                                                                         | `https://develocity.sonar.build/`                                                           |
-| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans                         | `next`                                                                                      |
-| `working-directory`         | Relative path under github.workspace to execute the build in                                                               | `.`                                                                                         |
-| `run-shadow-scans`          | If true, run SonarQube analysis on all 3 platforms (next, sqc-eu, sqc-us); if false, only on the selected `sonar-platform` | `false`                                                                                     |
-| `cache-paths`               | Custom cache paths (multiline). Overrides default `~/.m2/repository`.                                                      | (optional)                                                                                  |
-| `disable-caching`           | Whether to disable Maven caching entirely                                                                                  | `false`                                                                                     |
-| `provenance`                | Whether to generate provenance attestation for built artifacts                                                             | `false`                                                                                     |
+| Input                       | Description                                                                                                                  | Default                                                                                     |
+|-----------------------------|------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
+| `artifactory-deploy-repo`   | Deployment repository                                                                                                        | `sonarsource-private-qa` for private repositories, `sonarsource-public-qa` for public repos |
+| `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                                                              | `private-reader` for private repos, `public-reader` for public repos                        |
+| `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                                                            | `qa-deployer` for private repos, `public-deployer` for public repos                         |
+| `deploy`                    | Whether to deploy on master, maintenance, dogfood and long-lived branches                                                    | `true`                                                                                      |
+| `deploy-pull-request`       | Whether to also deploy for pull requests. If deploy is false, this has no effect.                                            | `false`                                                                                     |
+| `maven-args`                | Additional arguments to pass to Maven                                                                                        | (optional)                                                                                  |
+| `scanner-java-opts`         | Additional Java options for the Sonar scanner (`SONAR_SCANNER_JAVA_OPTS`)                                                    | `-Xmx512m`                                                                                  |
+| `repox-url`                 | URL for Repox                                                                                                                | `https://repox.jfrog.io`                                                                    |
+| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                  | (optional)                                                                                  |
+| `use-develocity`            | Whether to use Develocity for build tracking                                                                                 | `false`                                                                                     |
+| `develocity-url`            | URL for Develocity                                                                                                           | `https://develocity.sonar.build/`                                                           |
+| `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans                           | `next`                                                                                      |
+| `working-directory`         | Relative path under github.workspace to execute the build in                                                                 | `.`                                                                                         |
+| `run-shadow-scans`          | If true, run SonarQube analysis on all 3 platforms (next, sqc-eu, sqc-us); if false, only on the selected `sonar-platform`   | `false`                                                                                     |
+| `cache-paths`               | Custom cache paths (multiline). Overrides default `~/.m2/repository`.                                                        | (optional)                                                                                  |
+| `cache-cleanup`             | Whether to clean up the cache before saving it.                                                                              | `true`                                                                                      |
+| `disable-caching`           | Whether to disable Maven caching entirely                                                                                    | `false`                                                                                     |
+| `provenance`                | Whether to generate provenance attestation for built artifacts                                                               | `false`                                                                                     |
 | `provenance-artifact-paths` | Relative paths of artifacts for provenance attestation (glob pattern). See [Provenance Attestation](#provenance-attestation) | (optional)                                                                                  |
+| `mixed-privacy`             | Whether the repository contains both public and private code                                                                 | `false`                                                                                     |
+
+#### `cache-cleanup`
+
+Adds an extra step to delete the `<org|com>/sonarsource` artifacts from the cache before saving it.
+
+This is useful for avoiding the caching of Sonar artifacts which are built in the same repository and will not be reused. However, they may
+need to be kept, or deleted later in the workflow, if other steps depend on them.
+
+#### `mixed-privacy`
+
+When set to `true`, this input option configures the build to handle both public and private artifacts.
+
+- The Maven Artifactory plugin will not publish the artifacts.
+- The artifacts are individually deployed after the build with the JFrog CLI to their respective repositories.
+
+It is possible to customize the target public and private repository names and the roles used for deployment by setting the input parameters
+for the public values, and by setting the environment variables for the private values:
+
+- `artifactory-deploy-repo` input
+- `artifactory-deployer-role` input
+- `ARTIFACTORY_PRIVATE_DEPLOY_REPO` environment variable
+- `ARTIFACTORY_PRIVATE_DEPLOYER_ROLE` environment variable
 
 ### Outputs
 
@@ -293,7 +321,6 @@ See also [`config-maven`](#config-maven) input environment variables.
 | `project-version` | The project version with build number (after replacement). Also set as environment variable `PROJECT_VERSION` |
 | `BUILD_NUMBER`    | The current build number. Also set as environment variable `BUILD_NUMBER`                                     |
 | `deployed`        | `true` if the build succeed and was supposed to deploy                                                        |
-| `artifact-paths`  | Newline-separated list of artifact paths for provenance attestation                                           |
 
 ### Output Environment Variables
 
@@ -316,6 +343,7 @@ See also [`config-maven`](#config-maven) output environment variables.
   - **dogfood** (`dogfood-on-*`): Deploy only with dogfood profiles
   - **feature** (`feature/long/*`): Verify + SonarQube analysis only
   - **default**: Basic verify goal only
+- Mixed privacy repository support for combined public and private artifacts
 
 ## `build-poetry`
 
@@ -411,7 +439,6 @@ jobs:
 | `BUILD_NUMBER`   | The current build number. Also set as environment variable `BUILD_NUMBER`                                    |
 | `project-version`| The project version from pyproject.toml with build number. Also set as environment variable `PROJECT_VERSION`|
 | `deployed`       | `true` if the build succeed and was supposed to deploy                                                       |
-| `artifact-paths` | Newline-separated list of artifact paths for provenance attestation                                          |
 
 ## `config-gradle`
 
@@ -666,7 +693,6 @@ See also [`config-gradle`](#config-gradle) input environment variables.
 | `project-version` | The project version from gradle.properties                                |
 | `BUILD_NUMBER`    | The current build number. Also set as environment variable `BUILD_NUMBER` |
 | `deployed`        | `true` if the build succeed and was supposed to deploy                    |
-| `artifact-paths`  | Newline-separated list of artifact paths for provenance attestation       |
 
 ### Features
 
@@ -944,7 +970,6 @@ See also [`config-npm`](#config-npm) input environment variables.
 | `project-version` | The project version with build number (after replacement) |
 | `BUILD_NUMBER`    | The current build number                                  |
 | `deployed`        | `true` if the build succeed and was supposed to deploy    |
-| `artifact-paths`  | Newline-separated list of artifact paths for provenance attestation |
 
 ### Output Environment Variables
 
@@ -1053,7 +1078,6 @@ jobs:
 | `BUILD_NUMBER`    | The current build number. Also set as environment variable `BUILD_NUMBER` |
 | `project-version` | The project version from package.json                     |
 | `deployed`        | `true` if the build succeed and was supposed to deploy    |
-| `artifact-paths`  | Newline-separated list of artifact paths for provenance attestation |
 
 ### Features
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -75,9 +75,6 @@ outputs:
   deployed:
     description: Whether artifacts were deployed
     value: ${{ steps.build.outputs.deployed }}
-  artifact-paths:
-    description: Newline-separated list of artifact paths for provenance attestation
-    value: ${{ steps.build.outputs.artifact-paths }}
 
 runs:
   using: composite

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -63,8 +63,14 @@ inputs:
   cache-paths:
     description: Cache paths to use (multiline).
     default: ~/.m2/repository
+  cache-cleanup:
+    description: Whether to clean up the cache before saving it
+    default: 'true'
   disable-caching:
     description: Whether to disable Maven caching entirely
+    default: 'false'
+  mixed-privacy:
+    description: Whether the repository contains both public and private modules
     default: 'false'
 
 outputs:
@@ -77,9 +83,6 @@ outputs:
   deployed:
     description: Whether artifacts were deployed
     value: ${{ steps.build.outputs.deployed }}
-  artifact-paths:
-    description: Newline-separated list of artifact paths for provenance attestation
-    value: ${{ steps.build.outputs.artifact-paths }}
 
 runs:
   using: composite
@@ -119,12 +122,31 @@ runs:
 
     - name: Set build parameters
       shell: bash
+      id: params
       env:
+        USER_MAVEN_ARGS: ${{ inputs.maven-args }}
+        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
+          (github.event.repository.visibility == 'public' || inputs.mixed-privacy == 'true') && 'sonarsource-public-qa' ||
+          'sonarsource-private-qa' }}
         ARTIFACTORY_DEPLOYER_ROLE: ${{ inputs.artifactory-deployer-role != '' && inputs.artifactory-deployer-role ||
-          (github.event.repository.visibility == 'public' && 'public-deployer' || 'qa-deployer') }}
+          (github.event.repository.visibility == 'public' || inputs.mixed-privacy == 'true') && 'public-deployer' ||
+          'qa-deployer' }}
+      # yamllint disable rule:line-length
       run: |
-        echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
+        {
+          if [[ "${{ inputs.mixed-privacy }}" == 'true' ]]; then
+            USER_MAVEN_ARGS="${USER_MAVEN_ARGS} -Dartifactory.publish.artifacts=false"
+            echo "ARTIFACTORY_PRIVATE_DEPLOY_REPO=${ARTIFACTORY_PRIVATE_DEPLOY_REPO:=sonarsource-private-qa}"
+            echo "ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN_VAULT=development/artifactory/token/{REPO_OWNER_NAME_DASH}-${ARTIFACTORY_PRIVATE_DEPLOYER_ROLE:=qa-deployer} access_token | ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN;"
+          fi
+          echo "USER_MAVEN_ARGS=${USER_MAVEN_ARGS}"
+          echo "ARTIFACTORY_DEPLOY_REPO=${ARTIFACTORY_DEPLOY_REPO}"
+          echo "ARTIFACTORY_DEPLOY_USERNAME_VAULT=development/artifactory/token/{REPO_OWNER_NAME_DASH}-${ARTIFACTORY_DEPLOYER_ROLE} username | ARTIFACTORY_DEPLOY_USERNAME;"
+          echo "ARTIFACTORY_DEPLOY_ACCESS_TOKEN_VAULT=development/artifactory/token/{REPO_OWNER_NAME_DASH}-${ARTIFACTORY_DEPLOYER_ROLE} access_token | ARTIFACTORY_DEPLOY_ACCESS_TOKEN;"
+        } >> "$GITHUB_OUTPUT"
         echo "SONARSOURCE_REPOSITORY_URL=${ARTIFACTORY_URL}/sonarsource" >> "$GITHUB_ENV"
+      # yamllint enable rule:line-length
+
     - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets
       with:
@@ -136,8 +158,9 @@ runs:
           ${{ inputs.sonar-platform != 'none' && 'development/kv/data/sonarqube-us token | SQC_US_TOKEN;' || '' }}
           ${{ inputs.sonar-platform != 'none' && 'development/kv/data/sonarcloud url | SQC_EU_URL;' || '' }}
           ${{ inputs.sonar-platform != 'none' && 'development/kv/data/sonarcloud token | SQC_EU_TOKEN;' || '' }}
-          ${{ inputs.deploy != 'false' && inputs.run-shadow-scans != 'true' && format('development/artifactory/token/{{REPO_OWNER_NAME_DASH}}-{0} username | ARTIFACTORY_DEPLOY_USERNAME;', env.ARTIFACTORY_DEPLOYER_ROLE) || '' }}
-          ${{ inputs.deploy != 'false' && inputs.run-shadow-scans != 'true' && format('development/artifactory/token/{{REPO_OWNER_NAME_DASH}}-{0} access_token | ARTIFACTORY_DEPLOY_ACCESS_TOKEN;', env.ARTIFACTORY_DEPLOYER_ROLE) || '' }}
+          ${{ inputs.deploy != 'false' && inputs.run-shadow-scans != 'true' && steps.params.outputs.ARTIFACTORY_DEPLOY_USERNAME_VAULT || '' }}
+          ${{ inputs.deploy != 'false' && inputs.run-shadow-scans != 'true' && steps.params.outputs.ARTIFACTORY_DEPLOY_ACCESS_TOKEN_VAULT || '' }}
+          ${{ inputs.deploy != 'false' && inputs.mixed-privacy == 'true' && steps.params.outputs.ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN_VAULT || '' }}
           development/kv/data/sign key | SIGN_KEY;
           development/kv/data/sign passphrase | PGP_PASSPHRASE;
         # yamllint enable rule:line-length
@@ -154,12 +177,11 @@ runs:
         # Action inputs
         DEPLOY: ${{ inputs.deploy }}
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
-        USER_MAVEN_ARGS: ${{ inputs.maven-args }}
+        USER_MAVEN_ARGS: ${{ steps.params.outputs.USER_MAVEN_ARGS }}
         SONAR_SCANNER_JAVA_OPTS: ${{ inputs.scanner-java-opts }}
         SONAR_PLATFORM: ${{ inputs.sonar-platform }}
         RUN_SHADOW_SCANS: ${{ inputs.run-shadow-scans }}
-        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
-          github.event.repository.visibility == 'public' && 'sonarsource-public-qa' || 'sonarsource-private-qa' }}
+        ARTIFACTORY_DEPLOY_REPO: ${{ steps.params.outputs.ARTIFACTORY_DEPLOY_REPO }}
 
         # Vault secrets
         ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
@@ -176,7 +198,21 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: $ACTION_PATH_BUILD_MAVEN/build.sh
 
+    - name: Artifacts upload
+      shell: bash
+      if: |
+        inputs.mixed-privacy == 'true' && steps.build.outputs.deployed == 'true' &&
+        (github.event_name != 'pull_request' || inputs.deploy-pull-request == 'true')
+      env:
+        ARTIFACTORY_DEPLOY_REPO: ${{ steps.params.outputs.ARTIFACTORY_DEPLOY_REPO }}
+        ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
+        ARTIFACTORY_PRIVATE_DEPLOY_REPO: ${{ steps.params.outputs.ARTIFACTORY_PRIVATE_DEPLOY_REPO }}
+        ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN }}
+        INSTALLED_ARTIFACTS: ${{ steps.build.outputs.installed-artifacts }}
+      run: ${GITHUB_ACTION_PATH}/deploy-artifacts.sh
+
     - name: Cleanup Maven repository before caching
+      if: inputs.cache-cleanup == 'true'
       shell: bash
       run: |
         rm -rf "$MAVEN_CONFIG/repository/org/sonarsource/"
@@ -184,11 +220,9 @@ runs:
         /usr/bin/find "$MAVEN_CONFIG/repository" -name resolver-status.properties -delete
 
     - name: Generate provenance attestation
-      if: >-
-        ${{ inputs.provenance == 'true' &&
-            github.event_name != 'pull_request' &&
-            steps.build.outputs.deployed == 'true' &&
-            (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '') }}
+      if: |
+        inputs.provenance == 'true' && github.event_name != 'pull_request' && steps.build.outputs.deployed == 'true' &&
+        (inputs.provenance-artifact-paths != '' || steps.build.outputs.artifact-paths != '')
       uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
       with:
         subject-path: >-

--- a/build-maven/deploy-artifacts.sh
+++ b/build-maven/deploy-artifacts.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Deploy to public and private Artifactory repositories using JFrog CLI
+#
+# Required environment variables:
+# - ARTIFACTORY_URL: URL to Artifactory repository. Set by 'build-maven'.
+# - ARTIFACTORY_DEPLOY_REPO: Repository to deploy public artifacts.
+# - ARTIFACTORY_DEPLOY_ACCESS_TOKEN: Access token to deploy to public repository.
+# - ARTIFACTORY_PRIVATE_DEPLOY_REPO: Repository to deploy private artifacts
+# - ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN: Access token to deploy to private repository
+# - INSTALLED_ARTIFACTS: Artifacts produced by Maven and installed in the local repository.
+# - MAVEN_CONFIG: Path to the Maven configuration directory (typically $HOME/.m2). Set by 'build-maven'.
+
+set -euo pipefail
+
+: "${ARTIFACTORY_URL:?}" "${INSTALLED_ARTIFACTS:?}" "${MAVEN_CONFIG:?}"
+: "${ARTIFACTORY_DEPLOY_REPO:?}" "${ARTIFACTORY_DEPLOY_ACCESS_TOKEN:?}"
+: "${ARTIFACTORY_PRIVATE_DEPLOY_REPO:?}" "${ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN:?}"
+
+public_artifacts=()
+private_artifacts=()
+for artifact in $INSTALLED_ARTIFACTS; do
+  if [[ $artifact == "org/"* ]]; then
+    public_artifacts+=("$artifact")
+  elif [[ $artifact == "com/"* ]]; then
+    private_artifacts+=("$artifact")
+  else
+    echo "WARN: Unrecognized artifact path: $artifact" >&2
+  fi
+done
+
+build_name="${GITHUB_REPOSITORY#*/}"
+pushd "$MAVEN_CONFIG/repository"
+jfrog config add deploy --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_DEPLOY_ACCESS_TOKEN"
+jfrog config use deploy
+echo "Deploying public artifacts..."
+for artifact in "${public_artifacts[@]}"; do
+  jfrog rt u --build-name "$build_name" --build-number "$BUILD_NUMBER" "$artifact" "${ARTIFACTORY_DEPLOY_REPO}"
+done
+echo "Deploying private artifacts..."
+jfrog config edit deploy --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN"
+for artifact in "${private_artifacts[@]}"; do
+  jfrog rt u --build-name "$build_name" --build-number "$BUILD_NUMBER" "$artifact" "${ARTIFACTORY_PRIVATE_DEPLOY_REPO}"
+done
+popd

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -64,9 +64,6 @@ outputs:
   deployed:
     description: Whether artifacts were deployed
     value: ${{ steps.build.outputs.deployed }}
-  artifact-paths:
-    description: Newline-separated list of artifact paths for provenance attestation
-    value: ${{ steps.build.outputs.artifact-paths }}
 
 runs:
   using: composite

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -65,9 +65,6 @@ outputs:
   deployed:
     description: Whether artifacts were deployed
     value: ${{ steps.build.outputs.deployed }}
-  artifact-paths:
-    description: Newline-separated list of artifact paths for provenance attestation
-    value: ${{ steps.build.outputs.artifact-paths }}
 
 runs:
   using: composite

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -60,9 +60,6 @@ outputs:
   deployed:
     description: Whether artifacts were deployed
     value: ${{ steps.build.outputs.deployed }}
-  artifact-paths:
-    description: Newline-separated list of artifact paths for provenance attestation
-    value: ${{ steps.build.outputs.artifact-paths }}
 
 runs:
   using: composite

--- a/spec/build-maven_deploy-artifacts_spec.sh
+++ b/spec/build-maven_deploy-artifacts_spec.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+eval "$(shellspec - -c) exit 1"
+
+Mock jfrog
+  echo "jfrog $*"
+End
+
+# Set required environment variables
+export ARTIFACTORY_URL="https://dummy.repox"
+export ARTIFACTORY_DEPLOY_REPO="deploy-repo-qa"
+export ARTIFACTORY_DEPLOY_ACCESS_TOKEN="deploy-token"
+export ARTIFACTORY_PRIVATE_DEPLOY_REPO="private-repo-qa"
+export ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN="private-token"
+export GITHUB_REPOSITORY="sonarsource/test-repo"
+export BUILD_NUMBER="42"
+
+Describe 'build-maven/deploy-artifacts.sh'
+  It 'deploys public and private artifacts correctly'
+    MAVEN_CONFIG=$(mktemp -d)
+    export MAVEN_CONFIG
+    mkdir -p "$MAVEN_CONFIG/repository"
+    export INSTALLED_ARTIFACTS="org/sonarsource/app/1.0/app-1.0.pom
+org/sonarsource/app/1.0/app-1.0.jar
+com/sonarsource/private/app/1.0/app-1.0.pom
+com/sonarsource/private/app/1.0/app-1.0.jar"
+
+    When run script build-maven/deploy-artifacts.sh
+    The status should be success
+    The lines of stdout should equal 11
+    The line 2 of output should equal "jfrog config add deploy --artifactory-url https://dummy.repox --access-token deploy-token"
+    The line 3 of output should equal "jfrog config use deploy"
+    The line 4 of output should include "Deploying public artifacts..."
+    The line 5 of output should include "org/sonarsource/app/1.0/app-1.0.pom deploy-repo-qa"
+    The line 6 of output should include "org/sonarsource/app/1.0/app-1.0.jar deploy-repo-qa"
+    The line 7 of output should equal "Deploying private artifacts..."
+    The line 8 of output should equal "jfrog config edit deploy --artifactory-url https://dummy.repox --access-token private-token"
+    The line 9 of output should include "com/sonarsource/private/app/1.0/app-1.0.pom private-repo-qa"
+    The line 10 of output should include "com/sonarsource/private/app/1.0/app-1.0.jar private-repo-qa"
+
+    rm -rf "$MAVEN_CONFIG"
+  End
+
+  It 'warns about unrecognized artifact paths'
+    MAVEN_CONFIG=$(mktemp -d)
+    export MAVEN_CONFIG
+    mkdir -p "$MAVEN_CONFIG/repository"
+    export INSTALLED_ARTIFACTS="org/sonarsource/app/1.0/app-1.0.pom
+unknown/artifact/path.jar
+com/sonarsource/private/app/1.0/app-1.0.pom"
+
+    When run script build-maven/deploy-artifacts.sh
+    The status should be success
+    The stderr should include "WARN: Unrecognized artifact path: unknown/artifact/path.jar"
+    The output should include "org/sonarsource/app/1.0/app-1.0.pom"
+    The output should include "com/sonarsource/private/app/1.0/app-1.0.pom"
+
+    rm -rf "$MAVEN_CONFIG"
+  End
+End


### PR DESCRIPTION
[BUILD-9723](https://sonarsource.atlassian.net/browse/BUILD-9723)

Rework after https://github.com/SonarSource/sonar-python-enterprise/pull/628
- integrate the ["double promotion"](https://github.com/SonarSource/sonar-python-enterprise/blob/a63d041101148ab3cccf845be787469bd70e1477/.github/actions/build-sonar-python/deploy-artifacts.sh) (support for combined public and private artifacts) as `mixed-privacy` input option in `build-maven` 
- add `cache-cleanup` input option in `build-maven` (defaults to `true`)
- remove unused output `artifact-paths`
- remove obsolete `public` input from the README
- 100% test coverage

Tested with:
- https://github.com/SonarSource/sonar-python-enterprise/pull/674
- https://github.com/SonarSource/sonar-dummy/pull/526

[BUILD-9723]: https://sonarsource.atlassian.net/browse/BUILD-9723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ