### PR TITLE
PREQ-3425 append auth to .yarnrc.yml

### DIFF
--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -95,7 +95,7 @@ set_build_env() {
 registry=$NPM_ARTIFACTORY_URL
 ${ARTIFACTORY_URL#https:}/api/npm/:_authToken=${ARTIFACTORY_ACCESS_TOKEN}
 EOF
-  cat <<EOF > .yarnrc.yml
+  cat <<EOF >> .yarnrc.yml
 npmRegistryServer: "$NPM_ARTIFACTORY_URL"
 npmPublishRegistry: "$NPM_ARTIFACTORY_URL"
 npmRegistries:


### PR DESCRIPTION
PREQ-3425 append auth to .yarnrc.yml in order to preserve eventual other configuration as in https://github.com/SonarSource/echoes-react/pull/606