### PR TITLE
BUILD-10447 Fix GITHUB_ACTION_PATH usage in action files

### DIFF
--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -169,7 +169,7 @@ runs:
         ORG_GRADLE_PROJECT_signingPassword: ${{ fromJSON(steps.secrets.outputs.vault).PGP_PASSPHRASE }}
         ORG_GRADLE_PROJECT_signingKeyId: ${{ fromJSON(steps.secrets.outputs.vault).SIGN_KEY_ID }}
       working-directory: ${{ inputs.working-directory }}
-      run: ${GITHUB_ACTION_PATH}/build.sh
+      run: $ACTION_PATH_BUILD_GRADLE/build.sh
 
     - name: Archive problems report
       if: always()

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -209,7 +209,7 @@ runs:
         ARTIFACTORY_PRIVATE_DEPLOY_REPO: ${{ steps.params.outputs.ARTIFACTORY_PRIVATE_DEPLOY_REPO }}
         ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN }}
         INSTALLED_ARTIFACTS: ${{ steps.build.outputs.installed-artifacts }}
-      run: ${GITHUB_ACTION_PATH}/deploy-artifacts.sh
+      run: $ACTION_PATH_BUILD_MAVEN/deploy-artifacts.sh
 
     - name: Cleanup Maven repository before caching
       if: inputs.cache-cleanup == 'true'

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -172,7 +172,7 @@ runs:
       run: |
         GRADLE_INIT_DIR="$GRADLE_USER_HOME/init.d"
         mkdir -p "$GRADLE_INIT_DIR"
-        cp "${GITHUB_ACTION_PATH}/resources/repoxAuth.init.gradle.kts" "$GRADLE_INIT_DIR/"
+        cp "$ACTION_PATH_CONFIG_GRADLE/resources/repoxAuth.init.gradle.kts" "$GRADLE_INIT_DIR/"
 
     - name: Update project version and set current-version and project-version variables
       id: set-version
@@ -180,7 +180,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         SKIP: ${{ steps.config-gradle-completed.outputs.skip }}
-      run: ${GITHUB_ACTION_PATH}/set_gradle_project_version.sh
+      run: $ACTION_PATH_CONFIG_GRADLE/set_gradle_project_version.sh
 
     - name: Deactivate UseContainerSupport on github-ubuntu-* runners
       if: steps.config-gradle-completed.outputs.skip != 'true' && runner.os == 'Linux' && runner.environment == 'github-hosted'


### PR DESCRIPTION
Replace unreliable `${GITHUB_ACTION_PATH}` with action-specific variables:
- build-gradle: Use `$ACTION_PATH_BUILD_GRADLE`
- build-maven: Use `$ACTION_PATH_BUILD_MAVEN`
- config-gradle: Use `$ACTION_PATH_CONFIG_GRADLE` (2 occurrences)

These variables are already defined via `${{ github.action_path }}` to ensure reliability when running actions in containers or when using local actions within other local actions, as documented in CONTRIBUTE.md.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

Tested by:
- https://github.com/SonarSource/sonarlint-intellij/pull/1640