### PR TITLE
BUILD-10287 Use sonar.scm.revision instead of sonar.analysis.sha1

### DIFF
--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -133,27 +133,14 @@ build_gradle_args() {
     args+=("-Dsonar.analysis.pipeline=$GITHUB_RUN_ID")
     args+=("-Dsonar.analysis.repository=$GITHUB_REPOSITORY")
     args+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
-    args+=("-Dsonar.scm.revision=$GITHUB_SHA")
-
-    # Add branch-specific sonar arguments
-    if is_default_branch; then
-      # Master branch analysis
-      args+=("-Dsonar.analysis.sha1=$GITHUB_SHA")
-
-    elif is_maintenance_branch; then
-      # Maintenance branch analysis
-      args+=("-Dsonar.branch.name=$GITHUB_REF_NAME")
-      args+=("-Dsonar.analysis.sha1=$GITHUB_SHA")
-
-    elif is_pull_request; then
-      # Pull request analysis
-      args+=("-Dsonar.analysis.sha1=$PULL_REQUEST_SHA")
+    if is_pull_request; then
+      args+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
       args+=("-Dsonar.analysis.prNumber=$PULL_REQUEST")
-
-    elif is_long_lived_feature_branch; then
-      # Long-lived feature branch analysis
-      args+=("-Dsonar.branch.name=$GITHUB_REF_NAME")
-      args+=("-Dsonar.analysis.sha1=$GITHUB_SHA")
+    else
+      args+=("-Dsonar.scm.revision=$GITHUB_SHA")
+      if is_maintenance_branch || is_long_lived_feature_branch; then
+        args+=("-Dsonar.branch.name=$GITHUB_REF_NAME")
+      fi
     fi
   fi
 

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -86,7 +86,12 @@ sonar_scanner_implementation() {
     local additional_params=("$@")
     # Build sonar properties (using orchestrator-provided SONAR_HOST_URL/SONAR_TOKEN)
     local sonar_props=("-Dsonar.host.url=${SONAR_HOST_URL}" "-Dsonar.token=${SONAR_TOKEN}")
-    sonar_props+=("-Dsonar.projectVersion=${CURRENT_VERSION}" "-Dsonar.scm.revision=$GITHUB_SHA")
+    sonar_props+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
+    if is_pull_request; then
+        sonar_props+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
+    else
+        sonar_props+=("-Dsonar.scm.revision=${GITHUB_SHA}")
+    fi
     sonar_props+=("${additional_params[@]+"${additional_params[@]}"}")
 
     echo "Maven command: mvn $SONAR_GOAL ${sonar_props[*]}"

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -85,10 +85,13 @@ sonar_scanner_implementation() {
     scanner_args+=("-Dsonar.token=${SONAR_TOKEN}")
     scanner_args+=("-Dsonar.analysis.buildNumber=${BUILD_NUMBER}")
     scanner_args+=("-Dsonar.analysis.pipeline=${GITHUB_RUN_ID}")
-    scanner_args+=("-Dsonar.analysis.sha1=${GITHUB_SHA}")
+    if is_pull_request; then
+        scanner_args+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
+    else
+        scanner_args+=("-Dsonar.scm.revision=${GITHUB_SHA}")
+    fi
     scanner_args+=("-Dsonar.analysis.repository=${GITHUB_REPOSITORY}")
     scanner_args+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
-    scanner_args+=("-Dsonar.scm.revision=${GITHUB_SHA}")
 
     # Add region parameter only for sqc-us platform
     if [ -n "${SONAR_REGION:-}" ]; then

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -108,6 +108,12 @@ set_sonar_platform_vars() {
 
 run_sonar_scanner() {
     local additional_params=("$@")
+    local sonar_sha
+    if is_pull_request; then
+        sonar_sha="${PULL_REQUEST_SHA:?}"
+    else
+        sonar_sha="${GITHUB_SHA}"
+    fi
 
     # Install pysonar into Poetry's virtual environment without modifying project files
     poetry run pip install pysonar
@@ -115,7 +121,7 @@ run_sonar_scanner() {
         "-Dsonar.host.url=${SONAR_HOST_URL}" \
         "-Dsonar.analysis.buildNumber=${BUILD_NUMBER}" \
         "-Dsonar.analysis.pipeline=${GITHUB_RUN_ID}" \
-        "-Dsonar.analysis.sha1=${GITHUB_SHA}" \
+        "-Dsonar.scm.revision=${sonar_sha}" \
         "-Dsonar.analysis.repository=${GITHUB_REPOSITORY}" \
         "${additional_params[@]+${additional_params[@]}}"
     poetry run pysonar \
@@ -123,7 +129,7 @@ run_sonar_scanner() {
         -Dsonar.token="${SONAR_TOKEN}" \
         -Dsonar.analysis.buildNumber="${BUILD_NUMBER}" \
         -Dsonar.analysis.pipeline="${GITHUB_RUN_ID}" \
-        -Dsonar.analysis.sha1="${GITHUB_SHA}" \
+        -Dsonar.scm.revision="${sonar_sha}" \
         -Dsonar.analysis.repository="${GITHUB_REPOSITORY}" \
         "${additional_params[@]+${additional_params[@]}}"
 }

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -137,6 +137,7 @@ runs:
       env:
         # GitHub context
         PULL_REQUEST: ${{ github.event.pull_request.number || '' }}
+        PULL_REQUEST_SHA: ${{ github.event.pull_request.base.sha || '' }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
         # Action inputs

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -156,10 +156,13 @@ sonar_scanner_implementation() {
     scanner_args+=("-Dsonar.token=${SONAR_TOKEN}")
     scanner_args+=("-Dsonar.analysis.buildNumber=${BUILD_NUMBER}")
     scanner_args+=("-Dsonar.analysis.pipeline=${GITHUB_RUN_ID}")
-    scanner_args+=("-Dsonar.analysis.sha1=${GITHUB_SHA}")
+    if is_pull_request; then
+        scanner_args+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
+    else
+        scanner_args+=("-Dsonar.scm.revision=${GITHUB_SHA}")
+    fi
     scanner_args+=("-Dsonar.analysis.repository=${GITHUB_REPOSITORY}")
     scanner_args+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
-    scanner_args+=("-Dsonar.scm.revision=${GITHUB_SHA}")
 
     # Add region parameter only for sqc-us platform
     if [ -n "${SONAR_REGION:-}" ]; then

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -226,7 +226,7 @@ Describe 'build_gradle_args'
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
     The output should include "-Dsonar.projectVersion=1.0.0-SNAPSHOT"
-    The output should include "-Dsonar.analysis.sha1=abc123def456"
+    The output should include "-Dsonar.scm.revision=abc123def456"
   End
 
   It 'includes sonar args for maintenance branch'
@@ -247,6 +247,7 @@ Describe 'build_gradle_args'
     export SONAR_HOST_URL="https://sonar.example.com"
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
+    The output should include "-Dsonar.scm.revision=base123"
     The output should include "-Dsonar.analysis.prNumber=123"
   End
 
@@ -257,7 +258,7 @@ Describe 'build_gradle_args'
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
     The output should include "-Dsonar.branch.name=feature/long/my-feature"
-    The output should include "-Dsonar.analysis.sha1=abc123def456"
+    The output should include "-Dsonar.scm.revision=abc123def456"
   End
 
   It 'includes additional gradle args'

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -218,6 +218,18 @@ Describe 'run_sonar_scanner()'
     The line 2 should include "-Dsonar.pullrequest.key=123"
     The lines of stdout should equal 2
   End
+
+  It 'uses PULL_REQUEST_SHA for sonar.scm.revision when in a pull request'
+    export GITHUB_SHA="commit-sha-123"
+    export PULL_REQUEST_SHA="pr-base-sha-456"
+    export GITHUB_EVENT_NAME="pull_request"
+    export PULL_REQUEST="123"
+    When call sonar_scanner_implementation
+    The status should be success
+    The line 2 should include "-Dsonar.scm.revision=pr-base-sha-456"
+    The line 2 should not include "-Dsonar.scm.revision=commit-sha-123"
+    The lines of stdout should equal 2
+  End
 End
 
 Describe 'orchestrate_sonar_platforms()'

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -226,6 +226,7 @@ Describe 'build_npm()'
     export GITHUB_REF_NAME="123/merge"
     export DEPLOY_PULL_REQUEST="false"
     export PULL_REQUEST="123"
+    export PULL_REQUEST_SHA="pr-base-sha-123"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -241,6 +242,7 @@ Describe 'build_npm()'
     export GITHUB_REF_NAME="123/merge"
     export DEPLOY_PULL_REQUEST="true"
     export PULL_REQUEST="123"
+    export PULL_REQUEST_SHA="pr-base-sha-123"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -312,10 +314,9 @@ Describe 'sonar_scanner_implementation()'
     The output should include "-Dsonar.token=test-token"
     The output should include "-Dsonar.analysis.buildNumber=42"
     The output should include "-Dsonar.analysis.pipeline=12345"
-    The output should include "-Dsonar.analysis.sha1=abc123"
+    The output should include "-Dsonar.scm.revision=abc123"
     The output should include "-Dsonar.analysis.repository=test/repo"
     The output should include "-Dsonar.projectVersion=1.2.3"
-    The output should include "-Dsonar.scm.revision=abc123"
   End
 
   It 'runs sonar scanner with region parameter for sqc-us'
@@ -342,6 +343,22 @@ Describe 'sonar_scanner_implementation()'
     The status should be success
     The output should include "-Dsonar.pullrequest.key=123"
     The output should include "-Dsonar.branch.name=feature"
+  End
+
+  It 'uses PULL_REQUEST_SHA for sonar.scm.revision when in a pull request'
+    export SONAR_HOST_URL="https://sonar.example.com"
+    export SONAR_TOKEN="test-token"
+    export BUILD_NUMBER="42"
+    export GITHUB_RUN_ID="12345"
+    export GITHUB_SHA="commit-sha-123"
+    export PULL_REQUEST_SHA="pr-base-sha-456"
+    export GITHUB_REPOSITORY="test/repo"
+    export GITHUB_EVENT_NAME="pull_request"
+    export PULL_REQUEST="123"
+    When call sonar_scanner_implementation
+    The status should be success
+    The output should include "-Dsonar.scm.revision=pr-base-sha-456"
+    The output should not include "-Dsonar.scm.revision=commit-sha-123"
   End
 End
 

--- a/spec/build-yarn_spec.sh
+++ b/spec/build-yarn_spec.sh
@@ -304,10 +304,26 @@ Describe 'build-yarn/build.sh'
       The output should include "-Dsonar.token=test-token"
       The output should include "-Dsonar.analysis.buildNumber=42"
       The output should include "-Dsonar.analysis.pipeline=12345"
-      The output should include "-Dsonar.analysis.sha1=abc123"
+      The output should include "-Dsonar.scm.revision=abc123"
       The output should include "-Dsonar.analysis.repository=test/repo"
       The output should include "-Dsonar.projectVersion=1.2.3"
-      The output should include "-Dsonar.scm.revision=abc123"
+    End
+
+    It 'uses PULL_REQUEST_SHA for sonar.scm.revision when in a pull request'
+      export SONAR_HOST_URL="https://sonar.example.com"
+      export SONAR_TOKEN="test-token"
+      export BUILD_NUMBER="42"
+      export GITHUB_RUN_ID="12345"
+      export GITHUB_SHA="commit-sha-123"
+      export PULL_REQUEST_SHA="pr-base-sha-456"
+      export GITHUB_REPOSITORY="test/repo"
+      export CURRENT_VERSION="1.2.3"
+      export GITHUB_EVENT_NAME="pull_request"
+      export PULL_REQUEST="123"
+      When call sonar_scanner_implementation
+      The status should be success
+      The output should include "-Dsonar.scm.revision=pr-base-sha-456"
+      The output should not include "-Dsonar.scm.revision=commit-sha-123"
     End
 
     It 'runs sonar scanner with region parameter for sqc-us'
@@ -396,7 +412,7 @@ Describe 'build-yarn/build.sh'
 
     It 'builds pull request with deploy enabled'
       export GITHUB_REF_NAME="feature/test" GITHUB_EVENT_NAME="pull_request" PROJECT="test"
-      export PULL_REQUEST="123" DEPLOY_PULL_REQUEST="true"
+      export PULL_REQUEST="123" PULL_REQUEST_SHA="pr-base-sha-123" DEPLOY_PULL_REQUEST="true"
       When call build_yarn
       The status should be success
       The output should include "======= Building pull request ======="
@@ -405,7 +421,7 @@ Describe 'build-yarn/build.sh'
 
     It 'builds pull request without deploy'
       export GITHUB_REF_NAME="feature/test" GITHUB_EVENT_NAME="pull_request" PROJECT="test"
-      export PULL_REQUEST="123" DEPLOY_PULL_REQUEST="false"
+      export PULL_REQUEST="123" PULL_REQUEST_SHA="pr-base-sha-123" DEPLOY_PULL_REQUEST="false"
       When call build_yarn
       The status should be success
       The output should include "======= Building pull request ======="


### PR DESCRIPTION
BUILD-10287

This PR replaces the obsolete `sonar.analysis.sha1` property with `sonar.scm.revision` across all build-* actions.

Prefer https://github.com/SonarSource/ci-github-actions/pull/205 if it works without `sonar.scm.revision` parameter.

### Changes

**Property Migration:**
- Removed `sonar.analysis.sha1` (obsolete)
- Added `sonar.scm.revision` with proper value assignment

**Value Logic:**
- For pull requests: `sonar.scm.revision=PULL_REQUEST_SHA`
- For other builds: `sonar.scm.revision=GITHUB_SHA`

### Affected Files

**Build Scripts:**
- `build-maven/build.sh` - Added conditional logic for sonar.scm.revision
- `build-gradle/build.sh` - Simplified branch-specific logic and migrated property
- `build-npm/build.sh` - Migrated from sonar.analysis.sha1 to sonar.scm.revision
- `build-yarn/build.sh` - Migrated from sonar.analysis.sha1 to sonar.scm.revision
- `build-poetry/build.sh` - Migrated from sonar.analysis.sha1 to sonar.scm.revision

**Test Coverage:**
- Updated all spec files to verify `sonar.scm.revision` is used correctly
- Added specific test cases for `PULL_REQUEST_SHA` usage in PR scenarios

### Tests

- Maven: https://github.com/SonarSource/sonar-dummy/pull/549 :heavy_check_mark: 
- Gradle: https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/329 :x: 
- NPM: https://github.com/SonarSource/sonar-dummy-js/pull/117 :heavy_check_mark: 
- Yarn: https://github.com/SonarSource/sonar-dummy-yarn/pull/42
- Poetry: https://github.com/SonarSource/sonar-dummy-python-oss/pull/77 :heavy_check_mark: 