### PR TITLE
PREQ-2958 define sonar scanner prefix

### DIFF
--- a/config-maven/resources/settings.xml
+++ b/config-maven/resources/settings.xml
@@ -57,4 +57,8 @@
       </pluginRepositories>
     </profile>
   </profiles>
+  <pluginGroups>
+    <pluginGroup>com.gradle</pluginGroup>
+    <pluginGroup>org.sonarsource.scanner.maven</pluginGroup>
+  </pluginGroups>
 </settings>


### PR DESCRIPTION
Since the sonar shorthand was removed from maven central metadata, we need to define a plugin prefix.

This pull request makes a minor update to the Maven `settings.xml` configuration by adding two plugin groups, which will make it easier to use plugins from those groups without specifying the full group ID. 

* Added `com.gradle` and `org.sonarsource.scanner.maven` to the `<pluginGroups>` section in `settings.xml`.