### PR TITLE
PREQ-3151: Bump mise version on config-npm

### DIFF
--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
-        version: 2025.7.12
+        version: 2025.11.1
 
     - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets


### PR DESCRIPTION
PREQ-3151: Bump mise version on config-npm

On https://github.com/SonarSource/ci-github-actions/pull/181, I forgot to bump config-npm and bumped in build-npm instead