### PR TITLE
BUILD-10457 Include BUILD_NAME in promote check context for unique checks per build

### DIFF
--- a/promote/promote.sh
+++ b/promote/promote.sh
@@ -148,6 +148,7 @@ promote_mono() {
 }
 
 github_notify_promotion() {
+  local check_context="$1"
   local project_version longDescription shortDescription buildUrl githubApiUrl
   project_version="$PROJECT_VERSION"
   longDescription="Latest promoted build of '${project_version}' from branch '${GITHUB_REF}'"
@@ -159,7 +160,7 @@ github_notify_promotion() {
   "state": "success",
   "target_url": "$buildUrl",
   "description": "$shortDescription",
-  "context": "repox-${GITHUB_REF_NAME}"
+  "context": "$check_context"
 }
 EOF
 }
@@ -224,7 +225,8 @@ promote() {
   echo "::endgroup::"
 
   echo "::group::Notify GitHub"
-  github_notify_promotion
+  github_notify_promotion "repox-${BUILD_NAME}-${GITHUB_REF_NAME}"
+  github_notify_promotion "repox-${GITHUB_REF_NAME}" # DEPRECATED - backward compatibility
   echo "::endgroup::"
 
   generate_workflow_summary

--- a/spec/promote_spec.sh
+++ b/spec/promote_spec.sh
@@ -97,7 +97,7 @@ Describe 'promote/promote.sh'
     export PROMOTE_PULL_REQUEST="true"
     When run script promote/promote.sh
     The status should be success
-    The lines of stdout should equal 20
+    The lines of stdout should equal 21
     The line 1 should equal "::group::Check tools"
     The line 2 should include "gh"
     The line 3 should include "gh"
@@ -117,7 +117,8 @@ Describe 'promote/promote.sh'
     The line 17 should equal "::endgroup::"
     The line 18 should equal "::group::Notify GitHub"
     The line 19 should include "gh api -X POST"
-    The line 20 should equal "::endgroup::"
+    The line 20 should include "gh api -X POST"
+    The line 21 should equal "::endgroup::"
   End
 
   It 'skips promotion on pull_request when promotion is disabled'
@@ -351,9 +352,9 @@ Describe 'jfrog_promote()'
 End
 
 Describe 'github_notify_promotion()'
-  It 'calls gh api with correct parameters'
+  It 'calls gh api with the provided check context'
     export PROJECT_VERSION="1.2.3"
-    When call github_notify_promotion
+    When call github_notify_promotion "repox-dummy-project-dummy-branch"
     The output should include "gh api -X POST -H X-GitHub-Api-Version: 2022-11-28"
     The output should include "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA"
     The output should include "-H Content-Type: application/json --input -"


### PR DESCRIPTION
## Problem

When multiple promote jobs run in parallel (e.g. in a monorepo with consolidated matrix builds), they all write to the **same** GitHub commit status check. The check context was `repox-${GITHUB_REF_NAME}`, which is identical for all promote jobs in the same workflow run.

**Consequences:**

* Only one promote result is visible — the last job to finish overwrites all others
* The check description shows empty or wrong build info (e.g. "Latest promoted build of '' from branch 'refs/pull/64/merge'")
* Downstream scripts that read promote checks (e.g. release workflows) cannot distinguish promoted artifacts per project
* Developers cannot see which capabilities were promoted and their versions

**Example:** In sonarqube-unification, a consolidated workflow builds 6 capabilities in parallel (entitlements, organizations, template, unified-core, users, integration-bindings). Each runs the promote action with its own `BUILD_NAME` (e.g. `sonarqube-unification-template`, `sonarqube-unification-entitlements`). All 6 write to `repox-64/merge` and only one survives.

## Solution

Make `check_context` a parameter of `github_notify_promotion()` and call it **twice** from `promote()`:

1. `repox-${BUILD_NAME}-${GITHUB_REF_NAME}` — unique context per build (e.g. `repox-sonarqube-unification-template-64/merge`)
2. `repox-${GITHUB_REF_NAME}` — legacy context for backward compatibility (deprecated)

This way each parallel promote job creates its own distinct check, while the old check context is also written so that existing downstream scripts continue to work during a migration period.

## Backward compatibility

* **Single-build repos:** Both checks are written. Scripts matching `repox` or `promote` (e.g. sonarqube-unification's `resolve.py`) continue to work unchanged.
* **Multi-build monorepos:** Each build gets its own unique check; no more overwrites. The legacy check still gets overwritten (expected — it's deprecated), but the unique checks are preserved.

## Testing

* All 31 shellspec tests pass
* Shellcheck passes