### PR TITLE
BUILD-9915 preserve local and Repox repositories

### DIFF
--- a/config-gradle/resources/repoxAuth.init.gradle.kts
+++ b/config-gradle/resources/repoxAuth.init.gradle.kts
@@ -30,55 +30,52 @@
  */
 
 beforeSettings {
+    logger.debug("Applying Repox configuration init script before settings evaluation")
     pluginManagement {
         repositories {
-            removeNonRepoxRepositories()
-            addRepoxRepositoryIfMissing(providers)
-            enableBearerAuthForRepoxRepositories(providers)
+            configureRepoxRepositories(providers)
         }
         // hook between repository configuration and plugin resolution
         resolutionStrategy {
             eachPlugin {
                 repositories {
-                    removeNonRepoxRepositories()
-                    addRepoxRepositoryIfMissing(providers)
-                    enableBearerAuthForRepoxRepositories(providers)
+                    configureRepoxRepositories(providers)
                 }
             }
+        }
+    }
+    dependencyResolutionManagement {
+        repositories {
+            configureRepoxRepositories(providers)
         }
     }
 }
 
 settingsEvaluated {
+    logger.debug("Applying Repox configuration init script after settings evaluation")
     pluginManagement {
         repositories {
-            removeNonRepoxRepositories()
-            addRepoxRepositoryIfMissing(providers)
-            enableBearerAuthForRepoxRepositories(providers)
+            configureRepoxRepositories(providers)
         }
     }
     dependencyResolutionManagement {
         repositories {
-            removeNonRepoxRepositories()
-            addRepoxRepositoryIfMissing(providers)
-            enableBearerAuthForRepoxRepositories(providers)
+            configureRepoxRepositories(providers)
         }
     }
 }
 
 allprojects {
     beforeEvaluate {
+        logger.debug("Applying Repox configuration init script before project '${project.name}' evaluation")
         repositories {
-            removeNonRepoxRepositories()
-            addRepoxRepositoryIfMissing(providers)
-            enableBearerAuthForRepoxRepositories(providers)
+            configureRepoxRepositories(providers)
         }
     }
     afterEvaluate {
+        logger.debug("Applying Repox configuration init script after project '${project.name}' evaluation")
         repositories {
-            removeNonRepoxRepositories()
-            addRepoxRepositoryIfMissing(providers)
-            enableBearerAuthForRepoxRepositories(providers)
+            configureRepoxRepositories(providers)
         }
     }
 }
@@ -86,6 +83,9 @@ allprojects {
 class RepoxAuth {
     companion object {
         const val host = "repox.jfrog.io"
+        val artifactoryUrl = System.getenv("ARTIFACTORY_URL") ?: "https://repox.jfrog.io/artifactory"
+        val sonarsourceRepositoryUrl =
+            RepoxAuth.artifactoryUrl.trimEnd('/') + "/" + (System.getenv("SONARSOURCE_REPOSITORY") ?: "sonarsource")
         const val authType = "header"
         const val authHeaderName = "Authorization"
         const val authValueScheme = "Bearer"
@@ -118,11 +118,7 @@ fun RepositoryHandler.addBearerAuthForRepoxRepositories(token: (String) -> Provi
             it.authentication {
                 add(create<HttpHeaderAuthentication>(RepoxAuth.authType))
             }
-            logger.info(
-                "Set '{}' auth for '{}' repository",
-                RepoxAuth.authType,
-                repoCandidate.name,
-            )
+            logger.debug("Set '{}' auth for '{}' repository", RepoxAuth.authType, repoCandidate.name)
         }
     }
 }
@@ -132,41 +128,42 @@ fun <T : Any> Provider<T>.orElse(vararg providers: Provider<T>) =
         p1.orElse(p2)
     }
 
