### PR TITLE
BUILD-9451 Fix artifact cleanup pagination

### DIFF
--- a/pr_cleanup/cleanup.sh
+++ b/pr_cleanup/cleanup.sh
@@ -44,10 +44,10 @@ envsubst '$GITHUB_HEAD_REF' < "$CURDIR"/artifact_template.tpl > "$tpl_tmp_file"
 ARTIFACT_TEMPLATE="$(cat "$tpl_tmp_file")"
 
 ARTIFACT_API_URL="/repos/$GITHUB_REPOSITORY/actions/artifacts"
-gh api "$ARTIFACT_API_URL" --paginate --slurp --jq '[.[].artifacts[] | select(.workflow_run.head_branch == "'"$GITHUB_HEAD_REF"'")] | {artifacts: .}' --template "$ARTIFACT_TEMPLATE"
+gh api "$ARTIFACT_API_URL" --paginate --template "$ARTIFACT_TEMPLATE"
 echo
 
-artifactIds="$(gh api "$ARTIFACT_API_URL" --paginate --slurp --jq '.[].artifacts[] | select(.workflow_run.head_branch == "'"$GITHUB_HEAD_REF"'") | .id')"
+artifactIds="$(gh api "$ARTIFACT_API_URL" --paginate --jq '.artifacts[] | select(.workflow_run.head_branch == "'"$GITHUB_HEAD_REF"'") | .id')"
 echo "Deleting artifacts..."
 for artifactId in $artifactIds
 do
@@ -57,5 +57,5 @@ done
 echo
 
 echo "Fetching list of artifacts after deletion"
-gh api "$ARTIFACT_API_URL" --paginate --slurp --jq '[.[].artifacts[] | select(.workflow_run.head_branch == "'"$GITHUB_HEAD_REF"'")] | {artifacts: .}' --template "$ARTIFACT_TEMPLATE"
+gh api "$ARTIFACT_API_URL" --paginate --template "$ARTIFACT_TEMPLATE"
 echo "::endgroup::"

--- a/spec/pr_cleanup_spec.sh
+++ b/spec/pr_cleanup_spec.sh
@@ -19,7 +19,7 @@ Describe "cleanup.sh"
         cat "$CACHE_KEY_TO_DELETE"
       elif [[ "$*" =~ "cache delete" ]]; then
         echo "" > "$CACHE_KEY_TO_DELETE"
-      elif [[ "$*" =~ "api".*/repos/.*actions/artifacts.*--paginate ]]; then
+      elif [[ "$*" =~ "api /repos/".*/actions/artifacts.*--paginate ]]; then
         cat "$ARTIFACT_TO_DELETE"
       elif [[ "$*" =~ "api -X DELETE" ]]; then
         echo "" > "$ARTIFACT_TO_DELETE"


### PR DESCRIPTION
BUILD-9451

## Summary
- Use `gh api --paginate` to fetch ALL artifacts across all pages (unlimited)
- Fixes test-cleanup failure from #209 which was accidentally merged

## Changes
- Replace `--slurp` with `--paginate` alone (gh api doesn't support `--slurp` with `--jq`/`--template`)
- Update artifact ID collection and display to use pagination
- Update test mocks to match new command pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)