### PR TITLE
BUILD-9765 cleanup & align *-gradle and *-maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,11 +288,12 @@ See also [`config-maven`](#config-maven) input environment variables.
 
 ### Outputs
 
-| Output           | Description                                                               |
-|------------------|---------------------------------------------------------------------------|
-| `BUILD_NUMBER`   | The current build number. Also set as environment variable `BUILD_NUMBER` |
-| `deployed`       | `true` if the build succeed and was supposed to deploy                    |
-| `artifact-paths` | Newline-separated list of artifact paths for provenance attestation       |
+| Output            | Description                                                                                                   |
+|-------------------|---------------------------------------------------------------------------------------------------------------|
+| `project-version` | The project version with build number (after replacement). Also set as environment variable `PROJECT_VERSION` |
+| `BUILD_NUMBER`    | The current build number. Also set as environment variable `BUILD_NUMBER`                                     |
+| `deployed`        | `true` if the build succeed and was supposed to deploy                                                        |
+| `artifact-paths`  | Newline-separated list of artifact paths for provenance attestation                                           |
 
 ### Output Environment Variables
 
@@ -496,11 +497,11 @@ steps:
 
 ### Outputs
 
-| Output            | Description                                                                                                     |
-|-------------------|-----------------------------------------------------------------------------------------------------------------|
-| `BUILD_NUMBER`    | The current build number. Also set as environment variable `BUILD_NUMBER`                                       |
+| Output            | Description                                                                                                           |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------|
+| `BUILD_NUMBER`    | The current build number. Also set as environment variable `BUILD_NUMBER`                                             |
 | `current-version` | The project version set in gradle.properties (before replacement). Also set as environment variable `CURRENT_VERSION` |
-| `project-version` | The project version with build number (after replacement). Also set as environment variable `PROJECT_VERSION`   |
+| `project-version` | The project version with build number (after replacement). Also set as environment variable `PROJECT_VERSION`         |
 
 ### Output Environment Variables
 
@@ -604,7 +605,6 @@ jobs:
 
 | Input                       | Description                                                                               | Default                                                                                     |
 |-----------------------------|-------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `public`                    | Deprecated                                                                                | Repository visibility                                                                       |
 | `artifactory-deploy-repo`   | Deployment repository                                                                     | `sonarsource-private-qa` for private repositories, `sonarsource-public-qa` for public repos |
 | `artifactory-reader-role`   | Suffix for the Artifactory reader role in Vault                                           | `private-reader` for private repos, `public-reader` for public repos                        |
 | `artifactory-deployer-role` | Suffix for the Artifactory deployer role in Vault                                         | `qa-deployer` for private repos, `public-deployer` for public repos                         |

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -1,21 +1,14 @@
 ---
 name: Build Gradle
-description: GitHub Action to build, analyze, and deploy a Gradle project with SonarQube integration
+description: GitHub Action to build, analyze, and deploy a Gradle project
 inputs:
-  public:
-    description: Deprecated. Use `artifactory-reader-role`, `artifactory-deployer-role`, and `artifactory-deploy-repo` instead.
-    default: ${{ github.event.repository.visibility == 'public' && 'true' || 'false' }}
-  artifactory-deploy-repo:
-    description: Deployment repository. Defaults to `sonarsource-private-qa` for private repositories, and `sonarsource-public-qa` for
-      public repositories.
-    default: ''
-  artifactory-reader-role:
-    description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories,
-      and `public-reader` for public repositories.
-    default: ''
   artifactory-deployer-role:
     description: Suffix for the Artifactory deployer role in Vault. Defaults to `qa-deployer` for private repositories, and
       `public-deployer` for public repositories.
+    default: ''
+  artifactory-deploy-repo:
+    description: Deployment repository. Defaults to `sonarsource-private-qa` for private repositories, and `sonarsource-public-qa` for
+      public repositories.
     default: ''
   gradle-args:
     description: Additional arguments to pass to Gradle
@@ -28,35 +21,12 @@ inputs:
   skip-tests:
     description: Whether to skip running tests
     default: 'false'
-  use-develocity:
-    description: Whether to use Develocity for build tracking.
-    default: 'false'
-  develocity-url:
-    description: URL for Develocity
-    default: https://develocity.sonar.build/
-  repox-url:
-    description: URL for Repox
-    default: https://repox.jfrog.io
-  repox-artifactory-url:
-    description: URL for Repox Artifactory API (overrides repox-url/artifactory if provided)
-    default: ''
   sonar-platform:
-    description: SonarQube variant (next, sqc-eu, sqc-us, or none). Use 'none' to skip sonar scans.
+    description: SonarQube primary platform (next, sqc-eu, sqc-us, or none). Use 'none' to skip sonar scans.
     default: next
-  working-directory:
-    description: Relative path under github.workspace to execute the build in
-    default: .
   run-shadow-scans:
-    description: If true, run sonar scanner on all 3 platforms using the provided URL and token.
-     If false, run on the platform provided by SONAR_PLATFORM.
-    default: 'false'
-  cache-paths:
-    description: Cache paths to use (multiline). If provided, overrides the default Gradle cache directories
-    default: |-
-      ~/.gradle/caches
-      ~/.gradle/wrapper
-  disable-caching:
-    description: Whether to disable Gradle caching entirely
+    description: If true, run SonarQube analysis on all three platforms (next, sqc-eu, sqc-us).
+      If false, run analysis on the platform specified with sonar-platform.
     default: 'false'
   provenance:
     description: Whether to generate provenance attestation for built artifacts
@@ -66,14 +36,42 @@ inputs:
       Relative paths of the artifacts for which to generate a provenance attestation (glob pattern).
       Default is collected from '*/build/libs/*', '*/build/distributions/*', and '*/build/reports/*'
     default: ''
+  # Inputs passed to config-gradle
+  working-directory:
+    description: Relative path under github.workspace to execute the build in
+    default: .
+  artifactory-reader-role:
+    description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories, and `public-reader`
+      for public repositories.
+    default: ''
+  repox-url:
+    description: URL for Repox
+    default: https://repox.jfrog.io
+  repox-artifactory-url:
+    description: URL for Repox Artifactory API (overrides repox-url/artifactory if provided)
+    default: ''
+  use-develocity:
+    description: Whether to use Develocity for build tracking.
+    default: 'false'
+  develocity-url:
+    description: URL for Develocity
+    default: https://develocity.sonar.build/
+  cache-paths:
+    description: Cache paths to use (multiline).
+    default: |-
+      ~/.gradle/caches
+      ~/.gradle/wrapper
+  disable-caching:
+    description: Whether to disable Gradle caching entirely
+    default: 'false'
 
 outputs:
   project-version:
     description: The release version set as Gradle project version in gradle.properties
-    value: ${{ steps.config-gradle.outputs.project-version }}
+    value: ${{ steps.config.outputs.project-version }}
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
-    value: ${{ steps.config-gradle.outputs.BUILD_NUMBER }}
+    value: ${{ steps.config.outputs.BUILD_NUMBER }}
   deployed:
     description: Whether artifacts were deployed
     value: ${{ steps.build.outputs.deployed }}
@@ -103,6 +101,19 @@ runs:
         ls -la .actions/*
         echo "::endgroup::"
 
+    - uses: ./.actions/config-gradle
+      id: config
+      with:
+        host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
+        working-directory: ${{ inputs.working-directory }}
+        artifactory-reader-role: ${{ inputs.artifactory-reader-role }}
+        repox-url: ${{ inputs.repox-url }}
+        repox-artifactory-url: ${{ inputs.repox-artifactory-url }}
+        use-develocity: ${{ inputs.use-develocity }}
+        develocity-url: ${{ inputs.develocity-url }}
+        cache-paths: ${{ inputs.cache-paths }}
+        disable-caching: ${{ inputs.disable-caching }}
+
     - name: Set build parameters
       shell: bash
       env:
@@ -128,38 +139,9 @@ runs:
           development/kv/data/sign key_id | SIGN_KEY_ID;
         # yamllint enable rule:line-length
 
-    - name: Setup environment for deployment
-      shell: bash
-      env:
-        # Deployment secrets
-        ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
-        ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
-        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
-          github.event.repository.visibility == 'public' && 'sonarsource-public-qa' || 'sonarsource-private-qa' }}
-      run: |
-        echo "ARTIFACTORY_DEPLOY_USERNAME=$ARTIFACTORY_DEPLOY_USERNAME" >> "$GITHUB_ENV"
-        echo "ARTIFACTORY_DEPLOY_ACCESS_TOKEN=$ARTIFACTORY_DEPLOY_ACCESS_TOKEN" >> "$GITHUB_ENV"
-        echo "ARTIFACTORY_DEPLOY_PASSWORD=$ARTIFACTORY_DEPLOY_ACCESS_TOKEN" >> "$GITHUB_ENV"  # deprecated, backward compliance
-        echo "ARTIFACTORY_DEPLOY_REPO=${ARTIFACTORY_DEPLOY_REPO}" >> "$GITHUB_ENV"
-
-    - name: Configure Gradle
-      uses: ./.actions/config-gradle
-      id: config-gradle
-      with:
-        host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
-        working-directory: ${{ inputs.working-directory }}
-        artifactory-reader-role: ${{ inputs.artifactory-reader-role }}
-        use-develocity: ${{ inputs.use-develocity }}
-        develocity-url: ${{ inputs.develocity-url }}
-        repox-url: ${{ inputs.repox-url }}
-        repox-artifactory-url: ${{ inputs.repox-artifactory-url }}
-        cache-paths: ${{ inputs.cache-paths }}
-        disable-caching: ${{ inputs.disable-caching }}
-
     - name: Build, analyze and deploy
-      id: build
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
+      id: build
       env:
         # GitHub context
         PULL_REQUEST: ${{ github.event.pull_request.number || '' }}
@@ -171,20 +153,24 @@ runs:
         DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
         SKIP_TESTS: ${{ inputs.skip-tests }}
         GRADLE_ARGS: ${{ inputs.gradle-args }}
-
-        # Vault secrets - always fetch all platforms
-        NEXT_URL: ${{ fromJSON(steps.secrets.outputs.vault).NEXT_URL }}
-        NEXT_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).NEXT_TOKEN }}
-        SQC_US_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_URL }}
-        SQC_US_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_TOKEN }}
-        SQC_EU_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_EU_URL }}
-        SQC_EU_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SQC_EU_TOKEN }}
         SONAR_PLATFORM: ${{ inputs.sonar-platform }}
         RUN_SHADOW_SCANS: ${{ inputs.run-shadow-scans }}
+        ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
+          github.event.repository.visibility == 'public' && 'sonarsource-public-qa' || 'sonarsource-private-qa' }}
 
+        # Vault secrets
+        ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
+        ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
+        NEXT_URL: ${{ fromJSON(steps.secrets.outputs.vault).NEXT_URL }}
+        NEXT_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).NEXT_TOKEN }}
+        SQC_EU_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_EU_URL }}
+        SQC_EU_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SQC_EU_TOKEN }}
+        SQC_US_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_URL }}
+        SQC_US_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_TOKEN }}
         ORG_GRADLE_PROJECT_signingKey: ${{ fromJSON(steps.secrets.outputs.vault).SIGN_KEY }}
         ORG_GRADLE_PROJECT_signingPassword: ${{ fromJSON(steps.secrets.outputs.vault).PGP_PASSPHRASE }}
         ORG_GRADLE_PROJECT_signingKeyId: ${{ fromJSON(steps.secrets.outputs.vault).SIGN_KEY_ID }}
+      working-directory: ${{ inputs.working-directory }}
       run: ${GITHUB_ACTION_PATH}/build.sh
 
     - name: Archive problems report
@@ -194,6 +180,7 @@ runs:
         name: problems-report-${{ github.job }}${{ strategy.job-index }}
         path: build/reports/problems/problems-report.html
         if-no-files-found: ignore
+
     - name: Generate provenance attestation
       if: >-
         ${{ inputs.provenance == 'true' &&
@@ -209,9 +196,6 @@ runs:
     - name: Generate workflow summary
       if: always()
       shell: bash
-      env:
-        ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
-          format('{0}/artifactory', inputs.repox-url) }}
       run: |
         build_name="${GITHUB_REPOSITORY#*/}"
         echo "## 🏗️ Gradle Build Summary" >> $GITHUB_STEP_SUMMARY