-fun RepositoryHandler.removeNonRepoxRepositories() {
-    val reposToRemove = filter {
-        val urlRepo = it as? UrlArtifactRepository
-        // Remove if it's not a URL repository pointing to repox, or if it's mavenLocal() (not a UrlArtifactRepository)
-        urlRepo?.url?.host != RepoxAuth.host
-    }.toList()
+fun RepositoryHandler.configureRepoxRepositories(providers: ProviderFactory) {
+    addRepoxRepositoryIfMissing()
+    removeNonRepoxRepositories()
+    enableBearerAuthForRepoxRepositories(providers)
+}
 
-    reposToRemove.forEach { repo ->
-        remove(repo)
-        val repoType = when {
-            repo is UrlArtifactRepository -> "URL (host: ${repo.url.host})"
-            else -> "local/file-based (e.g., mavenLocal)"
+fun RepositoryHandler.removeNonRepoxRepositories() {
+    val reposToProcess = toList()
+    reposToProcess.forEach { repo ->
+        val urlRepo = repo as? UrlArtifactRepository
+        val repoUrl = urlRepo?.url?.toString()?.trimEnd('/')
+        val isSonarSourceRepo = repoUrl == RepoxAuth.sonarsourceRepositoryUrl
+        if (!isSonarSourceRepo) {
+            val repoInfo = repoUrl ?: "class: ${repo.javaClass.simpleName}"
+            val isLocal = urlRepo?.url?.let { it.scheme == "file" } ?: true
+            val isRepoxRepo = urlRepo?.url?.host == RepoxAuth.host
+            if (!isLocal && !isRepoxRepo) {
+                remove(repo)
+                logger.warn("Removed '{}' repository: {}", repo.name, repoInfo)
+            } else {
+                logger.info("Kept '{}' repository: {}", repo.name, repoInfo)
+            }
         }
-        logger.info(
-            "Removed non-Repox repository '{}' ({})",
-            repo.name,
-            repoType
-        )
     }
 }
 
-fun RepositoryHandler.addRepoxRepositoryIfMissing(providers: ProviderFactory) {
+fun RepositoryHandler.addRepoxRepositoryIfMissing() {
     val hasRepoxRepo = any {
         (it as? UrlArtifactRepository)?.url?.host == RepoxAuth.host
     }
-
     if (!hasRepoxRepo) {
-        val baseUrl =
-            System.getenv("ARTIFACTORY_URL") ?: providers.gradleProperty("artifactoryUrl").orNull ?: "https://repox.jfrog.io/artifactory"
-        val artifactoryUrl = baseUrl.trimEnd('/') + "/" + (System.getenv("SONARSOURCE_REPOSITORY") ?: "sonarsource")
         maven {
             name = "Repox"
-            url = uri(artifactoryUrl)
+            url = uri(RepoxAuth.sonarsourceRepositoryUrl)
         }
-        logger.info("Added Repox repository at '{}'", artifactoryUrl)
+        logger.info("Added 'Repox' repository: '{}'", RepoxAuth.sonarsourceRepositoryUrl)
     }
 }
 


### PR DESCRIPTION
BUILD-9915

Add missing dependencyResolutionManagement configuration in beforeSettings
Log added, kept and removed repositories at the warning level, to avoid use of `--info` that is very verbose. The logs can later be moved to the info level.
Do not remove repositories using Repox, and local repositories (with no URL or with the file scheme).
Ignore `artifactoryUrl` property. Use only `ARTIFACTORY_URL` environment parameter. This is useless for common usage and there is a default value of "https://repox.jfrog.io/artifactory".

Tested with 
- sonar-dummy-gradle-oss and 
```
repositories {
  mavenLocal()
  mavenCentral()
  maven {
    url 'https://repox.jfrog.io/artifactory/sonarsource'
  }
}
```
Result:
```
Added 'Repox' repository: 'https://repox.jfrog.io/artifactory/sonarsource-qa'
Added 'Repox' repository: 'https://repox.jfrog.io/artifactory/sonarsource-qa'

> Configure project :
Added 'Repox' repository: 'https://repox.jfrog.io/artifactory/sonarsource-qa'
Kept 'MavenLocal' repository: file:/home/julien.carsique/.m2/repository
Removed 'MavenRepo' repository: https://repo.maven.apache.org/maven2
Kept 'maven' repository: https://repox.jfrog.io/artifactory/sonarsource

> Configure project :sonar-dummy-gradle-oss-plugin
Added 'Repox' repository: 'https://repox.jfrog.io/artifactory/sonarsource-qa'
```
- https://github.com/SonarSource/sonarlint-intellij/pull/1585
```
Added 'Repox' repository: 'https://repox.jfrog.io/artifactory/sonarsource'
Added 'Repox' repository: 'https://repox.jfrog.io/artifactory/sonarsource'
Kept 'Local IntelliJ Platform Artifacts Repository' repository: class: DefaultIvyArtifactRepository_Decorated
Kept 'IntelliJ Platform Dependencies Repository' repository: https://repox.jfrog.io/artifactory/jetbrains-intellij-dependencies
Kept 'JetBrains IDE Installers' repository: https://repox.jfrog.io/artifactory/jetbrains-download
Kept 'Android Studio Installers' repository: https://repox.jfrog.io/artifactory/android-studio

> Configure project :clion
Added 'Repox' repository: 'https://repox.jfrog.io/artifactory/sonarsource'
No local installation of CLion found, using version 2023.1.7
...
```
