### PR TITLE
BUILD-9760 working-directory input for config-gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ steps:
 
 | Input                     | Description                                                                 | Default                                                              |
 |---------------------------|-----------------------------------------------------------------------------|----------------------------------------------------------------------|
+| `working-directory`       | Relative path under github.workspace to execute the build in                | `.`                                                                                                                     |
 | `artifactory-reader-role` | Suffix for the Artifactory reader role in Vault                             | `private-reader` for private repos, `public-reader` for public repos |
 | `use-develocity`          | Whether to use Develocity for build tracking                                | `false`                                                              |
 | `develocity-url`          | URL for Develocity                                                          | `https://develocity.sonar.build/`                                    |

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -147,6 +147,7 @@ runs:
       id: config-gradle
       with:
         host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
+        working-directory: ${{ inputs.working-directory }}
         artifactory-reader-role: ${{ inputs.artifactory-reader-role }}
         use-develocity: ${{ inputs.use-develocity }}
         develocity-url: ${{ inputs.develocity-url }}

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -2,6 +2,9 @@
 name: Configure Gradle
 description: GitHub Action to configure Gradle build environment with build number, authentication, and default settings
 inputs:
+  working-directory:
+    description: Relative path under github.workspace to execute the build in
+    default: .
   artifactory-reader-role:
     description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories,
       and `public-reader` for public repositories.
@@ -186,6 +189,7 @@ runs:
       id: set-version
       if: steps.config-gradle-completed.outputs.skip != 'true'
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: ${GITHUB_ACTION_PATH}/set_gradle_project_version.sh
 
     - name: Deactivate UseContainerSupport on github-ubuntu-* runners


### PR DESCRIPTION
Add working-directory input to config-gradle action, and pass it from build-gradle

Tested with:
- https://github.com/SonarSource/sonarcloud-domain-template/pull/382 
- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/315