--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -186,8 +186,9 @@ get_build_type() {
 
 set_gradle_cmd() {
   if [[ -f "./gradlew" ]]; then
+    check_tool ./gradlew --version
     export GRADLE_CMD="./gradlew"
-  elif check_tool gradle; then
+  elif check_tool gradle --version; then
     export GRADLE_CMD="gradle"
   else
     echo "Neither ./gradlew nor gradle command found!" >&2
@@ -246,10 +247,11 @@ export_built_artifacts() {
 
   # Find all built artifacts, excluding sources/javadoc/tests JARs
   local artifacts
-  artifacts=$(/usr/bin/find . \( -path '*/build/libs/*' -o -path '*/build/distributions/*' -o -path '*/build/reports/*' \) \
-    \( -name '*.jar' -o -name '*.war' -o -name '*.ear' -o -name '*.zip' -o -name '*.tar.gz' -o -name '*.tar' -o -name '*.json' \) \
-    ! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*-tests.jar' \
-    -type f 2>/dev/null)
+  local path_includes=(-path '*/build/libs/*' -o -path '*/build/distributions/*' -o -path '*/build/reports/*')
+  local name_includes=(-name '*.jar' -o -name '*.war' -o -name '*.ear' -o -name '*.zip' -o -name '*.tar.gz' -o -name '*.tar')
+  name_includes+=(-o -name '*.json')
+  local name_excludes=(! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*-tests.jar')
+  artifacts=$(/usr/bin/find . \( "${path_includes[@]}" \) \( "${name_includes[@]}" \) "${name_excludes[@]}" -type f 2>/dev/null)
 
   # Sort and deduplicate (avoid Windows sort.exe)
   if [[ -n "$artifacts" ]]; then

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -25,17 +25,25 @@ inputs:
   sonar-platform:
     description: SonarQube primary platform (next, sqc-eu, sqc-us, or none). Use 'none' to skip sonar scans.
     default: next
-  working-directory:
-    description: Relative path under github.workspace to execute the build in
-    default: .
   run-shadow-scans:
     description: If true, run SonarQube analysis on all three platforms (next, sqc-eu, sqc-us).
       If false, run analysis on the platform specified with sonar-platform.
     default: 'false'
+  provenance:
+    description: Whether to generate provenance attestation for built artifacts
+    default: 'false'
+  provenance-artifact-paths:
+    description: >-
+      Relative paths of the artifacts for which to generate a provenance attestation (glob pattern).
+      Default is collected from '*/target/*' (or custom build directory from pom.xml)
+    default: ''
   # Inputs passed to config-maven
+  working-directory:
+    description: Relative path under github.workspace to execute the build in
+    default: .
   artifactory-reader-role:
-    description: Suffix for the Artifactory reader role in Vault.
-      Defaults to `private-reader` for private repositories, and `public-reader` for public repositories.
+    description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories, and `public-reader`
+      for public repositories.
     default: ''
   common-mvn-flags:
     description: Maven flags for all subsequent mvn calls
@@ -58,15 +66,11 @@ inputs:
   disable-caching:
     description: Whether to disable Maven caching entirely
     default: 'false'
-  provenance:
-    description: Whether to generate provenance attestation for built artifacts
-    default: 'false'
-  provenance-artifact-paths:
-    description: >-
-      Relative paths of the artifacts for which to generate a provenance attestation (glob pattern).
-      Default is collected from '*/target/*' (or custom build directory from pom.xml)
-    default: ''
+
 outputs:
+  project-version:
+    description: The release version set as Gradle project version in gradle.properties
+    value: ${{ steps.config.outputs.project-version }}
   BUILD_NUMBER:
     description: The build number, incremented or reused if already cached
     value: ${{ steps.config.outputs.BUILD_NUMBER }}
@@ -112,6 +116,7 @@ runs:
         develocity-url: ${{ inputs.develocity-url }}
         cache-paths: ${{ inputs.cache-paths }}
         disable-caching: ${{ inputs.disable-caching }}
+
     - name: Set build parameters
       shell: bash
       env:
@@ -122,8 +127,8 @@ runs:
         echo "SONARSOURCE_REPOSITORY_URL=${ARTIFACTORY_URL}/sonarsource" >> "$GITHUB_ENV"
     - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets
-      # yamllint disable rule:line-length
       with:
+        # yamllint disable rule:line-length
         secrets: |
           ${{ inputs.sonar-platform != 'none' && 'development/kv/data/next url | NEXT_URL;' || '' }}
           ${{ inputs.sonar-platform != 'none' && 'development/kv/data/next token | NEXT_TOKEN;' || '' }}
@@ -135,35 +140,41 @@ runs:
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_DEPLOYER_ROLE }} access_token | ARTIFACTORY_DEPLOY_ACCESS_TOKEN;
           development/kv/data/sign key | SIGN_KEY;
           development/kv/data/sign passphrase | PGP_PASSPHRASE;
-      # yamllint enable rule:line-length
-    - name: Build, Analyze and deploy
+        # yamllint enable rule:line-length
+
+    - name: Build, analyze and deploy
       shell: bash
       id: build
       env:
+        # GitHub context
+        PULL_REQUEST: ${{ github.event.pull_request.number || '' }}
+        PULL_REQUEST_SHA: ${{ github.event.pull_request.base.sha || '' }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
+        # Action inputs
+        DEPLOY: ${{ inputs.deploy }}
+        DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
+        USER_MAVEN_ARGS: ${{ inputs.maven-args }}
+        SONAR_SCANNER_JAVA_OPTS: ${{ inputs.scanner-java-opts }}
+        SONAR_PLATFORM: ${{ inputs.sonar-platform }}
+        RUN_SHADOW_SCANS: ${{ inputs.run-shadow-scans }}
         ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
           github.event.repository.visibility == 'public' && 'sonarsource-public-qa' || 'sonarsource-private-qa' }}
+
+        # Vault secrets
         ARTIFACTORY_DEPLOY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_USERNAME }}
         ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
         ARTIFACTORY_DEPLOY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }} # used in parent POM
