### PR TITLE
BUILD-9398 Use full path to find command in config-gradle action

### DIFF
--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -145,7 +145,7 @@ runs:
       shell: bash
       run: |
         # Generate cache key from all Gradle files
-        find . \( -name '*.gradle' -o -name '*.gradle.kts' \) -type f -exec md5sum {} \; | sort > gradle-md5-sums.txt
+        /usr/bin/find . \( -name '*.gradle' -o -name '*.gradle.kts' \) -type f -exec md5sum {} \; | sort > gradle-md5-sums.txt
         md5sum gradle/libs.versions.toml gradle/wrapper/gradle-wrapper.properties 2>/dev/null >> gradle-md5-sums.txt || true
 
         GRADLE_CACHE_KEY=$(md5sum gradle-md5-sums.txt | awk '{ print $1 }')


### PR DESCRIPTION
[BUILD-9398](https://sonarsource.atlassian.net/browse/BUILD-9398)

Builds on the Windows runners are failing with

```
shell: C:\Program Files\Git\usr\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
# Generate cache key from all Gradle files
find . \( -name '*.gradle' -o -name '*.gradle.kts' \) -type f -exec md5sum {} \; | sort > gradle-md5-sums.txt
File not found - *.gradle.kts
Error: Process completed with exit code 2.
```

We need to ensure that the Linux `find` command is used

Tested with https://github.com/SonarSource/sonar-dummy-gradle-oss/actions/runs/19371526333?pr=313

[BUILD-9398]: https://sonarsource.atlassian.net/browse/BUILD-9398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