### PR TITLE
BUILD-9854 Fix yarn install

### DIFF
--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -250,7 +250,7 @@ get_build_config() {
 # Complete build pipeline with optional steps
 run_standard_pipeline() {
   echo "Installing yarn dependencies..."
-  yarn install --immutable --ignore-scripts
+  yarn install --immutable
 
   if [ "$SKIP_TESTS" != "true" ]; then
     echo "Running tests..."


### PR DESCRIPTION
`--ignore-scripts` doesn't exist for yarn v4+
Also, it seems we need legitimate scripts to run their post-install.

Broken build: https://github.com/SonarSource/echoes-react/actions/runs/19852782540/job/56883276878?pr=569#step:4:681