### PR TITLE
SC-37240 Add config-pip action

### DIFF
--- a/.cursor/cirrus-github-migration.md
+++ b/.cursor/cirrus-github-migration.md
@@ -73,7 +73,7 @@ Update this section when newer versions are released:
 
 #### Core GitHub Actions
 
-- [ ] `actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8`
+- [ ] `actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0`
 - [ ] `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
 - [ ] `actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0`
 
@@ -394,7 +394,7 @@ build_task:
 jobs:
   build:
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       # Step 1: Retrieve secrets from Vault
       - name: Vault
@@ -951,7 +951,7 @@ jobs:
   build:
     runs-on: github-ubuntu-latest-s
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: echo "Custom GitHub-hosted runner"
 ```
 
@@ -977,7 +977,7 @@ jobs:
   build:
     runs-on: sonar-m
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: echo "Private self-hosted (new generation)"
 ```
 
@@ -1192,7 +1192,7 @@ permissions:
 
 Standard order:
 
-1. `actions/checkout@v4`
+1. `actions/checkout`
 2. `jdx/mise-action` (tool setup)
 3. Build action (`build-maven@v1`, etc.)
 4. `promote@v1` (promote job only)

--- a/.shellspec
+++ b/.shellspec
@@ -1,5 +1,5 @@
 # kcov (coverage) options
---kcov-options "--include-pattern=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,config-maven,build-maven,config-npm,build-npm,build-yarn,shared,config-gradle"
+--kcov-options "--include-pattern=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,config-maven,build-maven,config-npm,build-npm,build-yarn,shared,config-gradle,config-pip"
 # --kcov-options "--exclude-pattern=.github,.idea,.git"
 
 # define minimum coverage (fail otherwise)

--- a/config-pip/action.yml
+++ b/config-pip/action.yml
@@ -1,0 +1,103 @@
+---
+name: Config Pip
+description: GitHub Action to configure pip build environment with build number, authentication, and default settings
+inputs:
+  working-directory:
+    description: Relative path under github.workspace to execute the build in
+    default: .
+  artifactory-reader-role:
+    description:
+      Suffix for the Artifactory reader role in Vault. Defaults to `private-reader` for private repositories, and `public-reader`
+      for public repositories.
+    default: ''
+  repox-url:
+    description: URL for Repox
+    default: https://repox.jfrog.io
+  repox-artifactory-url:
+    description: URL for Repox Artifactory API (overrides repox-url/artifactory if provided)
+    default: ''
+  cache-paths:
+    description: Cache paths to use (multiline).
+    default: ~/.cache/pip
+  disable-caching:
+    description: Whether to disable pip caching entirely
+    default: 'false'
+  host-actions-root:
+    description: Path to the actions folder on the host (used when called from another local action)
+    default: ''
+
+outputs:
+  BUILD_NUMBER:
+    description: The current build number. Also set as environment variable BUILD_NUMBER
+    value: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set local action paths
+      id: set-path
+      shell: bash
+      run: |
+        echo "::group::Fix for using local actions"
+        echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
+        echo "github.action_path=${{ github.action_path }}"
+        ACTION_PATH_CONFIG_PIP="${{ github.action_path }}"
+        host_actions_root="${{ inputs.host-actions-root }}"
+        if [ -z "$host_actions_root" ]; then
+          host_actions_root="$(dirname "$ACTION_PATH_CONFIG_PIP")"
+        else
+          ACTION_PATH_CONFIG_PIP="$host_actions_root/config-pip"
+        fi
+        echo "ACTION_PATH_CONFIG_PIP=$ACTION_PATH_CONFIG_PIP"
+        echo "ACTION_PATH_CONFIG_PIP=$ACTION_PATH_CONFIG_PIP" >> "$GITHUB_ENV"
+        echo "host_actions_root=$host_actions_root" >> "$GITHUB_OUTPUT"
+
+        mkdir -p ".actions"
+        ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
+        ln -sf "$host_actions_root/cache" .actions/cache
+        ln -sf "$host_actions_root/shared" .actions/shared
+        ls -la .actions/*
+        echo "::endgroup::"
+
+    - uses: ./.actions/get-build-number
+      id: get-build-number
+      with:
+        host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
+
+    - name: Set Artifactory reader role
+      shell: bash
+      env:
+        # Use custom role if provided, otherwise auto-detect based on repository visibility
+        ARTIFACTORY_READER_ROLE:
+          ${{ inputs.artifactory-reader-role != '' && inputs.artifactory-reader-role ||
+          (github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader') }}
+      run: |
+        echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
+
+    - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
+      id: secrets
+      with:
+        secrets: |
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_USERNAME;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} access_token | ARTIFACTORY_ACCESS_TOKEN;
+
+    - name: Run pip configuration script
+      id: config
+      shell: bash
+      env:
+        # Use custom Artifactory URL if provided, otherwise construct from repox-url
+        ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
+          format('{0}/artifactory', inputs.repox-url) }}
+        ARTIFACTORY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}
+        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+      run: $ACTION_PATH_CONFIG_PIP/config.sh
+
+    - name: Cache pip dependencies
+      uses: ./.actions/cache
+      if: inputs.disable-caching == 'false'
+      with:
+        path: ${{ inputs.cache-paths }}
+        key: pip-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles(format('{0}/requirements*.txt', inputs.working-directory),
+          format('{0}/Pipfile.lock', inputs.working-directory), format('{0}/poetry.lock', inputs.working-directory),
+          format('{0}/pyproject.toml', inputs.working-directory)) }}
+        restore-keys: pip-${{ runner.os }}-${{ github.workflow }}-

--- a/config-pip/config.sh
+++ b/config-pip/config.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Config script for pip to use SonarSource Artifactory.
+#
+# Required environment variables (must be explicitly provided):
+# - ARTIFACTORY_URL: URL to Artifactory repository
+# - ARTIFACTORY_USERNAME: Username for Artifactory authentication
+# - ARTIFACTORY_ACCESS_TOKEN: Access token to read Repox repositories
+#
+# GitHub Actions auto-provided:
+# - GITHUB_REPOSITORY: Repository name in format "owner/repo"
+
+set -euo pipefail
+
+: "${ARTIFACTORY_URL:?}" "${ARTIFACTORY_USERNAME:?}" "${ARTIFACTORY_ACCESS_TOKEN:?}"
+
+configure_pip() {
+  echo "Configuring pip to use Artifactory..."
+
+  # Extract the host from ARTIFACTORY_URL
+  local repox_host="${ARTIFACTORY_URL#https://}"
+  repox_host="${repox_host#http://}"
+  echo "Repox host: $repox_host"
+
+  mkdir -p "$HOME/.pip"
+  cat > "${HOME}/.pip/pip.conf" <<EOF
+[global]
+index-url = https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_ACCESS_TOKEN}@$repox_host/api/pypi/sonarsource-pypi/simple
+EOF
+  echo "Configuration file: ${HOME}/.pip/pip.conf"
+  return 0
+}
+
+main() {
+  echo "::group::Configure pip"
+  configure_pip
+  echo "::endgroup::"
+  return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main
+fi

--- a/run_shell_tests.sh
+++ b/run_shell_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 LANG=
-shellspec --kcov spec "$@"
+shellspec --kcov spec "$@" --shell bash

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.projectName=ci-github-actions
 
 sonar.sourceEncoding=UTF-8
 
-sonar.sources=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-maven,config-npm,build-npm,build-yarn,shared
+sonar.sources=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-maven,config-npm,build-npm,build-yarn,shared,config-pip,cache,code-signing,config-gradle,config-maven
 sonar.tests=spec
 
 sonar.coverageReportPaths=coverage/coverage_data/sonar_coverage.xml

--- a/spec/config-pip_spec.sh
+++ b/spec/config-pip_spec.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+eval "$(shellspec - -c) exit 1"
+
+# Set up environment variables
+export GITHUB_REPOSITORY="my-org/test-project"
+export GITHUB_ENV=/dev/null
+export GITHUB_OUTPUT=/dev/null
+export ARTIFACTORY_URL="https://repox.jfrog.io/artifactory"
+export ARTIFACTORY_USERNAME="test-user"
+export ARTIFACTORY_ACCESS_TOKEN="test-token"
+
+# Expected output messages
+MESSAGE_CONFIGURING_PIP="Configuring pip to use Artifactory..."
+MESSAGE_REPOX_HOST="Repox host: repox.jfrog.io/artifactory"
+
+Describe 'config-pip/config.sh'
+  It 'does not run main when sourced'
+    When run source config-pip/config.sh
+    The status should be success
+    The lines of output should equal 0
+    The lines of error should equal 0
+  End
+End
+
+Include config-pip/config.sh
+
+common_setup() {
+  TEST_PIP_DIR=$(mktemp -d)
+  export HOME="$TEST_PIP_DIR"
+
+  return 0
+}
+
+common_cleanup() {
+  [[ -d "$TEST_PIP_DIR" ]] && rm -rf "$TEST_PIP_DIR"
+
+  return 0
+}
+
+Describe 'configure_pip()'
+  BeforeEach 'common_setup'
+  AfterEach 'common_cleanup'
+
+  It 'creates pip config directory, file and correct content'
+    When call configure_pip
+    The status should be success
+    The lines of output should equal 3
+    The lines of error should equal 0
+    The line 1 should equal "$MESSAGE_CONFIGURING_PIP"
+    The line 2 should equal "$MESSAGE_REPOX_HOST"
+    The line 3 should start with "Configuration file: "
+    The line 3 should end with "/.pip/pip.conf"
+    The path "${HOME}/.pip" should be directory
+    The path "${HOME}/.pip/pip.conf" should be file
+    The contents of file "${HOME}/.pip/pip.conf" should equal "[global]
+index-url = https://test-user:test-token@repox.jfrog.io/artifactory/api/pypi/sonarsource-pypi/simple"
+  End
+
+  It 'handles URL with custom port'
+    export ARTIFACTORY_URL="https://repox.jfrog.io:8080/artifactory"
+    When call configure_pip
+    The status should be success
+    The lines of output should equal 3
+    The lines of error should equal 0
+    The line 1 should equal "$MESSAGE_CONFIGURING_PIP"
+    The line 2 should equal "Repox host: repox.jfrog.io:8080/artifactory"
+    The line 3 should start with "Configuration file: "
+    The line 3 should end with "/.pip/pip.conf"
+    The contents of file "${HOME}/.pip/pip.conf" should equal "[global]
+index-url = https://test-user:test-token@repox.jfrog.io:8080/artifactory/api/pypi/sonarsource-pypi/simple"
+  End
+End
+
+Describe 'main()'
+  BeforeEach 'common_setup'
+  AfterEach 'common_cleanup'
+
+  It 'runs configure_pip within a GitHub Actions group and creates valid pip.conf'
+    export ARTIFACTORY_USERNAME="my-user"
+    export ARTIFACTORY_ACCESS_TOKEN="my-secret-token"
+    When run script config-pip/config.sh
+    The status should be success
+    The lines of output should equal 5
+    The lines of error should equal 0
+    The line 1 should equal "::group::Configure pip"
+    The line 2 should equal "$MESSAGE_CONFIGURING_PIP"
+    The line 3 should equal "$MESSAGE_REPOX_HOST"
+    The line 4 should start with "Configuration file: "
+    The line 4 should end with "/.pip/pip.conf"
+    The line 5 should equal "::endgroup::"
+    The path "${HOME}/.pip/pip.conf" should be file
+    The contents of file "${HOME}/.pip/pip.conf" should equal "[global]
+index-url = https://my-user:my-secret-token@repox.jfrog.io/artifactory/api/pypi/sonarsource-pypi/simple"
+  End
+End


### PR DESCRIPTION
In most of InfraSec repositories, we use pip to install `pipenv`, and we want to make sure we pull it from JFrog Artifactory.

This action configures `pip` to use the internal instead of the public pypi registry.

Tested with: https://github.com/SonarSource/infra-aws-account-vending-service/actions/runs/19966951800/job/57266012611?pr=26#step:3:1085