### PR TITLE
BUILD-9854 use --ignore-scripts for npm and yarn

### DIFF
--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -188,7 +188,7 @@ get_build_config() {
 # Complete build pipeline with optional steps
 run_standard_pipeline() {
   echo "Installing npm dependencies..."
-  npm ci
+  npm ci --ignore-scripts
 
   if [ "$SKIP_TESTS" != "true" ]; then
     echo "Running tests..."

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -245,7 +245,7 @@ get_build_config() {
 # Complete build pipeline with optional steps
 run_standard_pipeline() {
   echo "Installing yarn dependencies..."
-  yarn install --immutable
+  yarn install --immutable --ignore-scripts
 
   if [ "$SKIP_TESTS" != "true" ]; then
     echo "Running tests..."


### PR DESCRIPTION
Follow SQ recommendations to `--ignore-scripts` during npm and yarn install 