-        SIGN_KEY: ${{ fromJSON(steps.secrets.outputs.vault).SIGN_KEY }}
-        SQC_EU_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_EU_URL }}
-        SQC_US_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_URL }}
         NEXT_URL: ${{ fromJSON(steps.secrets.outputs.vault).NEXT_URL }}
         NEXT_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).NEXT_TOKEN }}
+        SQC_EU_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_EU_URL }}
         SQC_EU_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SQC_EU_TOKEN }}
+        SQC_US_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_URL }}
         SQC_US_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_TOKEN }}
-        SONAR_PLATFORM: ${{ inputs.sonar-platform }}
-        RUN_SHADOW_SCANS: ${{ inputs.run-shadow-scans }}
+        SIGN_KEY: ${{ fromJSON(steps.secrets.outputs.vault).SIGN_KEY }}
         PGP_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).PGP_PASSPHRASE }}
-        DEPLOY: ${{ inputs.deploy }}
-        DEPLOY_PULL_REQUEST: ${{ inputs.deploy-pull-request }}
-        PULL_REQUEST: ${{ github.event.pull_request.number || '' }}
-        PULL_REQUEST_SHA: ${{ github.event.pull_request.base.sha || '' }}
-        USER_MAVEN_ARGS: ${{ inputs.maven-args }}
-        SONAR_SCANNER_JAVA_OPTS: ${{ inputs.scanner-java-opts }}
       working-directory: ${{ inputs.working-directory }}
