### PR TITLE
PREQ-3628 Handle -Dmaven.install.skip=true in build-maven action

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ When set to `true`, this input option configures the build to handle both public
 
 - The Maven Artifactory plugin will not publish the artifacts.
 - The artifacts are individually deployed after the build with the JFrog CLI to their respective repositories.
+- This feature relies on Maven install being enabled (`maven.install.skip=false`).
 
 It is possible to customize the target public and private repository names and the roles used for deployment by setting the input parameters
 for the public values, and by setting the environment variables for the private values:

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -205,7 +205,7 @@ build_maven() {
 export_built_artifacts() {
   local installed_artifacts deployed build_dir artifacts
 
-  installed_artifacts=$(grep Installing "$mvn_output" | sed 's,.*\.m2/repository/,,')
+  installed_artifacts=$(grep Installing "$mvn_output" | sed 's,.*\.m2/repository/,,' || true)
   {
     echo "installed-artifacts<<EOF"
     echo "$installed_artifacts"


### PR DESCRIPTION
### Problem

The build-maven action fails with exit code 1 when the Maven build uses `-Dmaven.install.skip=true`, even though Maven itself reports BUILD SUCCESS. 

Example: https://github.com/SonarSource/sonarlint-eclipse/actions/runs/21145102642/job/60812714640

### Root Cause

In export_built_artifacts(), line 208 uses grep to find installed artifacts:

```bash
installed_artifacts=\$(grep Installing "\$mvn_output" \| sed 's,.\*\\m2/repository/,,')
```

When `-Dmaven.install.skip=true` is passed to Maven:

- Maven skips the install phase and outputs `[INFO] Skipping artifact installation`
- `grep` finds no matches and returns *exit code 1*
- Due to `set -euo pipefail` at the top of the script, this causes the entire script to exit with code 1

This prevents subsequent steps (like SonarQube analysis) from running, even though the build itself succeeded.

### Validation

Tested with https://github.com/SonarSource/sonarlint-eclipse/actions/runs/21173322820/job/60901969239