### PR TITLE
BUILD-9451 Fix PR cleanup pagination limits

### DIFF
--- a/pr_cleanup/artifact_template.tpl
+++ b/pr_cleanup/artifact_template.tpl
@@ -1,7 +1,5 @@
 {{tablerow "NAME" "ID" "SIZE (BYTES)" "BRANCH" "HEAD_SHA" "RUN_ID"}}
   {{- range .artifacts -}}
-    {{- if eq .workflow_run.head_branch "$GITHUB_HEAD_REF" -}}
-      {{- tablerow .name .id .size_in_bytes .workflow_run.head_branch .workflow_run.head_sha .workflow_run.id -}}
-    {{- end -}}
+    {{- tablerow .name .id .size_in_bytes .workflow_run.head_branch .workflow_run.head_sha .workflow_run.id -}}
   {{- end -}}
 {{- tablerender -}}

--- a/pr_cleanup/cleanup.sh
+++ b/pr_cleanup/cleanup.sh
@@ -14,14 +14,15 @@ set -euo pipefail
 : "${GITHUB_HEAD_REF:?Required environment variable not set}"
 
 CURDIR=$(dirname "$0")
+readonly CACHE_LIST_LIMIT=100000
 
 echo "::group::Cache Cleanup"
 echo "Fetching list of cache keys on $GITHUB_REPOSITORY for $CACHE_REF"
 CACHE_TEMPLATE="$(cat "$CURDIR"/cache_template.tpl)"
-gh cache list --repo "$GITHUB_REPOSITORY" --ref "$CACHE_REF" --json id,key,sizeInBytes --template "$CACHE_TEMPLATE"
+gh cache list --repo "$GITHUB_REPOSITORY" --ref "$CACHE_REF" --limit "$CACHE_LIST_LIMIT" --json id,key,sizeInBytes --template "$CACHE_TEMPLATE"
 echo
 
-cacheKeysForPR="$(gh cache list --repo "$GITHUB_REPOSITORY" --ref "$CACHE_REF" --json id --jq '.[].id')"
+cacheKeysForPR="$(gh cache list --repo "$GITHUB_REPOSITORY" --ref "$CACHE_REF" --limit "$CACHE_LIST_LIMIT" --json id --jq '.[].id')"
 echo "Deleting caches..."
 for cacheKey in $cacheKeysForPR
 do
@@ -31,7 +32,7 @@ done
 echo
 
 echo "Fetching list of cache keys after deletion"
-gh cache list --repo "$GITHUB_REPOSITORY" --ref "$CACHE_REF" --json id,key,sizeInBytes --template "$CACHE_TEMPLATE"
+gh cache list --repo "$GITHUB_REPOSITORY" --ref "$CACHE_REF" --limit "$CACHE_LIST_LIMIT" --json id,key,sizeInBytes --template "$CACHE_TEMPLATE"
 echo
 echo "::endgroup::"
 
@@ -43,10 +44,10 @@ envsubst '$GITHUB_HEAD_REF' < "$CURDIR"/artifact_template.tpl > "$tpl_tmp_file"
 ARTIFACT_TEMPLATE="$(cat "$tpl_tmp_file")"
 
 ARTIFACT_API_URL="/repos/$GITHUB_REPOSITORY/actions/artifacts"
-gh api -X GET "$ARTIFACT_API_URL" --template "$ARTIFACT_TEMPLATE"
+gh api "$ARTIFACT_API_URL" --paginate --slurp --jq '[.[].artifacts[] | select(.workflow_run.head_branch == "'"$GITHUB_HEAD_REF"'")] | {artifacts: .}' --template "$ARTIFACT_TEMPLATE"
 echo
 
-artifactIds="$(gh api -X GET "$ARTIFACT_API_URL" --jq '.artifacts[] | select(.workflow_run.head_branch == "'"$GITHUB_HEAD_REF"'") | .id')"
+artifactIds="$(gh api "$ARTIFACT_API_URL" --paginate --slurp --jq '.[].artifacts[] | select(.workflow_run.head_branch == "'"$GITHUB_HEAD_REF"'") | .id')"
 echo "Deleting artifacts..."
 for artifactId in $artifactIds
 do
@@ -56,5 +57,5 @@ done
 echo
 
 echo "Fetching list of artifacts after deletion"
-gh api -X GET "$ARTIFACT_API_URL" --template "$ARTIFACT_TEMPLATE"
+gh api "$ARTIFACT_API_URL" --paginate --slurp --jq '[.[].artifacts[] | select(.workflow_run.head_branch == "'"$GITHUB_HEAD_REF"'")] | {artifacts: .}' --template "$ARTIFACT_TEMPLATE"
 echo "::endgroup::"

--- a/spec/pr_cleanup_spec.sh
+++ b/spec/pr_cleanup_spec.sh
@@ -19,7 +19,7 @@ Describe "cleanup.sh"
         cat "$CACHE_KEY_TO_DELETE"
       elif [[ "$*" =~ "cache delete" ]]; then
         echo "" > "$CACHE_KEY_TO_DELETE"
-      elif [[ "$*" =~ "api -X GET" ]]; then
+      elif [[ "$*" =~ "api".*/repos/.*actions/artifacts.*--paginate ]]; then
         cat "$ARTIFACT_TO_DELETE"
       elif [[ "$*" =~ "api -X DELETE" ]]; then
         echo "" > "$ARTIFACT_TO_DELETE"


### PR DESCRIPTION
BUILD-9451

## Summary
- Add `--limit 100000` to all `gh cache list` commands to handle PRs with more than 30 caches
- Add `gh api --paginate --slurp` to artifact API calls to handle PRs with unlimited artifacts
- Move artifact branch filtering from template to JQ for consistency
- Fixes the issue where only the first 30 caches or 100 artifacts were being cleaned up, leaving orphaned resources

## Implementation Notes
- Caches: Limited to 100,000 items (GitHub's practical maximum)
- Artifacts: Full pagination support (all pages processed via `--paginate --slurp`)
- JQ filters updated to handle multi-page responses: `.[].artifacts[]`
- Use `--jq --arg` for safer variable handling
