### PR TITLE
PREQ-3599 Fix hashFiles failure in post step by using absolute path

### DIFF
--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -173,7 +173,7 @@ runs:
       if: steps.config-maven-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}
-        key: maven-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles(format('{0}/**/pom.xml', inputs.working-directory)) }}
+        key: maven-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles(format('{0}/{1}/**/pom.xml', github.workspace, inputs.working-directory)) }}
         restore-keys: maven-${{ runner.os }}-${{ github.workflow }}-
 
     - name: Update project version and set current-version and project-version variables


### PR DESCRIPTION
## Summary
- Fix `hashFiles()` failure in post (cleanup) step of `config-maven` action
- Use `github.workspace` to construct absolute path instead of relying on `inputs.working-directory` alone

## Problem
The GitHub Actions workflow for `sonar-security` repository is failing in the post (cleanup) step with error:

```
Error: The template is not valid. SonarSource/ci-github-actions/v1/config-maven/action.yml (Line: 176, Col: 14): hashFiles('/**/pom.xml') failed. Fail to hash files under directory '/home/runner/_work/sonar-security/sonar-security'
```

### Root Cause
During the **post cleanup phase** of composite actions:
- The `inputs.working-directory` parameter evaluates to empty or `/` (root)
- This causes `format('{0}/**/pom.xml', inputs.working-directory)` to become `/**/pom.xml`
- `hashFiles('/**/pom.xml')` attempts to search from filesystem root, causing failures

## Solution
Changed line 176 from:
```yaml
key: maven-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles(format('{0}/**/pom.xml', inputs.working-directory)) }}
```

To:
```yaml
key: maven-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles(format('{0}/{1}/**/pom.xml', github.workspace, inputs.working-directory)) }}
```

This uses `github.workspace` to create an absolute path that remains valid throughout the entire action lifecycle, including the post cleanup phase.

## Testing
A companion draft PR in `sonar-security` will test this fix by using this branch: `SonarSource/ci-github-actions@feat/smarini/PREQ-3599-fix-hashFiles-post-step`

## References
- JIRA: https://sonarsource.atlassian.net/browse/PREQ-3599
- Failing workflow: https://github.com/SonarSource/sonar-security/actions/runs/21014413203/job/60435250487
- Trigger commit: https://github.com/SonarSource/sonar-security/commit/26922d00d74d746437191bcf13d3d05995a8dde4