-      run: $ACTION_PATH_BUILD_MAVEN/build.sh $USER_MAVEN_ARGS
+      run: $ACTION_PATH_BUILD_MAVEN/build.sh
 
     - name: Cleanup Maven repository before caching
       shell: bash

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -9,20 +9,20 @@ inputs:
     description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories,
       and `public-reader` for public repositories.
     default: ''
-  use-develocity:
-    description: Whether to use Develocity for build tracking.
-    default: 'false'
-  develocity-url:
-    description: URL for Develocity
-    default: https://develocity.sonar.build/
   repox-url:
     description: URL for Repox
     default: https://repox.jfrog.io
   repox-artifactory-url:
     description: URL for Repox Artifactory API (overrides repox-url/artifactory if provided)
     default: ''
+  use-develocity:
+    description: Whether to use Develocity for build tracking.
+    default: 'false'
+  develocity-url:
+    description: URL for Develocity
+    default: https://develocity.sonar.build/
   cache-paths:
-    description: Cache paths to use (multiline). If provided, overrides the default Gradle cache directories
+    description: Cache paths to use (multiline).
     default: |-
       ~/.gradle/caches
       ~/.gradle/wrapper
@@ -35,7 +35,7 @@ inputs:
 
 outputs:
   BUILD_NUMBER:
