### PR TITLE
BUILD-9956 move cache action to SonarSource/gh-action_cache

### DIFF
--- a/.cursor/cirrus-github-migration.md
+++ b/.cursor/cirrus-github-migration.md
@@ -814,7 +814,7 @@ The SonarQube platform used for analysis is based on the `SONAR_HOST_URL` in you
 Adaptive cache action that automatically chooses the appropriate caching backend based on repository visibility.
 
 ```yaml
-- uses: SonarSource/ci-github-actions/cache@v1
+- uses: SonarSource/gh-action_cache@v1
   with:
     path: |
       ~/.m2/repository

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -104,7 +104,7 @@ runs:
       with:
         host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
     - name: Cache local Poetry cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: SonarSource/gh-action_cache@v1
       with:
         path: ${{ github.workspace }}/${{ inputs.poetry-cache-dir }}
         key: poetry-${{ runner.os }}-${{ hashFiles('poetry.lock') }}

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -79,7 +79,6 @@ runs:
 
         mkdir -p ".actions"
         ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
-        ln -sf "$host_actions_root/cache" .actions/cache
         ln -sf "$host_actions_root/shared" .actions/shared
         ls -la .actions/*
         echo "::endgroup::"
@@ -106,7 +105,7 @@ runs:
         version: 2025.11.1
 
     - name: Cache Yarn dependencies
-      uses: ./.actions/cache
+      uses: SonarSource/gh-action_cache@v1
       if: ${{ inputs.cache-yarn == 'true' }}
       with:
         path: |

--- a/cache/action.yml
+++ b/cache/action.yml
@@ -1,6 +1,5 @@
-name: Adaptive Cache Action
+name: Adaptive Cache Action (Deprecated)
 description: Automatically chooses GitHub Actions cache for public repos, S3 for private/internal repos
-author: SonarSource
 
 inputs:
   path:
@@ -26,56 +25,19 @@ inputs:
 outputs:
   cache-hit:
     description: A boolean value to indicate an exact match was found for the primary key
-    value: ${{ steps.github-cache.outputs.cache-hit || steps.s3-cache.outputs.cache-hit }}
+    value: ${{ steps.cache.outputs.cache-hit || steps.cache.outputs.cache-hit }}
 
 runs:
   using: composite
   steps:
-    - name: Determine repository visibility
-      id: repo-visibility
+    - id: warning
       shell: bash
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
       run: |
-        REPO_VISIBILITY="${{ github.event.repository.visibility }}"
+        echo "::warning:: This action is deprecated and will be removed in future releases. " \
+          "Please migrate to using the SonarSource/gh-action_cache action directly."
 
-        # If visibility is not available in the event, try to get it from the API
-        if [ -z "$REPO_VISIBILITY" ] || [ "$REPO_VISIBILITY" = "null" ]; then
-          REPO_VISIBILITY=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            "https://api.github.com/repos/${{ github.repository }}" | \
-            jq -r '.visibility // "private"')
-        fi
-
-        echo "Repository visibility: $REPO_VISIBILITY"
-
-        if [ "$REPO_VISIBILITY" = "public" ]; then
-          CACHE_BACKEND="github"
-          echo "Using GitHub cache for public repository"
-        else
-          CACHE_BACKEND="s3"
-          echo "Using S3 cache for private/internal repository"
-        fi
-
-        echo "cache-backend=$CACHE_BACKEND" >> $GITHUB_OUTPUT
-        echo "repo-visibility=$REPO_VISIBILITY" >> $GITHUB_OUTPUT
-
-    - name: Cache with GitHub Actions (public repos)
-      if: steps.repo-visibility.outputs.cache-backend == 'github'
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      id: github-cache
-      with:
-        path: ${{ inputs.path }}
-        key: ${{ inputs.key }}
-        restore-keys: ${{ inputs.restore-keys }}
-        upload-chunk-size: ${{ inputs.upload-chunk-size }}
-        enableCrossOsArchive: ${{ inputs.enableCrossOsArchive }}
-        fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}
-        lookup-only: ${{ inputs.lookup-only }}
-
-    - name: Cache with S3 (private/internal repos)
-      if: steps.repo-visibility.outputs.cache-backend == 's3'
-      uses: SonarSource/gh-action_cache@v1
-      id: s3-cache
+    - uses: SonarSource/gh-action_cache@v1
+      id: cache
       with:
         path: ${{ inputs.path }}
         key: ${{ inputs.key }}

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -67,7 +67,6 @@ runs:
 
         mkdir -p ".actions"
         ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
-        ln -sf "$host_actions_root/cache" .actions/cache
         ln -sf "$host_actions_root/shared" .actions/shared
         ls -la .actions/*
         echo "::endgroup::"
@@ -159,7 +158,7 @@ runs:
         rm -f gradle-md5-sums.txt
 
     - name: Gradle Cache
-      uses: ./.actions/cache
+      uses: SonarSource/gh-action_cache@v1
       if: steps.config-gradle-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -68,7 +68,6 @@ runs:
 
         mkdir -p ".actions"
         ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
-        ln -sf "$host_actions_root/cache" .actions/cache
         ln -sf "$host_actions_root/shared" .actions/shared
         ls -la .actions/*
         echo "::endgroup::"
@@ -170,7 +169,7 @@ runs:
         fi
 
     - name: Cache local Maven repository
-      uses: ./.actions/cache
+      uses: SonarSource/gh-action_cache@v1
       if: steps.config-maven-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -58,7 +58,6 @@ runs:
 
         mkdir -p ".actions"
         ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
-        ln -sf "$host_actions_root/cache" .actions/cache
         ln -sf "$host_actions_root/shared" .actions/shared
         ls -la .actions/*
         echo "::endgroup::"
@@ -99,7 +98,7 @@ runs:
         echo "::endgroup::"
 
     - name: Cache NPM dependencies
-      uses: ./.actions/cache
+      uses: SonarSource/gh-action_cache@v1
       if: ${{ inputs.cache-npm == 'true' }}
       with:
         path: ~/.npm

--- a/config-pip/action.yml
+++ b/config-pip/action.yml
@@ -54,7 +54,6 @@ runs:
 
         mkdir -p ".actions"
         ln -sf "$host_actions_root/get-build-number" .actions/get-build-number
-        ln -sf "$host_actions_root/cache" .actions/cache
         ln -sf "$host_actions_root/shared" .actions/shared
         ls -la .actions/*
         echo "::endgroup::"
@@ -93,7 +92,7 @@ runs:
       run: $ACTION_PATH_CONFIG_PIP/config.sh
 
     - name: Cache pip dependencies
-      uses: ./.actions/cache
+      uses: SonarSource/gh-action_cache@v1
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}


### PR DESCRIPTION
BUILD-9956 move cache action to https://github.com/SonarSource/gh-action_cache
This is resolving the weird issue with missing input 'path'

Depends on https://github.com/SonarSource/gh-action_cache/pull/27

Deprecate cache/action.yml 
- display warning
- call SonarSource/gh-action_cache

Tested with: https://github.com/SonarSource/sonar-dummy-maven-enterprise/pull/113