### PR TITLE
BUILD-9208 Exclude release and sign profiles during shadow scans

### DIFF
--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -166,12 +166,16 @@ build_maven() {
 
   if is_default_branch || is_maintenance_branch; then
     echo "======= Build and analyze $GITHUB_REF_NAME ======="
-    maven_command_args+=("-Prelease,sign")
+    if [[ "${RUN_SHADOW_SCANS}" != "true" ]]; then
+      maven_command_args+=("-Prelease,sign")
+    fi
   elif is_pull_request; then
     echo "======= Build and analyze pull request $PULL_REQUEST ($GITHUB_HEAD_REF) ======="
   elif is_dogfood_branch; then
     echo "======= Build dogfood branch $GITHUB_REF_NAME ======="
-    maven_command_args+=("-Prelease")
+    if [[ "${RUN_SHADOW_SCANS}" != "true" ]]; then
+      maven_command_args+=("-Prelease")
+    fi
   elif is_long_lived_feature_branch; then
     echo "======= Build and analyze long lived feature branch $GITHUB_REF_NAME ======="
   else

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -495,6 +495,28 @@ Describe 'build_maven()'
       The output should include "Maven command: mvn install"
       The output should not include "Maven command: mvn deploy"
     End
+
+    It 'excludes release and sign profiles when shadow scans are enabled'
+      When call build_maven
+      The status should be success
+      The stderr should include "Shadow scans enabled - disabling deployment"
+      The output should include "Maven command: mvn install -Pcoverage"
+      The output should not include "release"
+      The output should not include "sign"
+    End
+  End
+
+  Describe 'dogfood branch with shadow scans'
+    export GITHUB_REF_NAME="dogfood-on-next"
+    export RUN_SHADOW_SCANS="true"
+
+    It 'excludes release profile when shadow scans are enabled'
+      When call build_maven
+      The status should be success
+      The stderr should include "Shadow scans enabled - disabling deployment"
+      The output should include "Maven command: mvn install"
+      The output should not include "release"
+    End
   End
 
   Describe 'scan depends on the sonar platform and branch'


### PR DESCRIPTION
BUILD-9208 Exclude release and sign profiles during shadow scans

## Changes

This PR modifies the `build-maven` action to exclude the `release` and `sign` Maven profiles when `run-shadow-scans` is enabled. 

Shadow scans perform SonarQube analysis on all three platforms (next, sqc-us, sqc-eu) without deploying artifacts. Including release and sign profiles during shadow scans is unnecessary overhead since:
- No artifacts are being deployed
- Signing and release preparation activities are irrelevant for analysis-only builds
- The profiles add unnecessary time to the build process

## Implementation

Modified `build-maven/build.sh` to check `RUN_SHADOW_SCANS` before adding Maven profiles:
- Default/maintenance branches: Skip `-Prelease,sign` when shadow scans are enabled
- Dogfood branches: Skip `-Prelease` when shadow scans are enabled

**Before (with shadow scans on master):**
```bash
maven_command_args=("install" "-Pcoverage" "-Prelease,sign")
```

**After (with shadow scans on master):**
```bash
maven_command_args=("install" "-Pcoverage")
```