-    description: The build number, incremented or reused if already cached
+    description: The current build number. Also set as environment variable BUILD_NUMBER
     value: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
   current-version:
     description: The project version set in the gradle.properties (before replacement). Also set as environment variable CURRENT_VERSION
@@ -67,13 +67,13 @@ runs:
 
         mkdir -p ".actions"
         ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
+        ln -sf "$host_actions_root/cache" .actions/cache
         ln -sf "$host_actions_root/shared" .actions/shared
         ls -la .actions/*
         echo "::endgroup::"
 
-    - name: Get build number
+    - uses: ./.actions/get-build-number
       id: get-build-number
-      uses: ./.actions/get-build-number
       with:
         host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
 
@@ -92,11 +92,9 @@ runs:
           (github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader') }}
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
-
-    - name: Get secrets from Vault
-      id: secrets
+    - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       if: steps.config-gradle-completed.outputs.skip != 'true'
-      uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
+      id: secrets
       with:
         secrets: |
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_USERNAME;
@@ -113,17 +111,12 @@ runs:
       if: steps.config-gradle-completed.outputs.skip != 'true'
       shell: bash
       env:
-        ARTIFACTORY_URL:
-          ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url  || format('{0}/artifactory', inputs.repox-url) }}
-        ARTIFACTORY_USERNAME:
-          ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME || '' }}
-        ARTIFACTORY_ACCESS_TOKEN:
-          ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN || '' }}
-        DEVELOCITY_TOKEN:
-          ${{ inputs.use-develocity == 'true'
-            && steps.secrets.outputs.vault
-            && fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN
-            || '' }}
+        ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
+          format('{0}/artifactory', inputs.repox-url) }}
+        ARTIFACTORY_USERNAME: ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME || '' }}
+        ARTIFACTORY_ACCESS_TOKEN: ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN || '' }}
+        DEVELOCITY_TOKEN: ${{ inputs.use-develocity == 'true' && steps.secrets.outputs.vault &&
+          fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN || '' }}
       run: |
         if [[ "${DEVELOCITY_ACCESS_KEY:-}" == "${{ steps.develocity-hostname.outputs.hostname }}=" ]]; then
           echo "::warning title=Found invalid DEVELOCITY_ACCESS_KEY::DEVELOCITY_ACCESS_KEY should not be set manually in the environment."
@@ -140,7 +133,6 @@ runs:
           echo "DEVELOCITY_ACCESS_KEY=${{ steps.develocity-hostname.outputs.hostname }}=$DEVELOCITY_TOKEN" >> "$GITHUB_ENV"
         fi
 
-    # Configure Gradle for comprehensive caching and build summary reporting. It does not install Gradle.
     - name: Configure Gradle
       if: steps.config-gradle-completed.outputs.skip != 'true'
       uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
@@ -166,15 +158,13 @@ runs:
 
         rm -f gradle-md5-sums.txt
 
-    - name: Restore Gradle Cache
-      if: steps.config-gradle-completed.outputs.skip != 'true' && inputs.disable-caching != 'true'
-      uses: SonarSource/gh-action_cache@v1
-      id: gradle-cache-restore
+    - name: Gradle Cache
+      uses: ./.actions/cache
+      if: steps.config-gradle-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}
         key: gradle-${{ runner.os }}-${{ github.workflow }}-${{ env.GRADLE_CACHE_KEY }}
-        restore-keys: |
-          gradle-${{ runner.os }}-${{ github.workflow }}-
+        restore-keys: gradle-${{ runner.os }}-${{ github.workflow }}-
 
     # $GRADLE_USER_HOME is typically set to ~/.gradle/ by gradle/actions/setup-gradle
     - name: Configure Gradle Authentication
@@ -187,9 +177,10 @@ runs:
 
     - name: Update project version and set current-version and project-version variables
       id: set-version
-      if: steps.config-gradle-completed.outputs.skip != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        SKIP: ${{ steps.config-gradle-completed.outputs.skip }}
       run: ${GITHUB_ACTION_PATH}/set_gradle_project_version.sh
 
     - name: Deactivate UseContainerSupport on github-ubuntu-* runners

--- a/config-gradle/set_gradle_project_version.sh
+++ b/config-gradle/set_gradle_project_version.sh
@@ -14,15 +14,16 @@
 set -euo pipefail
 
 : "${BUILD_NUMBER:?}"
-: "${GITHUB_OUTPUT:?}" "${GITHUB_ENV:?}"
+: "${GITHUB_OUTPUT:?}" "${GITHUB_ENV:?}" "${SKIP:=false}"
 
 # shellcheck source=SCRIPTDIR/../shared/common-functions.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../shared/common-functions.sh"
 
 set_gradle_cmd() {
   if [[ -f "./gradlew" ]]; then
+    check_tool ./gradlew --version
     export GRADLE_CMD="./gradlew"
-  elif check_tool gradle; then
+  elif check_tool gradle --version; then
     export GRADLE_CMD="gradle"
   else
     echo "Neither ./gradlew nor gradle command found!" >&2
@@ -32,17 +33,20 @@ set_gradle_cmd() {
 
 set_project_version() {
   local current_version
-  current_version=$($GRADLE_CMD properties --no-scan --no-daemon --console plain | grep 'version:' | tr -d "[:space:]" | cut -d ":" -f 2)
-  if [[ -z "$current_version" || "$current_version" == "unspecified" ]]; then
-    echo "ERROR: Could not get valid version from Gradle properties. Got: '$current_version'" >&2
+  GRADLE_CMD_PARAMS=("properties" "--no-scan" "--no-daemon" "--console" "plain")
+  if ! current_version=$($GRADLE_CMD "${GRADLE_CMD_PARAMS[@]}" |grep 'version:' | cut -d ":" -f 2 | tr -d "[:space:]") || \
+      [[ -z "$current_version" || "$current_version" == "unspecified" ]]; then
+    current_version=$($GRADLE_CMD properties --no-scan --no-daemon --console plain 2>&1 || true)
+    echo -e "::error title=Gradle project version::Could not get valid version from Gradle properties\nERROR: $current_version"
     return 1
   fi
 
   # Saving the snapshot version to the output and environment variables
   # This is used by the sonar-scanner to set the value of sonar.projectVersion without the build number
-  echo "CURRENT_VERSION=$current_version"
+  echo "current-version=$current_version" >> "$GITHUB_OUTPUT"
   echo "CURRENT_VERSION=$current_version" >> "$GITHUB_ENV"
-  export CURRENT_VERSION=$current_version
+  echo "CURRENT_VERSION=$current_version"
+  export CURRENT_VERSION="$current_version"
 
   release_version="${current_version/-SNAPSHOT/}"
   if [[ "${release_version}" =~ ^[0-9]+\.[0-9]+$ ]]; then
@@ -51,14 +55,15 @@ set_project_version() {
   release_version="${release_version}.${BUILD_NUMBER}"
   echo "Replacing version $current_version with $release_version"
   sed -i.bak "s/$current_version/$release_version/g" gradle.properties
+  rm -f gradle.properties.bak
   echo "project-version=$release_version" >> "$GITHUB_OUTPUT"
   echo "PROJECT_VERSION=$release_version" >> "$GITHUB_ENV"
   echo "PROJECT_VERSION=$release_version"
-  export PROJECT_VERSION=$release_version
+  export PROJECT_VERSION="$release_version"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  if [[ -n "${CURRENT_VERSION:-}" && -n "${PROJECT_VERSION:-}" ]]; then
+  if [[ -n "${CURRENT_VERSION:-}" && -n "${PROJECT_VERSION:-}" || "$SKIP" == "true" ]]; then
     echo "Using provided CURRENT_VERSION $CURRENT_VERSION and PROJECT_VERSION $PROJECT_VERSION without changes."
     echo "current-version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
     echo "project-version=$PROJECT_VERSION" >> "$GITHUB_OUTPUT"

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: Relative path under github.workspace to execute the build in
     default: .
   artifactory-reader-role:
-    description: Suffix for the Artifactory reader role in Vault.
-      Defaults to `private-reader` for private repositories, and `public-reader` for public repositories.
+    description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories, and `public-reader`
+      for public repositories.
     default: ''
   common-mvn-flags:
     description: Maven flags for all subsequent mvn calls
@@ -78,7 +78,7 @@ runs:
       with:
         host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
 
-    - id: from-env
+    - id: config-maven-completed
       if: env.CONFIG_MAVEN_COMPLETED != ''
       shell: bash
       run: |
@@ -86,7 +86,7 @@ runs:
         echo "skip=true" >> $GITHUB_OUTPUT
 
     - name: Set parameter for Vault
-      if: steps.from-env.outputs.skip != 'true'
+      if: steps.config-maven-completed.outputs.skip != 'true'
       shell: bash
       env:
         ARTIFACTORY_READER_ROLE: ${{ inputs.artifactory-reader-role != '' && inputs.artifactory-reader-role ||
@@ -94,7 +94,7 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
     - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
-      if: steps.from-env.outputs.skip != 'true'
+      if: steps.config-maven-completed.outputs.skip != 'true'
       id: secrets
       with:
         secrets: |
@@ -104,12 +104,12 @@ runs:
 
     - name: Extract Develocity hostname
       id: develocity-hostname
-      if: steps.from-env.outputs.skip != 'true' && inputs.use-develocity == 'true'
+      if: steps.config-maven-completed.outputs.skip != 'true' && inputs.use-develocity == 'true'
       shell: bash
       run: echo "hostname=$(echo '${{ inputs.develocity-url }}' | sed -e 's|https://||' -e 's|/$||')" >> $GITHUB_OUTPUT
 
     - name: Set environment variables for Artifactory authentication
-      if: steps.from-env.outputs.skip != 'true'
+      if: steps.config-maven-completed.outputs.skip != 'true'
       shell: bash
       env:
         ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
@@ -135,7 +135,7 @@ runs:
         fi
 
     - name: Configure Maven settings and set repository URL
-      if: steps.from-env.outputs.skip != 'true'
+      if: steps.config-maven-completed.outputs.skip != 'true'
       shell: bash
       run: |
         MAVEN_CONFIG="$HOME/.m2"
@@ -171,22 +171,22 @@ runs:
 
     - name: Cache local Maven repository
       uses: ./.actions/cache
-      if: steps.from-env.outputs.skip != 'true' && inputs.disable-caching == 'false'
+      if: steps.config-maven-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
-        path: |-
-          ${{ inputs.cache-paths }}
+        path: ${{ inputs.cache-paths }}
         key: maven-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles(format('{0}/**/pom.xml', inputs.working-directory)) }}
         restore-keys: maven-${{ runner.os }}-${{ github.workflow }}-
 
     - name: Update project version and set current-version and project-version variables
       id: set-version
