### PR TITLE
PREQ-3151: upgrade mise binary to 2025.11.1 (build-poetry, build-yarn, promote)

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,7 +645,7 @@ See also [`config-gradle`](#config-gradle) input environment variables.
 >          cp <working-directory>/mise.toml mise.toml
 >      - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
 >        with:
->          version: 2025.7.12
+>          version: 2025.11.1
 >      - uses: SonarSource/ci-github-actions/build-gradle@v1
 >        with:
 >          working-directory: <working-directory>
@@ -803,7 +803,7 @@ config:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
       with:
-        version: 2025.7.12
+        version: 2025.11.1
     - uses: SonarSource/ci-github-actions/config-npm@v1
 ```
 

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -111,7 +111,7 @@ runs:
         restore-keys: poetry-${{ runner.os }}-
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
-        version: 2025.7.12
+        version: 2025.11.1
     - uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
       id: secrets
       # yamllint disable rule:line-length

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -103,7 +103,7 @@ runs:
 
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
-        version: 2025.7.12
+        version: 2025.11.1
 
     - name: Cache Yarn dependencies
       uses: ./.actions/cache

--- a/promote/action.yml
+++ b/promote/action.yml
@@ -52,7 +52,7 @@ runs:
           development/github/token/{REPO_OWNER_NAME_DASH}-promotion token | GITHUB_TOKEN;
     - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3.2.0
       with:
-        version: 2025.7.12
+        version: 2025.11.1
     - name: Promote artifacts
       shell: bash
       env:


### PR DESCRIPTION
PREQ-3151: Bump mise version

upgrade mise binary from 2025.7.12 to 2025.11.1 in build-poetry, build-yarn, promote