### PR TITLE
BUILD-10287 Test without sonar.scm.revision parameter

### DIFF
--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -133,27 +133,14 @@ build_gradle_args() {
     args+=("-Dsonar.analysis.pipeline=$GITHUB_RUN_ID")
     args+=("-Dsonar.analysis.repository=$GITHUB_REPOSITORY")
     args+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
-    args+=("-Dsonar.scm.revision=$GITHUB_SHA")
-
-    # Add branch-specific sonar arguments
-    if is_default_branch; then
-      # Master branch analysis
-      args+=("-Dsonar.analysis.sha1=$GITHUB_SHA")
-
-    elif is_maintenance_branch; then
-      # Maintenance branch analysis
-      args+=("-Dsonar.branch.name=$GITHUB_REF_NAME")
-      args+=("-Dsonar.analysis.sha1=$GITHUB_SHA")
-
-    elif is_pull_request; then
-      # Pull request analysis
-      args+=("-Dsonar.analysis.sha1=$PULL_REQUEST_SHA")
+    if is_pull_request; then
+      args+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
       args+=("-Dsonar.analysis.prNumber=$PULL_REQUEST")
-
-    elif is_long_lived_feature_branch; then
-      # Long-lived feature branch analysis
-      args+=("-Dsonar.branch.name=$GITHUB_REF_NAME")
-      args+=("-Dsonar.analysis.sha1=$GITHUB_SHA")
+    else
+      args+=("-Dsonar.scm.revision=$GITHUB_SHA")
+      if is_maintenance_branch || is_long_lived_feature_branch; then
+        args+=("-Dsonar.branch.name=$GITHUB_REF_NAME")
+      fi
     fi
   fi
 

--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -134,13 +134,9 @@ build_gradle_args() {
     args+=("-Dsonar.analysis.repository=$GITHUB_REPOSITORY")
     args+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
     if is_pull_request; then
-      args+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
       args+=("-Dsonar.analysis.prNumber=$PULL_REQUEST")
-    else
-      args+=("-Dsonar.scm.revision=$GITHUB_SHA")
-      if is_maintenance_branch || is_long_lived_feature_branch; then
-        args+=("-Dsonar.branch.name=$GITHUB_REF_NAME")
-      fi
+    elif is_maintenance_branch || is_long_lived_feature_branch; then
+      args+=("-Dsonar.branch.name=$GITHUB_REF_NAME")
     fi
   fi
 

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -87,11 +87,6 @@ sonar_scanner_implementation() {
     # Build sonar properties (using orchestrator-provided SONAR_HOST_URL/SONAR_TOKEN)
     local sonar_props=("-Dsonar.host.url=${SONAR_HOST_URL}" "-Dsonar.token=${SONAR_TOKEN}")
     sonar_props+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
-    if is_pull_request; then
-        sonar_props+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
-    else
-        sonar_props+=("-Dsonar.scm.revision=${GITHUB_SHA}")
-    fi
     sonar_props+=("${additional_params[@]+"${additional_params[@]}"}")
 
     echo "Maven command: mvn $SONAR_GOAL ${sonar_props[*]}"

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -86,7 +86,12 @@ sonar_scanner_implementation() {
     local additional_params=("$@")
     # Build sonar properties (using orchestrator-provided SONAR_HOST_URL/SONAR_TOKEN)
     local sonar_props=("-Dsonar.host.url=${SONAR_HOST_URL}" "-Dsonar.token=${SONAR_TOKEN}")
-    sonar_props+=("-Dsonar.projectVersion=${CURRENT_VERSION}" "-Dsonar.scm.revision=$GITHUB_SHA")
+    sonar_props+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
+    if is_pull_request; then
+        sonar_props+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
+    else
+        sonar_props+=("-Dsonar.scm.revision=${GITHUB_SHA}")
+    fi
     sonar_props+=("${additional_params[@]+"${additional_params[@]}"}")
 
     echo "Maven command: mvn $SONAR_GOAL ${sonar_props[*]}"

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -85,10 +85,13 @@ sonar_scanner_implementation() {
     scanner_args+=("-Dsonar.token=${SONAR_TOKEN}")
     scanner_args+=("-Dsonar.analysis.buildNumber=${BUILD_NUMBER}")
     scanner_args+=("-Dsonar.analysis.pipeline=${GITHUB_RUN_ID}")
-    scanner_args+=("-Dsonar.analysis.sha1=${GITHUB_SHA}")
+    if is_pull_request; then
+        scanner_args+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
+    else
+        scanner_args+=("-Dsonar.scm.revision=${GITHUB_SHA}")
+    fi
     scanner_args+=("-Dsonar.analysis.repository=${GITHUB_REPOSITORY}")
     scanner_args+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
-    scanner_args+=("-Dsonar.scm.revision=${GITHUB_SHA}")
 
     # Add region parameter only for sqc-us platform
     if [ -n "${SONAR_REGION:-}" ]; then

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -85,11 +85,6 @@ sonar_scanner_implementation() {
     scanner_args+=("-Dsonar.token=${SONAR_TOKEN}")
     scanner_args+=("-Dsonar.analysis.buildNumber=${BUILD_NUMBER}")
     scanner_args+=("-Dsonar.analysis.pipeline=${GITHUB_RUN_ID}")
-    if is_pull_request; then
-        scanner_args+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
-    else
-        scanner_args+=("-Dsonar.scm.revision=${GITHUB_SHA}")
-    fi
     scanner_args+=("-Dsonar.analysis.repository=${GITHUB_REPOSITORY}")
     scanner_args+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
 

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -108,6 +108,12 @@ set_sonar_platform_vars() {
 
 run_sonar_scanner() {
     local additional_params=("$@")
+    local sonar_sha
+    if is_pull_request; then
+        sonar_sha="${PULL_REQUEST_SHA:?}"
+    else
+        sonar_sha="${GITHUB_SHA}"
+    fi
 
     # Install pysonar into Poetry's virtual environment without modifying project files
     poetry run pip install pysonar
@@ -115,7 +121,7 @@ run_sonar_scanner() {
         "-Dsonar.host.url=${SONAR_HOST_URL}" \
         "-Dsonar.analysis.buildNumber=${BUILD_NUMBER}" \
         "-Dsonar.analysis.pipeline=${GITHUB_RUN_ID}" \
-        "-Dsonar.analysis.sha1=${GITHUB_SHA}" \
+        "-Dsonar.scm.revision=${sonar_sha}" \
         "-Dsonar.analysis.repository=${GITHUB_REPOSITORY}" \
         "${additional_params[@]+${additional_params[@]}}"
     poetry run pysonar \
@@ -123,7 +129,7 @@ run_sonar_scanner() {
         -Dsonar.token="${SONAR_TOKEN}" \
         -Dsonar.analysis.buildNumber="${BUILD_NUMBER}" \
         -Dsonar.analysis.pipeline="${GITHUB_RUN_ID}" \
-        -Dsonar.analysis.sha1="${GITHUB_SHA}" \
+        -Dsonar.scm.revision="${sonar_sha}" \
         -Dsonar.analysis.repository="${GITHUB_REPOSITORY}" \
         "${additional_params[@]+${additional_params[@]}}"
 }

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -108,12 +108,6 @@ set_sonar_platform_vars() {
 
 run_sonar_scanner() {
     local additional_params=("$@")
-    local sonar_sha
-    if is_pull_request; then
-        sonar_sha="${PULL_REQUEST_SHA:?}"
-    else
-        sonar_sha="${GITHUB_SHA}"
-    fi
 
     # Install pysonar into Poetry's virtual environment without modifying project files
     poetry run pip install pysonar
@@ -121,7 +115,6 @@ run_sonar_scanner() {
         "-Dsonar.host.url=${SONAR_HOST_URL}" \
         "-Dsonar.analysis.buildNumber=${BUILD_NUMBER}" \
         "-Dsonar.analysis.pipeline=${GITHUB_RUN_ID}" \
-        "-Dsonar.scm.revision=${sonar_sha}" \
         "-Dsonar.analysis.repository=${GITHUB_REPOSITORY}" \
         "${additional_params[@]+${additional_params[@]}}"
     poetry run pysonar \
@@ -129,7 +122,6 @@ run_sonar_scanner() {
         -Dsonar.token="${SONAR_TOKEN}" \
         -Dsonar.analysis.buildNumber="${BUILD_NUMBER}" \
         -Dsonar.analysis.pipeline="${GITHUB_RUN_ID}" \
-        -Dsonar.scm.revision="${sonar_sha}" \
         -Dsonar.analysis.repository="${GITHUB_REPOSITORY}" \
         "${additional_params[@]+${additional_params[@]}}"
 }

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -156,11 +156,6 @@ sonar_scanner_implementation() {
     scanner_args+=("-Dsonar.token=${SONAR_TOKEN}")
     scanner_args+=("-Dsonar.analysis.buildNumber=${BUILD_NUMBER}")
     scanner_args+=("-Dsonar.analysis.pipeline=${GITHUB_RUN_ID}")
-    if is_pull_request; then
-        scanner_args+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
-    else
-        scanner_args+=("-Dsonar.scm.revision=${GITHUB_SHA}")
-    fi
     scanner_args+=("-Dsonar.analysis.repository=${GITHUB_REPOSITORY}")
     scanner_args+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
 

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -156,10 +156,13 @@ sonar_scanner_implementation() {
     scanner_args+=("-Dsonar.token=${SONAR_TOKEN}")
     scanner_args+=("-Dsonar.analysis.buildNumber=${BUILD_NUMBER}")
     scanner_args+=("-Dsonar.analysis.pipeline=${GITHUB_RUN_ID}")
-    scanner_args+=("-Dsonar.analysis.sha1=${GITHUB_SHA}")
+    if is_pull_request; then
+        scanner_args+=("-Dsonar.scm.revision=${PULL_REQUEST_SHA:?}")
+    else
+        scanner_args+=("-Dsonar.scm.revision=${GITHUB_SHA}")
+    fi
     scanner_args+=("-Dsonar.analysis.repository=${GITHUB_REPOSITORY}")
     scanner_args+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
-    scanner_args+=("-Dsonar.scm.revision=${GITHUB_SHA}")
 
     # Add region parameter only for sqc-us platform
     if [ -n "${SONAR_REGION:-}" ]; then

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -226,7 +226,6 @@ Describe 'build_gradle_args'
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
     The output should include "-Dsonar.projectVersion=1.0.0-SNAPSHOT"
-    The output should include "-Dsonar.scm.revision=abc123def456"
   End
 
   It 'includes sonar args for maintenance branch'
@@ -247,7 +246,6 @@ Describe 'build_gradle_args'
     export SONAR_HOST_URL="https://sonar.example.com"
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
-    The output should include "-Dsonar.scm.revision=base123"
     The output should include "-Dsonar.analysis.prNumber=123"
   End
 
@@ -258,7 +256,6 @@ Describe 'build_gradle_args'
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
     The output should include "-Dsonar.branch.name=feature/long/my-feature"
-    The output should include "-Dsonar.scm.revision=abc123def456"
   End
 
   It 'includes additional gradle args'

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -226,7 +226,7 @@ Describe 'build_gradle_args'
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
     The output should include "-Dsonar.projectVersion=1.0.0-SNAPSHOT"
-    The output should include "-Dsonar.analysis.sha1=abc123def456"
+    The output should include "-Dsonar.scm.revision=abc123def456"
   End
 
   It 'includes sonar args for maintenance branch'
@@ -247,6 +247,7 @@ Describe 'build_gradle_args'
     export SONAR_HOST_URL="https://sonar.example.com"
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
+    The output should include "-Dsonar.scm.revision=base123"
     The output should include "-Dsonar.analysis.prNumber=123"
   End
 
@@ -257,7 +258,7 @@ Describe 'build_gradle_args'
     export SONAR_TOKEN="sonar-token"
     When call build_gradle_args
     The output should include "-Dsonar.branch.name=feature/long/my-feature"
-    The output should include "-Dsonar.analysis.sha1=abc123def456"
+    The output should include "-Dsonar.scm.revision=abc123def456"
   End
 
   It 'includes additional gradle args'

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -208,7 +208,6 @@ Describe 'run_sonar_scanner()'
     The line 2 should include "-Dsonar.host.url=https://test.sonarqube.com"
     The line 2 should include "-Dsonar.token=test-token"
     The line 2 should include "-Dsonar.projectVersion=1.2.3-SNAPSHOT"
-    The line 2 should include "-Dsonar.scm.revision=abc123def456"
     The lines of stdout should equal 2
   End
 
@@ -219,17 +218,6 @@ Describe 'run_sonar_scanner()'
     The lines of stdout should equal 2
   End
 
-  It 'uses PULL_REQUEST_SHA for sonar.scm.revision when in a pull request'
-    export GITHUB_SHA="commit-sha-123"
-    export PULL_REQUEST_SHA="pr-base-sha-456"
-    export GITHUB_EVENT_NAME="pull_request"
-    export PULL_REQUEST="123"
-    When call sonar_scanner_implementation
-    The status should be success
-    The line 2 should include "-Dsonar.scm.revision=pr-base-sha-456"
-    The line 2 should not include "-Dsonar.scm.revision=commit-sha-123"
-    The lines of stdout should equal 2
-  End
 End
 
 Describe 'orchestrate_sonar_platforms()'

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -218,6 +218,18 @@ Describe 'run_sonar_scanner()'
     The line 2 should include "-Dsonar.pullrequest.key=123"
     The lines of stdout should equal 2
   End
+
+  It 'uses PULL_REQUEST_SHA for sonar.scm.revision when in a pull request'
+    export GITHUB_SHA="commit-sha-123"
+    export PULL_REQUEST_SHA="pr-base-sha-456"
+    export GITHUB_EVENT_NAME="pull_request"
+    export PULL_REQUEST="123"
+    When call sonar_scanner_implementation
+    The status should be success
+    The line 2 should include "-Dsonar.scm.revision=pr-base-sha-456"
+    The line 2 should not include "-Dsonar.scm.revision=commit-sha-123"
+    The lines of stdout should equal 2
+  End
 End
 
 Describe 'orchestrate_sonar_platforms()'

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -314,7 +314,6 @@ Describe 'sonar_scanner_implementation()'
     The output should include "-Dsonar.token=test-token"
     The output should include "-Dsonar.analysis.buildNumber=42"
     The output should include "-Dsonar.analysis.pipeline=12345"
-    The output should include "-Dsonar.scm.revision=abc123"
     The output should include "-Dsonar.analysis.repository=test/repo"
     The output should include "-Dsonar.projectVersion=1.2.3"
   End
@@ -345,21 +344,6 @@ Describe 'sonar_scanner_implementation()'
     The output should include "-Dsonar.branch.name=feature"
   End
 
-  It 'uses PULL_REQUEST_SHA for sonar.scm.revision when in a pull request'
-    export SONAR_HOST_URL="https://sonar.example.com"
-    export SONAR_TOKEN="test-token"
-    export BUILD_NUMBER="42"
-    export GITHUB_RUN_ID="12345"
-    export GITHUB_SHA="commit-sha-123"
-    export PULL_REQUEST_SHA="pr-base-sha-456"
-    export GITHUB_REPOSITORY="test/repo"
-    export GITHUB_EVENT_NAME="pull_request"
-    export PULL_REQUEST="123"
-    When call sonar_scanner_implementation
-    The status should be success
-    The output should include "-Dsonar.scm.revision=pr-base-sha-456"
-    The output should not include "-Dsonar.scm.revision=commit-sha-123"
-  End
 End
 
 Describe 'get_build_config()'

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -226,6 +226,7 @@ Describe 'build_npm()'
     export GITHUB_REF_NAME="123/merge"
     export DEPLOY_PULL_REQUEST="false"
     export PULL_REQUEST="123"
+    export PULL_REQUEST_SHA="pr-base-sha-123"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -241,6 +242,7 @@ Describe 'build_npm()'
     export GITHUB_REF_NAME="123/merge"
     export DEPLOY_PULL_REQUEST="true"
     export PULL_REQUEST="123"
+    export PULL_REQUEST_SHA="pr-base-sha-123"
     export BUILD_NUMBER="42"
     When call build_npm
     The status should be success
@@ -312,10 +314,9 @@ Describe 'sonar_scanner_implementation()'
     The output should include "-Dsonar.token=test-token"
     The output should include "-Dsonar.analysis.buildNumber=42"
     The output should include "-Dsonar.analysis.pipeline=12345"
-    The output should include "-Dsonar.analysis.sha1=abc123"
+    The output should include "-Dsonar.scm.revision=abc123"
     The output should include "-Dsonar.analysis.repository=test/repo"
     The output should include "-Dsonar.projectVersion=1.2.3"
-    The output should include "-Dsonar.scm.revision=abc123"
   End
 
   It 'runs sonar scanner with region parameter for sqc-us'
@@ -342,6 +343,22 @@ Describe 'sonar_scanner_implementation()'
     The status should be success
     The output should include "-Dsonar.pullrequest.key=123"
     The output should include "-Dsonar.branch.name=feature"
+  End
+
+  It 'uses PULL_REQUEST_SHA for sonar.scm.revision when in a pull request'
+    export SONAR_HOST_URL="https://sonar.example.com"
+    export SONAR_TOKEN="test-token"
+    export BUILD_NUMBER="42"
+    export GITHUB_RUN_ID="12345"
+    export GITHUB_SHA="commit-sha-123"
+    export PULL_REQUEST_SHA="pr-base-sha-456"
+    export GITHUB_REPOSITORY="test/repo"
+    export GITHUB_EVENT_NAME="pull_request"
+    export PULL_REQUEST="123"
+    When call sonar_scanner_implementation
+    The status should be success
+    The output should include "-Dsonar.scm.revision=pr-base-sha-456"
+    The output should not include "-Dsonar.scm.revision=commit-sha-123"
   End
 End
 

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -288,39 +288,6 @@ Describe 'set_project_version()'
   End
 End
 
-Describe 'run_sonar_scanner()'
-  export SONAR_HOST_URL="https://test.sonarqube.com"
-  export SONAR_TOKEN="test-token"
-  export BUILD_NUMBER="42"
-  export GITHUB_RUN_ID="run-123"
-  export GITHUB_REPOSITORY="my-org/my-repo"
-
-  It 'uses GITHUB_SHA for sonar.scm.revision by default'
-    export GITHUB_SHA="commit-sha-abc"
-    export PULL_REQUEST=""
-    Mock poetry
-      echo "poetry $*"
-    End
-    When call run_sonar_scanner
-    The status should be success
-    The output should include "-Dsonar.scm.revision=commit-sha-abc"
-  End
-
-  It 'uses PULL_REQUEST_SHA for sonar.scm.revision when in a pull request'
-    export GITHUB_SHA="commit-sha-123"
-    export PULL_REQUEST_SHA="pr-base-sha-456"
-    export GITHUB_EVENT_NAME="pull_request"
-    export PULL_REQUEST="123"
-    Mock poetry
-      echo "poetry $*"
-    End
-    When call run_sonar_scanner
-    The status should be success
-    The output should include "-Dsonar.scm.revision=pr-base-sha-456"
-    The output should not include "-Dsonar.scm.revision=commit-sha-123"
-  End
-End
-
 Describe 'jfrog_poetry_install()'
   export PROJECT="my-repo"
   It 'installs Poetry dependencies using JFrog CLI'
@@ -370,7 +337,7 @@ Describe 'build_poetry()'
     The line 10 should equal '=== Running Sonar analysis on selected platform: next ==='
     The line 12 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
     The line 13 should equal 'poetry run pip install pysonar'
-    The line 15 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.scm.revision=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
+    The line 15 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
     The line 17 should equal 'jf config remove repox'
     The line 18 should equal 'jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>'
     The line 19 should include '/dist'
@@ -399,7 +366,7 @@ Describe 'build_poetry()'
     The line 11 should equal '=== Running Sonar analysis on selected platform: next ==='
     The line 13 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
     The line 14 should equal 'poetry run pip install pysonar'
-    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.scm.revision=dummy-sha -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
+    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
     The line 18 should equal '=== Build completed successfully ==='
     The status should be success
   End
@@ -423,7 +390,7 @@ Describe 'build_poetry()'
     The line 11 should equal '=== Running Sonar analysis on selected platform: next ==='
     The line 13 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
     The line 14 should equal 'poetry run pip install pysonar'
-    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.scm.revision=dummy-sha -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
+    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
     The line 18 should equal "jf config remove repox"
     The line 19 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>"
     The line 20 should include "/dist"
@@ -504,15 +471,15 @@ Describe 'build_poetry()'
     The line 12 should equal '--- ORCHESTRATOR: Analyzing with platform: next ---'
     The line 13 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
     The line 14 should equal 'poetry run pip install pysonar'
-    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.scm.revision=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
+    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
     The line 19 should equal '--- ORCHESTRATOR: Analyzing with platform: sqc-us ---'
     The line 20 should equal 'Using Sonar platform: sqc-us (URL: https://sonarqube-us.com)'
     The line 21 should equal 'poetry run pip install pysonar'
-    The line 23 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarqube-us.com -Dsonar.token=sqc-us-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.scm.revision=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
+    The line 23 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarqube-us.com -Dsonar.token=sqc-us-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
     The line 26 should equal '--- ORCHESTRATOR: Analyzing with platform: sqc-eu ---'
     The line 27 should equal 'Using Sonar platform: sqc-eu (URL: https://sonarcloud.io)'
     The line 28 should equal 'poetry run pip install pysonar'
-    The line 30 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=sqc-eu-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.scm.revision=dummy-sha -Dsonar.analysis.repository=my-org/my-repo'
+    The line 30 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=sqc-eu-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
     The line 32 should equal '=== Completed Sonar analysis on all platforms ==='
     The status should be success
   End

--- a/spec/build-yarn_spec.sh
+++ b/spec/build-yarn_spec.sh
@@ -304,10 +304,26 @@ Describe 'build-yarn/build.sh'
       The output should include "-Dsonar.token=test-token"
       The output should include "-Dsonar.analysis.buildNumber=42"
       The output should include "-Dsonar.analysis.pipeline=12345"
-      The output should include "-Dsonar.analysis.sha1=abc123"
+      The output should include "-Dsonar.scm.revision=abc123"
       The output should include "-Dsonar.analysis.repository=test/repo"
       The output should include "-Dsonar.projectVersion=1.2.3"
-      The output should include "-Dsonar.scm.revision=abc123"
+    End
+
+    It 'uses PULL_REQUEST_SHA for sonar.scm.revision when in a pull request'
+      export SONAR_HOST_URL="https://sonar.example.com"
+      export SONAR_TOKEN="test-token"
+      export BUILD_NUMBER="42"
+      export GITHUB_RUN_ID="12345"
+      export GITHUB_SHA="commit-sha-123"
+      export PULL_REQUEST_SHA="pr-base-sha-456"
+      export GITHUB_REPOSITORY="test/repo"
+      export CURRENT_VERSION="1.2.3"
+      export GITHUB_EVENT_NAME="pull_request"
+      export PULL_REQUEST="123"
+      When call sonar_scanner_implementation
+      The status should be success
+      The output should include "-Dsonar.scm.revision=pr-base-sha-456"
+      The output should not include "-Dsonar.scm.revision=commit-sha-123"
     End
 
     It 'runs sonar scanner with region parameter for sqc-us'
@@ -396,7 +412,7 @@ Describe 'build-yarn/build.sh'
 
     It 'builds pull request with deploy enabled'
       export GITHUB_REF_NAME="feature/test" GITHUB_EVENT_NAME="pull_request" PROJECT="test"
-      export PULL_REQUEST="123" DEPLOY_PULL_REQUEST="true"
+      export PULL_REQUEST="123" PULL_REQUEST_SHA="pr-base-sha-123" DEPLOY_PULL_REQUEST="true"
       When call build_yarn
       The status should be success
       The output should include "======= Building pull request ======="
@@ -405,7 +421,7 @@ Describe 'build-yarn/build.sh'
 
     It 'builds pull request without deploy'
       export GITHUB_REF_NAME="feature/test" GITHUB_EVENT_NAME="pull_request" PROJECT="test"
-      export PULL_REQUEST="123" DEPLOY_PULL_REQUEST="false"
+      export PULL_REQUEST="123" PULL_REQUEST_SHA="pr-base-sha-123" DEPLOY_PULL_REQUEST="false"
       When call build_yarn
       The status should be success
       The output should include "======= Building pull request ======="

--- a/spec/build-yarn_spec.sh
+++ b/spec/build-yarn_spec.sh
@@ -304,26 +304,8 @@ Describe 'build-yarn/build.sh'
       The output should include "-Dsonar.token=test-token"
       The output should include "-Dsonar.analysis.buildNumber=42"
       The output should include "-Dsonar.analysis.pipeline=12345"
-      The output should include "-Dsonar.scm.revision=abc123"
       The output should include "-Dsonar.analysis.repository=test/repo"
       The output should include "-Dsonar.projectVersion=1.2.3"
-    End
-
-    It 'uses PULL_REQUEST_SHA for sonar.scm.revision when in a pull request'
-      export SONAR_HOST_URL="https://sonar.example.com"
-      export SONAR_TOKEN="test-token"
-      export BUILD_NUMBER="42"
-      export GITHUB_RUN_ID="12345"
-      export GITHUB_SHA="commit-sha-123"
-      export PULL_REQUEST_SHA="pr-base-sha-456"
-      export GITHUB_REPOSITORY="test/repo"
-      export CURRENT_VERSION="1.2.3"
-      export GITHUB_EVENT_NAME="pull_request"
-      export PULL_REQUEST="123"
-      When call sonar_scanner_implementation
-      The status should be success
-      The output should include "-Dsonar.scm.revision=pr-base-sha-456"
-      The output should not include "-Dsonar.scm.revision=commit-sha-123"
     End
 
     It 'runs sonar scanner with region parameter for sqc-us'


### PR DESCRIPTION
BUILD-10287

This PR extends #204 with removing the `sonar.scm.revision` parameter, considering that SonarQube can auto-detect the SCM revision and the parameter is actually not needed.

### Changes

Completely removed `sonar.scm.revision` from all build scripts to test auto-detection:
- build-maven/build.sh
- build-gradle/build.sh
- build-npm/build.sh
- build-yarn/build.sh
- build-poetry/build.sh

### Tests

- Maven: https://github.com/SonarSource/sonar-dummy/pull/550 :heavy_check_mark: 
- Gradle: https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/330 :heavy_check_mark: 
- NPM: https://github.com/SonarSource/sonar-dummy-js/pull/118 :heavy_check_mark: 
- Yarn: https://github.com/SonarSource/sonar-dummy-yarn/pull/43 :heavy_check_mark: 
- Poetry: https://github.com/SonarSource/sonar-dummy-python-oss/pull/78 :heavy_check_mark: 
- https://github.com/SonarSource/sonar-text-enterprise/pull/1246 :heavy_check_mark: 