-      if: steps.from-env.outputs.skip != 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        SKIP: ${{ steps.config-maven-completed.outputs.skip }}
       run: $ACTION_PATH_CONFIG_MAVEN/set_maven_project_version.sh
 
     - name: Deactivate UseContainerSupport on github-ubuntu-* runners
-      if: runner.os == 'Linux' && runner.environment == 'github-hosted' && steps.from-env.outputs.skip != 'true'
+      if: steps.config-maven-completed.outputs.skip != 'true' && runner.os == 'Linux' && runner.environment == 'github-hosted'
       shell: bash
       run: |
         echo "::warning title=Deactivating UseContainerSupport::The GitHub-hosted Ubuntu runners have an issue with Java's" \
@@ -194,7 +194,7 @@ runs:
         echo "JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS:=-XX:-UseContainerSupport}" >> "$GITHUB_ENV"
 
     - name: Create mvn wrapper function with common Maven flags and set MAVEN_OPTS
-      if: steps.from-env.outputs.skip != 'true'
+      if: steps.config-maven-completed.outputs.skip != 'true'
       shell: bash
       env:
         COMMON_MVN_FLAGS: ${{ inputs.common-mvn-flags }}

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: Relative path under github.workspace to execute the build in
     default: .
   artifactory-reader-role:
