### PR TITLE
BUILD-9954 no conditional skip of get-build-number in config-npm

### DIFF
--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -120,7 +120,6 @@ runs:
 
     - uses: ./.actions/get-build-number
       id: get_build_number
-      if: ${{ steps.check_package_json.outputs.exists == 'true' }}
       with:
         host-actions-root: ${{ steps.setup.outputs.host_actions_root }}
 


### PR DESCRIPTION
Remove the conditional skip on call to get-build-number in config-npm. The need for a build number does not relate to the presence of a package.json file.