-    description: Suffix for the Artifactory reader role in Vault.
-      Defaults to `private-reader` for private repositories, and `public-reader` for public repositories.
+    description: Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories, and `public-reader`
+      for public repositories.
     default: ''
   cache-npm:
     description: Whether to cache NPM dependencies

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -174,6 +174,24 @@ Describe 'export_built_artifacts()'
     The output should be blank
     The contents of file "$GITHUB_OUTPUT" should not include "artifact-paths<<EOF"
   End
+
+  It 'reports no artifacts found when build directory is empty'
+    GITHUB_OUTPUT=$(mktemp)
+    export GITHUB_OUTPUT
+    echo "should-deploy=true" >> "$GITHUB_OUTPUT"
+    Mock grep
+      echo "should-deploy=true"
+    End
+
+    When call export_built_artifacts
+    The status should be success
+    The lines of stdout should equal 3
+    The line 1 should equal "::group::Capturing built artifacts for attestation"
+    The line 2 should equal "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
+    The line 3 should equal "::endgroup::"
+    The lines of contents of file "$GITHUB_OUTPUT" should equal 1
+    The line 1 of contents of file "$GITHUB_OUTPUT" should equal "should-deploy=true"
+  End
 End
 
 Describe 'set_sonar_platform_vars() - poetry specific'

--- a/spec/set_gradle_project_version_spec.sh
+++ b/spec/set_gradle_project_version_spec.sh
@@ -27,10 +27,12 @@ Include config-gradle/set_gradle_project_version.sh
 Describe 'set_gradle_cmd()'
   It 'uses gradlew when available'
     touch ./gradlew
+    chmod +x ./gradlew
 
     When call set_gradle_cmd
     The status should be success
-    The lines of output should equal 0
+    The lines of output should equal 1
+    The line 1 should equal "./gradlew"
     The variable GRADLE_CMD should equal "./gradlew"
 
     rm -f ./gradlew
@@ -92,8 +94,9 @@ Describe 'set_project_version()'
     The line 3 should equal "PROJECT_VERSION=1.2.3.42"
     The variable CURRENT_VERSION should equal "1.2.3-SNAPSHOT"
     The variable PROJECT_VERSION should equal "1.2.3.42"
-    The lines of contents of file "$GITHUB_OUTPUT" should equal 1
-    The line 1 of contents of file "$GITHUB_OUTPUT" should equal "project-version=1.2.3.42"
+    The lines of contents of file "$GITHUB_OUTPUT" should equal 2
+    The line 1 of contents of file "$GITHUB_OUTPUT" should equal "current-version=1.2.3-SNAPSHOT"
+    The line 2 of contents of file "$GITHUB_OUTPUT" should equal "project-version=1.2.3.42"
     The lines of contents of file "$GITHUB_ENV" should equal 2
     The line 1 of contents of file "$GITHUB_ENV" should equal "CURRENT_VERSION=1.2.3-SNAPSHOT"
     The line 2 of contents of file "$GITHUB_ENV" should equal "PROJECT_VERSION=1.2.3.42"
@@ -111,8 +114,9 @@ Describe 'set_project_version()'
     The line 3 should equal "PROJECT_VERSION=1.2.0.42"
     The variable CURRENT_VERSION should equal "1.2-SNAPSHOT"
     The variable PROJECT_VERSION should equal "1.2.0.42"
-    The lines of contents of file "$GITHUB_OUTPUT" should equal 1
-    The line 1 of contents of file "$GITHUB_OUTPUT" should equal "project-version=1.2.0.42"
+    The lines of contents of file "$GITHUB_OUTPUT" should equal 2
+    The line 1 of contents of file "$GITHUB_OUTPUT" should equal "current-version=1.2-SNAPSHOT"
+    The line 2 of contents of file "$GITHUB_OUTPUT" should equal "project-version=1.2.0.42"
     The lines of contents of file "$GITHUB_ENV" should equal 2
     The line 1 of contents of file "$GITHUB_ENV" should equal "CURRENT_VERSION=1.2-SNAPSHOT"
     The line 2 of contents of file "$GITHUB_ENV" should equal "PROJECT_VERSION=1.2.0.42"
@@ -124,9 +128,10 @@ Describe 'set_project_version()'
     End
     When run set_project_version
     The status should be failure
-    The lines of output should equal 0
-    The lines of error should equal 1
-    The line 1 of error should equal "ERROR: Could not get valid version from Gradle properties. Got: ''"
+    The lines of output should equal 2
+    The line 1 should equal "::error title=Gradle project version::Could not get valid version from Gradle properties"
+    The line 2 should equal "ERROR: version:"
+    The lines of error should equal 0
   End
 
   It 'fails when version is unspecified'
@@ -135,9 +140,10 @@ Describe 'set_project_version()'
     End
     When run set_project_version
     The status should be failure
-    The lines of output should equal 0
-    The lines of error should equal 1
-    The line 1 of error should equal "ERROR: Could not get valid version from Gradle properties. Got: 'unspecified'"
+    The lines of output should equal 2
+    The line 1 should equal "::error title=Gradle project version::Could not get valid version from Gradle properties"
+    The line 2 should equal "ERROR: version: unspecified"
+    The lines of error should equal 0
   End
 End
 


### PR DESCRIPTION
Realign the two implementations, use the same or similar code ordering and variable names.

- build-gradle
  - remove public input (obsolete and ignored by the implementation)
  - don’t export deployment secrets to the environment
- build-maven
  - add project-version output
  - use USER_MAVEN_ARGS in the script instead of command line call parameters
- config-gradle
  - use [https://github.com/SonarSource/ci-github-actions/tree/master/cacheCan't find link](https://github.com/SonarSource/ci-github-actions/tree/master/cache)  instead of [SonarSource/gh-action_cache](https://github.com/SonarSource/gh-action_cache) 
  - add missing current-version output

100% code coverage

Tested with:
- https://github.com/SonarSource/sonar-dummy/pull/521
- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/316