### PR TITLE
BUILD-9431 Group GitHub Actions logs for readability

### DIFF
--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -218,7 +218,9 @@ gradle_build() {
 
   if [[ "$SONAR_PLATFORM" == "none" ]]; then
     # Build without sonar - call gradle_build_and_analyze directly
+    echo "::group::Gradle build"
     gradle_build_and_analyze
+    echo "::endgroup::"
   else
     # Build with sonar analysis via orchestrator
     # shellcheck disable=SC2119
@@ -265,9 +267,15 @@ export_built_artifacts() {
 }
 
 main() {
+  echo "::group::Check tools"
   check_tool java -version
   set_gradle_cmd
+  echo "::endgroup::"
+
+  echo "::group::Configure build environment"
   set_build_env
+  echo "::endgroup::"
+
   gradle_build
 }
 

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -144,11 +144,15 @@ should_scan() {
 }
 
 build_maven() {
+  echo "::group::Check tools"
   check_tool mvn --version
   check_settings_xml
+  echo "::endgroup::"
 
   if should_scan; then
+    echo "::group::Fetch Git history"
     git_fetch_unshallow
+    echo "::endgroup::"
   else
     echo "Skipping git fetch (Sonar analysis disabled)"
   fi
@@ -164,6 +168,7 @@ build_maven() {
     maven_command_args+=("-Pcoverage")
   fi
 
+  echo "::group::Maven build"
   if is_default_branch || is_maintenance_branch; then
     echo "======= Build and analyze $GITHUB_REF_NAME ======="
     if [[ "${RUN_SHADOW_SCANS}" != "true" ]]; then
@@ -187,6 +192,7 @@ build_maven() {
   mvn_output=$(mktemp)
   echo "Maven command: mvn ${maven_command_args[*]} $*"
   mvn "${maven_command_args[@]}" "$@" | tee "$mvn_output"
+  echo "::endgroup::"
 
   if should_deploy; then
     echo "$DEPLOYED_OUTPUT_KEY=true" >> "$GITHUB_OUTPUT"

--- a/build-maven/deploy-artifacts.sh
+++ b/build-maven/deploy-artifacts.sh
@@ -30,15 +30,25 @@ done
 
 build_name="${GITHUB_REPOSITORY#*/}"
 pushd "$MAVEN_CONFIG/repository"
+
+echo "::group::Configure JFrog deployment"
 jfrog config add deploy --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_DEPLOY_ACCESS_TOKEN"
 jfrog config use deploy
+echo "::endgroup::"
+
+echo "::group::Deploy public artifacts"
 echo "Deploying public artifacts..."
 for artifact in "${public_artifacts[@]}"; do
   jfrog rt u --build-name "$build_name" --build-number "$BUILD_NUMBER" "$artifact" "${ARTIFACTORY_DEPLOY_REPO}"
 done
+echo "::endgroup::"
+
+echo "::group::Deploy private artifacts"
 echo "Deploying private artifacts..."
 jfrog config edit deploy --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_PRIVATE_DEPLOY_ACCESS_TOKEN"
 for artifact in "${private_artifacts[@]}"; do
   jfrog rt u --build-name "$build_name" --build-number "$BUILD_NUMBER" "$artifact" "${ARTIFACTORY_PRIVATE_DEPLOY_REPO}"
 done
+echo "::endgroup::"
+
 popd

--- a/config-gradle/set_gradle_project_version.sh
+++ b/config-gradle/set_gradle_project_version.sh
@@ -68,7 +68,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     echo "current-version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
     echo "project-version=$PROJECT_VERSION" >> "$GITHUB_OUTPUT"
   else
+    echo "::group::Check tools"
     set_gradle_cmd
+    echo "::endgroup::"
+    echo "::group::Set project version"
     set_project_version
+    echo "::endgroup::"
   fi
 fi

--- a/config-maven/set_maven_project_version.sh
+++ b/config-maven/set_maven_project_version.sh
@@ -77,7 +77,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     echo "current-version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
     echo "project-version=$PROJECT_VERSION" >> "$GITHUB_OUTPUT"
   else
+    echo "::group::Check tools"
     check_tool mvn --version
+    echo "::endgroup::"
+    echo "::group::Set project version"
     set_project_version
+    echo "::endgroup::"
   fi
 fi

--- a/promote/promote.sh
+++ b/promote/promote.sh
@@ -204,14 +204,26 @@ EOF
 }
 
 promote() {
+  echo "::group::Check tools"
   check_tool gh --version
   check_tool jq --version
   check_tool jf --version
+  echo "::endgroup::"
+
+  echo "::group::Configure promotion"
   set_build_env
   check_branch
   jfrog_config_repox
+  echo "::endgroup::"
+
+  echo "::group::Promote build artifacts"
   jfrog_promote
+  echo "::endgroup::"
+
+  echo "::group::Notify GitHub"
   github_notify_promotion
+  echo "::endgroup::"
+
   generate_workflow_summary
 }
 

--- a/shared/common-functions.sh
+++ b/shared/common-functions.sh
@@ -74,10 +74,12 @@ orchestrate_sonar_platforms() {
       done
       echo "=== ORCHESTRATOR: Completed Sonar analysis on all platforms ==="
   else
+      echo "::group::Sonar analysis on $SONAR_PLATFORM"
       echo "=== ORCHESTRATOR: Running Sonar analysis on selected platform: $SONAR_PLATFORM ==="
       set_sonar_platform_vars "$SONAR_PLATFORM"
       # CALLBACK: Hand control back to build script's implementation
       sonar_scanner_implementation "$@"
+      echo "::endgroup::"
   fi
 }
 

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -489,10 +489,14 @@ Describe 'main function'
 
     When call main
     The status should be success
-    The line 1 should equal "java ok"
-    The line 2 should equal "gradle ok"
-    The line 3 should equal "env set"
-    The line 4 should equal "build done"
+    The line 1 should equal "::group::Check tools"
+    The line 2 should equal "java ok"
+    The line 3 should equal "gradle ok"
+    The line 4 should equal "::endgroup::"
+    The line 5 should equal "::group::Configure build environment"
+    The line 6 should equal "env set"
+    The line 7 should equal "::endgroup::"
+    The line 8 should equal "build done"
   End
 End
 

--- a/spec/build-maven_deploy-artifacts_spec.sh
+++ b/spec/build-maven_deploy-artifacts_spec.sh
@@ -26,16 +26,22 @@ com/sonarsource/private/app/1.0/app-1.0.jar"
 
     When run script build-maven/deploy-artifacts.sh
     The status should be success
-    The lines of stdout should equal 11
-    The line 2 of output should equal "jfrog config add deploy --artifactory-url https://dummy.repox --access-token deploy-token"
-    The line 3 of output should equal "jfrog config use deploy"
-    The line 4 of output should include "Deploying public artifacts..."
-    The line 5 of output should include "org/sonarsource/app/1.0/app-1.0.pom deploy-repo-qa"
-    The line 6 of output should include "org/sonarsource/app/1.0/app-1.0.jar deploy-repo-qa"
-    The line 7 of output should equal "Deploying private artifacts..."
-    The line 8 of output should equal "jfrog config edit deploy --artifactory-url https://dummy.repox --access-token private-token"
-    The line 9 of output should include "com/sonarsource/private/app/1.0/app-1.0.pom private-repo-qa"
-    The line 10 of output should include "com/sonarsource/private/app/1.0/app-1.0.jar private-repo-qa"
+    The lines of stdout should equal 17
+    The line 2 of output should equal "::group::Configure JFrog deployment"
+    The line 3 of output should equal "jfrog config add deploy --artifactory-url https://dummy.repox --access-token deploy-token"
+    The line 4 of output should equal "jfrog config use deploy"
+    The line 5 of output should equal "::endgroup::"
+    The line 6 of output should equal "::group::Deploy public artifacts"
+    The line 7 of output should include "Deploying public artifacts..."
+    The line 8 of output should include "org/sonarsource/app/1.0/app-1.0.pom deploy-repo-qa"
+    The line 9 of output should include "org/sonarsource/app/1.0/app-1.0.jar deploy-repo-qa"
+    The line 10 of output should equal "::endgroup::"
+    The line 11 of output should equal "::group::Deploy private artifacts"
+    The line 12 of output should equal "Deploying private artifacts..."
+    The line 13 of output should equal "jfrog config edit deploy --artifactory-url https://dummy.repox --access-token private-token"
+    The line 14 of output should include "com/sonarsource/private/app/1.0/app-1.0.pom private-repo-qa"
+    The line 15 of output should include "com/sonarsource/private/app/1.0/app-1.0.jar private-repo-qa"
+    The line 16 of output should equal "::endgroup::"
 
     rm -rf "$MAVEN_CONFIG"
   End

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -238,10 +238,12 @@ Describe 'orchestrate_sonar_platforms()'
     export SONAR_PLATFORM="next"
     When call orchestrate_sonar_platforms "-Dsome.property=value"
     The status should be success
-    The lines of stdout should equal 3
-    The line 1 should include "ORCHESTRATOR: Running Sonar analysis on selected platform: next"
-    The line 2 should include "Using Sonar platform: next"
-    The line 3 should include "sonar_scanner_implementation -Dsome.property=value"
+    The lines of stdout should equal 5
+    The line 1 should equal "::group::Sonar analysis on next"
+    The line 2 should include "ORCHESTRATOR: Running Sonar analysis on selected platform: next"
+    The line 3 should include "Using Sonar platform: next"
+    The line 4 should include "sonar_scanner_implementation -Dsome.property=value"
+    The line 5 should equal "::endgroup::"
   End
 
   It 'runs analysis on all platforms when shadow scans enabled'

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -84,13 +84,17 @@ Describe 'build.sh'
     End
     When call build_maven
     The status should be success
-    The lines of stdout should equal 6
-    The line 1 should include "mvn"
-    The line 2 should include "mvn --version"
-    The line 3 should include "Skipping git fetch (Sonar analysis disabled)"
-    The line 4 should include "Build, no analysis, no deploy"
-    The line 5 should include "Maven command: mvn verify"
-    The line 6 should match pattern "mvn verify"
+    The lines of stdout should equal 10
+    The line 1 should equal "::group::Check tools"
+    The line 2 should include "mvn"
+    The line 3 should include "mvn --version"
+    The line 4 should equal "::endgroup::"
+    The line 5 should include "Skipping git fetch (Sonar analysis disabled)"
+    The line 6 should equal "::group::Maven build"
+    The line 7 should include "Build, no analysis, no deploy"
+    The line 8 should include "Maven command: mvn verify"
+    The line 9 should match pattern "mvn verify"
+    The line 10 should equal "::endgroup::"
   End
 
   It 'runs build_maven() for windows'
@@ -100,13 +104,17 @@ Describe 'build.sh'
     End
     When call build_maven
     The status should be success
-    The lines of stdout should equal 6
-    The line 1 should include "mvn"
-    The line 2 should include "mvn --version"
-    The line 3 should include "Skipping git fetch (Sonar analysis disabled)"
-    The line 4 should include "Build, no analysis, no deploy"
-    The line 5 should include "Maven command: mvn verify"
-    The line 6 should match pattern "mvn verify"
+    The lines of stdout should equal 10
+    The line 1 should equal "::group::Check tools"
+    The line 2 should include "mvn"
+    The line 3 should include "mvn --version"
+    The line 4 should equal "::endgroup::"
+    The line 5 should include "Skipping git fetch (Sonar analysis disabled)"
+    The line 6 should equal "::group::Maven build"
+    The line 7 should include "Build, no analysis, no deploy"
+    The line 8 should include "Maven command: mvn verify"
+    The line 9 should match pattern "mvn verify"
+    The line 10 should equal "::endgroup::"
   End
 End
 
@@ -339,24 +347,36 @@ Describe 'build_maven()'
 
     It 'builds, deploys and analyzes main branch'
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "Build and analyze def_main"
-      The line 2 should start with "Maven command: mvn deploy"
-      The line 3 should start with "mvn deploy"
-      The line 3 should include "-Pdeploy-sonarsource -Pcoverage -Prelease,sign"
-      The line 4 should start with "orchestrate_sonar_platforms"
+      The lines of stdout should equal 10
+      The line 1 should equal "::group::Check tools"
+      The line 2 should equal "::endgroup::"
+      The line 3 should equal "::group::Fetch Git history"
+      The line 4 should equal "::endgroup::"
+      The line 5 should equal "::group::Maven build"
+      The line 6 should include "Build and analyze def_main"
+      The line 7 should start with "Maven command: mvn deploy"
+      The line 8 should start with "mvn deploy"
+      The line 8 should include "-Pdeploy-sonarsource -Pcoverage -Prelease,sign"
+      The line 9 should equal "::endgroup::"
+      The line 10 should start with "orchestrate_sonar_platforms"
     End
 
     It 'builds and analyzes main branch when DEPLOY is false'
       export DEPLOY="false"
 
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "Build and analyze def_main"
-      The line 2 should start with "Maven command: mvn install"
-      The line 3 should start with "mvn install"
-      The line 3 should include "-Pcoverage -Prelease,sign"
-      The line 4 should start with "orchestrate_sonar_platforms"
+      The lines of stdout should equal 10
+      The line 1 should equal "::group::Check tools"
+      The line 2 should equal "::endgroup::"
+      The line 3 should equal "::group::Fetch Git history"
+      The line 4 should equal "::endgroup::"
+      The line 5 should equal "::group::Maven build"
+      The line 6 should include "Build and analyze def_main"
+      The line 7 should start with "Maven command: mvn install"
+      The line 8 should start with "mvn install"
+      The line 8 should include "-Pcoverage -Prelease,sign"
+      The line 9 should equal "::endgroup::"
+      The line 10 should start with "orchestrate_sonar_platforms"
     End
   End
 
@@ -365,21 +385,33 @@ Describe 'build_maven()'
 
     It 'builds, deploys and analyzes maintenance branch'
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "Build and analyze branch-1.2"
-      The line 3 should start with "mvn deploy"
-      The line 4 should start with "orchestrate_sonar_platforms"
+      The lines of stdout should equal 10
+      The line 1 should equal "::group::Check tools"
+      The line 2 should equal "::endgroup::"
+      The line 3 should equal "::group::Fetch Git history"
+      The line 4 should equal "::endgroup::"
+      The line 5 should equal "::group::Maven build"
+      The line 6 should include "Build and analyze branch-1.2"
+      The line 8 should start with "mvn deploy"
+      The line 9 should equal "::endgroup::"
+      The line 10 should start with "orchestrate_sonar_platforms"
     End
 
     It 'builds and analyzes main branch when DEPLOY is false'
       export DEPLOY="false"
 
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "Build and analyze branch-1.2"
-      The line 2 should start with "Maven command: mvn install"
-      The line 3 should start with "mvn install"
-      The line 4 should start with "orchestrate_sonar_platforms"
+      The lines of stdout should equal 10
+      The line 1 should equal "::group::Check tools"
+      The line 2 should equal "::endgroup::"
+      The line 3 should equal "::group::Fetch Git history"
+      The line 4 should equal "::endgroup::"
+      The line 5 should equal "::group::Maven build"
+      The line 6 should include "Build and analyze branch-1.2"
+      The line 7 should start with "Maven command: mvn install"
+      The line 8 should start with "mvn install"
+      The line 9 should equal "::endgroup::"
+      The line 10 should start with "orchestrate_sonar_platforms"
     End
   End
 
@@ -392,43 +424,61 @@ Describe 'build_maven()'
 
     It 'builds, analyzes pull request with no deploy by default'
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
-      The line 2 should start with "Maven command: mvn install"
-      The line 3 should start with "mvn install"
-      The line 3 should include "-Pcoverage"
-      The line 4 should start with "orchestrate_sonar_platforms"
-      The line 4 should include "-Dsonar.pullrequest.key=123"
-      The line 4 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
-      The line 4 should include "-Dsonar.pullrequest.base=def_main"
+      The lines of stdout should equal 10
+      The line 1 should equal "::group::Check tools"
+      The line 2 should equal "::endgroup::"
+      The line 3 should equal "::group::Fetch Git history"
+      The line 4 should equal "::endgroup::"
+      The line 5 should equal "::group::Maven build"
+      The line 6 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
+      The line 7 should start with "Maven command: mvn install"
+      The line 8 should start with "mvn install"
+      The line 8 should include "-Pcoverage"
+      The line 9 should equal "::endgroup::"
+      The line 10 should start with "orchestrate_sonar_platforms"
+      The line 10 should include "-Dsonar.pullrequest.key=123"
+      The line 10 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
+      The line 10 should include "-Dsonar.pullrequest.base=def_main"
     End
 
     It 'builds, analyzes pull request with deploy when DEPLOY_PULL_REQUEST is true'
       export DEPLOY_PULL_REQUEST="true"
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
-      The line 2 should start with "Maven command: mvn deploy"
-      The line 3 should start with "mvn deploy"
-      The line 3 should include "-Pdeploy-sonarsource -Pcoverage"
-      The line 4 should start with "orchestrate_sonar_platforms"
-      The line 4 should include "-Dsonar.pullrequest.key=123"
-      The line 4 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
-      The line 4 should include "-Dsonar.pullrequest.base=def_main"
+      The lines of stdout should equal 10
+      The line 1 should equal "::group::Check tools"
+      The line 2 should equal "::endgroup::"
+      The line 3 should equal "::group::Fetch Git history"
+      The line 4 should equal "::endgroup::"
+      The line 5 should equal "::group::Maven build"
+      The line 6 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
+      The line 7 should start with "Maven command: mvn deploy"
+      The line 8 should start with "mvn deploy"
+      The line 8 should include "-Pdeploy-sonarsource -Pcoverage"
+      The line 9 should equal "::endgroup::"
+      The line 10 should start with "orchestrate_sonar_platforms"
+      The line 10 should include "-Dsonar.pullrequest.key=123"
+      The line 10 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
+      The line 10 should include "-Dsonar.pullrequest.base=def_main"
     End
     It 'builds, analyzes pull request with no deploy when DEPLOY_PULL_REQUEST is true and DEPLOY is false'
       export DEPLOY_PULL_REQUEST="true"
       export DEPLOY="false"
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
-      The line 2 should start with "Maven command: mvn install"
-      The line 3 should start with "mvn install"
-      The line 3 should include "-Pcoverage"
-      The line 4 should start with "orchestrate_sonar_platforms"
-      The line 4 should include "-Dsonar.pullrequest.key=123"
-      The line 4 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
-      The line 4 should include "-Dsonar.pullrequest.base=def_main"
+      The lines of stdout should equal 10
+      The line 1 should equal "::group::Check tools"
+      The line 2 should equal "::endgroup::"
+      The line 3 should equal "::group::Fetch Git history"
+      The line 4 should equal "::endgroup::"
+      The line 5 should equal "::group::Maven build"
+      The line 6 should include "Build and analyze pull request 123 (fix/jdoe/JIRA-1234-aFix)"
+      The line 7 should start with "Maven command: mvn install"
+      The line 8 should start with "mvn install"
+      The line 8 should include "-Pcoverage"
+      The line 9 should equal "::endgroup::"
+      The line 10 should start with "orchestrate_sonar_platforms"
+      The line 10 should include "-Dsonar.pullrequest.key=123"
+      The line 10 should include "-Dsonar.pullrequest.branch=fix/jdoe/JIRA-1234-aFix"
+      The line 10 should include "-Dsonar.pullrequest.base=def_main"
     End
   End
 
@@ -437,23 +487,31 @@ Describe 'build_maven()'
 
     It 'builds and deploy'
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "Skipping git fetch (Sonar analysis disabled)"
-      The line 2 should include "Build dogfood branch dogfood-on-something"
-      The line 3 should start with "Maven command: mvn deploy"
-      The line 4 should start with "mvn deploy"
-      The line 4 should include "-Pdeploy-sonarsource -Prelease"
+      The lines of stdout should equal 8
+      The line 1 should equal "::group::Check tools"
+      The line 2 should equal "::endgroup::"
+      The line 3 should include "Skipping git fetch (Sonar analysis disabled)"
+      The line 4 should equal "::group::Maven build"
+      The line 5 should include "Build dogfood branch dogfood-on-something"
+      The line 6 should start with "Maven command: mvn deploy"
+      The line 7 should start with "mvn deploy"
+      The line 7 should include "-Pdeploy-sonarsource -Prelease"
+      The line 8 should equal "::endgroup::"
     End
 
     It 'builds when DEPLOY is false'
       export DEPLOY="false"
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "Skipping git fetch (Sonar analysis disabled)"
-      The line 2 should include "Build dogfood branch dogfood-on-something"
-      The line 3 should start with "Maven command: mvn install"
-      The line 4 should start with "mvn install"
-      The line 4 should include "-Prelease"
+      The lines of stdout should equal 8
+      The line 1 should equal "::group::Check tools"
+      The line 2 should equal "::endgroup::"
+      The line 3 should include "Skipping git fetch (Sonar analysis disabled)"
+      The line 4 should equal "::group::Maven build"
+      The line 5 should include "Build dogfood branch dogfood-on-something"
+      The line 6 should start with "Maven command: mvn install"
+      The line 7 should start with "mvn install"
+      The line 7 should include "-Prelease"
+      The line 8 should equal "::endgroup::"
     End
   End
 
@@ -462,12 +520,18 @@ Describe 'build_maven()'
 
     It 'builds, deploys and analyzes long lived feature branch'
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "Build and analyze long lived feature branch feature/long/some-feature"
-      The line 2 should start with "Maven command: mvn deploy"
-      The line 3 should start with "mvn deploy"
-      The line 3 should include "-Pdeploy-sonarsource -Pcoverage"
-      The line 4 should start with "orchestrate_sonar_platforms"
+      The lines of stdout should equal 10
+      The line 1 should equal "::group::Check tools"
+      The line 2 should equal "::endgroup::"
+      The line 3 should equal "::group::Fetch Git history"
+      The line 4 should equal "::endgroup::"
+      The line 5 should equal "::group::Maven build"
+      The line 6 should include "Build and analyze long lived feature branch feature/long/some-feature"
+      The line 7 should start with "Maven command: mvn deploy"
+      The line 8 should start with "mvn deploy"
+      The line 8 should include "-Pdeploy-sonarsource -Pcoverage"
+      The line 9 should equal "::endgroup::"
+      The line 10 should start with "orchestrate_sonar_platforms"
     End
   End
 
@@ -476,11 +540,15 @@ Describe 'build_maven()'
 
     It 'builds only'
       When call build_maven
-      The lines of stdout should equal 4
-      The line 1 should include "Skipping git fetch (Sonar analysis disabled)"
-      The line 2 should include "Build, no analysis, no deploy some-branch"
-      The line 3 should start with "Maven command: mvn verify"
-      The line 4 should start with "mvn verify"
+      The lines of stdout should equal 8
+      The line 1 should equal "::group::Check tools"
+      The line 2 should equal "::endgroup::"
+      The line 3 should include "Skipping git fetch (Sonar analysis disabled)"
+      The line 4 should equal "::group::Maven build"
+      The line 5 should include "Build, no analysis, no deploy some-branch"
+      The line 6 should start with "Maven command: mvn verify"
+      The line 7 should start with "mvn verify"
+      The line 8 should equal "::endgroup::"
     End
   End
 

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -206,7 +206,7 @@ Describe 'build_npm()'
     When call build_npm
     The status should be success
     The line 8 should equal "======= Building maintenance branch ======="
-    The line 16 should include "-Dsonar.projectVersion=1.2.3-SNAPSHOT"
+    The line 20 should include "-Dsonar.projectVersion=1.2.3-SNAPSHOT"
   End
 
   It 'builds maintenance branch with RELEASE version'
@@ -218,7 +218,7 @@ Describe 'build_npm()'
     When call build_npm
     The status should be success
     The line 8 should equal "======= Building maintenance branch ======="
-    The line 16 should include "-Dsonar.projectVersion=1.2.3"
+    The line 20 should include "-Dsonar.projectVersion=1.2.3"
   End
 
   It 'builds pull request without deploy'

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -68,32 +68,42 @@ Describe 'build-poetry/build.sh'
     export GITHUB_OUTPUT
     When run script build-poetry/build.sh
       The status should be success
-      The lines of stdout should equal 26
-      The line 1 should include "jq"
+      The lines of stdout should equal 36
+      The line 1 should equal "::group::Check tools"
       The line 2 should include "jq"
-      The line 3 should include "python"
+      The line 3 should include "jq"
       The line 4 should include "python"
-      The line 5 should include "poetry"
+      The line 5 should include "python"
       The line 6 should include "poetry"
-      The line 7 should include "jf"
+      The line 7 should include "poetry"
       The line 8 should include "jf"
-      The line 9 should equal "PROJECT: my-repo"
-      The line 10 should equal "Fetch Git references for SonarQube analysis..."
-      The line 11 should equal "git fetch --unshallow"
-      The line 12 should equal "=== Poetry Build, Deploy, and Analyze ==="
-      The line 13 should equal "Branch: any-branch"
-      The line 14 should equal "Pull Request: "
-      The line 15 should equal "Deploy Pull Request: false"
-      The line 16 should equal "Replacing version 1.2 with 1.2.0.42"
-      The line 17 should equal "poetry version 1.2.0.42"
-      The line 18 should equal "PROJECT_VERSION=1.2.0.42"
-      The line 19 should equal "======= Build other branch ======="
-      The line 20 should equal "Installing dependencies..."
-      The line 21 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token dummy access token"
-      The line 22 should equal "jf poetry-config --server-id-resolve repox --repo-resolve <repox pypi repo>"
-      The line 23 should equal "jf poetry install --build-name=my-repo --build-number=42"
-      The line 25 should equal "poetry build"
-      The line 26 should equal "=== Build completed successfully ==="
+      The line 9 should include "jf"
+      The line 10 should equal "::endgroup::"
+      The line 11 should equal "::group::Configure build environment"
+      The line 12 should equal "PROJECT: my-repo"
+      The line 13 should equal "Fetch Git references for SonarQube analysis..."
+      The line 14 should equal "git fetch --unshallow"
+      The line 15 should equal "::endgroup::"
+      The line 16 should equal "=== Poetry Build, Deploy, and Analyze ==="
+      The line 17 should equal "Branch: any-branch"
+      The line 18 should equal "Pull Request: "
+      The line 19 should equal "Deploy Pull Request: false"
+      The line 20 should equal "::group::Set project version"
+      The line 21 should equal "Replacing version 1.2 with 1.2.0.42"
+      The line 22 should equal "poetry version 1.2.0.42"
+      The line 23 should equal "PROJECT_VERSION=1.2.0.42"
+      The line 24 should equal "::endgroup::"
+      The line 25 should equal "======= Build other branch ======="
+      The line 26 should equal "::group::Install dependencies"
+      The line 27 should equal "Installing dependencies..."
+      The line 28 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token dummy access token"
+      The line 29 should equal "jf poetry-config --server-id-resolve repox --repo-resolve <repox pypi repo>"
+      The line 30 should equal "jf poetry install --build-name=my-repo --build-number=42"
+      The line 31 should equal "::endgroup::"
+      The line 32 should equal "::group::Build project"
+      The line 34 should equal "poetry build"
+      The line 35 should equal "::endgroup::"
+      The line 36 should equal "=== Build completed successfully ==="
     End
 End
 
@@ -331,20 +341,32 @@ Describe 'build_poetry()'
     The line 2 should equal 'Branch: main'
     The line 3 should equal 'Pull Request: '
     The line 4 should equal 'Deploy Pull Request: false'
-    The line 5 should equal '======= Building main branch ======='
-    The line 8 should equal 'poetry build'
-    The line 9 should equal 'run_sonar_analysis()'
-    The line 10 should equal '=== Running Sonar analysis on selected platform: next ==='
-    The line 12 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
-    The line 13 should equal 'poetry run pip install pysonar'
-    The line 15 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
-    The line 17 should equal 'jf config remove repox'
-    The line 18 should equal 'jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>'
-    The line 19 should include '/dist'
-    The line 20 should equal 'jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42'
-    The line 22 should equal 'jf rt build-collect-env my-repo 42'
-    The line 23 should include 'jf rt build-publish my-repo 42'
-    The line 24 should include '=== Build completed successfully ==='
+    The line 5 should equal '::group::Set project version'
+    The line 6 should equal '::endgroup::'
+    The line 7 should equal '======= Building main branch ======='
+    The line 8 should equal '::group::Install dependencies'
+    The line 9 should equal 'Installing dependencies...'
+    The line 10 should equal '::endgroup::'
+    The line 11 should equal '::group::Build project'
+    The line 12 should equal 'Building project...'
+    The line 13 should equal 'poetry build'
+    The line 14 should equal '::endgroup::'
+    The line 15 should equal 'run_sonar_analysis()'
+    The line 16 should equal '=== Running Sonar analysis on selected platform: next ==='
+    The line 17 should equal '::group::Sonar analysis on next'
+    The line 18 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
+    The line 19 should equal 'poetry run pip install pysonar'
+    The line 21 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
+    The line 22 should equal '::endgroup::'
+    The line 23 should equal '::group::Publish to Artifactory'
+    The line 24 should equal 'jf config remove repox'
+    The line 25 should equal 'jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>'
+    The line 26 should include '/dist'
+    The line 27 should equal 'jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42'
+    The line 29 should equal 'jf rt build-collect-env my-repo 42'
+    The line 30 should include 'jf rt build-publish my-repo 42'
+    The line 31 should equal '::endgroup::'
+    The line 32 should include '=== Build completed successfully ==='
     The status should be success
   End
 
@@ -359,15 +381,25 @@ Describe 'build_poetry()'
     The line 2 should equal 'Branch: 123/merge'
     The line 3 should equal 'Pull Request: 123'
     The line 4 should equal 'Deploy Pull Request: false'
-    The line 5 should equal '======= Building pull request ======='
-    The line 6 should equal '======= no deploy ======='
-    The line 9 should equal 'poetry build'
-    The line 10 should equal 'run_sonar_analysis()'
-    The line 11 should equal '=== Running Sonar analysis on selected platform: next ==='
-    The line 13 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
-    The line 14 should equal 'poetry run pip install pysonar'
-    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
-    The line 18 should equal '=== Build completed successfully ==='
+    The line 5 should equal '::group::Set project version'
+    The line 6 should equal '::endgroup::'
+    The line 7 should equal '======= Building pull request ======='
+    The line 8 should equal '======= no deploy ======='
+    The line 9 should equal '::group::Install dependencies'
+    The line 10 should equal 'Installing dependencies...'
+    The line 11 should equal '::endgroup::'
+    The line 12 should equal '::group::Build project'
+    The line 13 should equal 'Building project...'
+    The line 14 should equal 'poetry build'
+    The line 15 should equal '::endgroup::'
+    The line 16 should equal 'run_sonar_analysis()'
+    The line 17 should equal '=== Running Sonar analysis on selected platform: next ==='
+    The line 18 should equal '::group::Sonar analysis on next'
+    The line 19 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
+    The line 20 should equal 'poetry run pip install pysonar'
+    The line 22 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
+    The line 23 should equal '::endgroup::'
+    The line 24 should equal '=== Build completed successfully ==='
     The status should be success
   End
 
@@ -383,20 +415,32 @@ Describe 'build_poetry()'
     The line 2 should equal 'Branch: 123/merge'
     The line 3 should equal 'Pull Request: 123'
     The line 4 should equal 'Deploy Pull Request: true'
-    The line 5 should equal '======= Building pull request ======='
-    The line 6 should equal '======= with deploy ======='
-    The line 9 should equal 'poetry build'
-    The line 10 should equal 'run_sonar_analysis()'
-    The line 11 should equal '=== Running Sonar analysis on selected platform: next ==='
-    The line 13 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
-    The line 14 should equal 'poetry run pip install pysonar'
-    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
-    The line 18 should equal "jf config remove repox"
-    The line 19 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>"
-    The line 20 should include "/dist"
-    The line 21 should equal "jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42"
-    The line 23 should equal "jf rt build-collect-env my-repo 42"
-    The line 24 should include "jf rt build-publish my-repo 42"
+    The line 5 should equal '::group::Set project version'
+    The line 6 should equal '::endgroup::'
+    The line 7 should equal '======= Building pull request ======='
+    The line 8 should equal '======= with deploy ======='
+    The line 9 should equal '::group::Install dependencies'
+    The line 10 should equal 'Installing dependencies...'
+    The line 11 should equal '::endgroup::'
+    The line 12 should equal '::group::Build project'
+    The line 13 should equal 'Building project...'
+    The line 14 should equal 'poetry build'
+    The line 15 should equal '::endgroup::'
+    The line 16 should equal 'run_sonar_analysis()'
+    The line 17 should equal '=== Running Sonar analysis on selected platform: next ==='
+    The line 18 should equal '::group::Sonar analysis on next'
+    The line 19 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
+    The line 20 should equal 'poetry run pip install pysonar'
+    The line 22 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo -Dsonar.analysis.prNumber=123'
+    The line 23 should equal '::endgroup::'
+    The line 24 should equal "::group::Publish to Artifactory"
+    The line 25 should equal "jf config remove repox"
+    The line 26 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>"
+    The line 27 should include "/dist"
+    The line 28 should equal "jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42"
+    The line 30 should equal "jf rt build-collect-env my-repo 42"
+    The line 31 should include "jf rt build-publish my-repo 42"
+    The line 32 should equal "::endgroup::"
     The status should be success
   End
 
@@ -408,7 +452,9 @@ Describe 'build_poetry()'
     The line 2 should equal 'Branch: dogfood-on-test'
     The line 3 should equal 'Pull Request: '
     The line 4 should equal 'Deploy Pull Request: false'
-    The line 5 should equal '======= Build dogfood branch ======='
+    The line 5 should equal '::group::Set project version'
+    The line 6 should equal '::endgroup::'
+    The line 7 should equal '======= Build dogfood branch ======='
     The status should be success
     The variable BUILD_ENABLE_SONAR should equal "false"
   End
@@ -421,7 +467,9 @@ Describe 'build_poetry()'
     The line 2 should equal 'Branch: feature/long/test'
     The line 3 should equal 'Pull Request: '
     The line 4 should equal 'Deploy Pull Request: false'
-    The line 5 should equal '======= Build long-lived feature branch ======='
+    The line 5 should equal '::group::Set project version'
+    The line 6 should equal '::endgroup::'
+    The line 7 should equal '======= Build long-lived feature branch ======='
     The status should be success
     The variable BUILD_ENABLE_SONAR should equal "true"
     The variable BUILD_SONAR_ARGS should equal "-Dsonar.branch.name=feature/long/test"
@@ -435,7 +483,9 @@ Describe 'build_poetry()'
     The line 2 should equal 'Branch: branch-1.2'
     The line 3 should equal 'Pull Request: '
     The line 4 should equal 'Deploy Pull Request: false'
-    The line 5 should equal '======= Building maintenance branch ======='
+    The line 5 should equal '::group::Set project version'
+    The line 6 should equal '::endgroup::'
+    The line 7 should equal '======= Building maintenance branch ======='
     The status should be success
     The variable BUILD_ENABLE_SONAR should equal "true"
   End
@@ -448,7 +498,9 @@ Describe 'build_poetry()'
     The line 2 should equal 'Branch: gh-readonly-queue/123'
     The line 3 should equal 'Pull Request: '
     The line 4 should equal 'Deploy Pull Request: false'
-    The line 5 should equal '======= Build other branch ======='
+    The line 5 should equal '::group::Set project version'
+    The line 6 should equal '::endgroup::'
+    The line 7 should equal '======= Build other branch ======='
     The status should be success
     The variable BUILD_ENABLE_SONAR should equal "false"
     The variable BUILD_ENABLE_DEPLOY should equal "false"
@@ -464,23 +516,32 @@ Describe 'build_poetry()'
     The line 2 should equal 'Branch: main'
     The line 3 should equal 'Pull Request: '
     The line 4 should equal 'Deploy Pull Request: false'
-    The line 5 should equal '======= Building main branch ======='
-    The line 8 should equal 'poetry build'
-    The line 9 should equal 'run_sonar_analysis()'
-    The line 10 should equal '=== Running Sonar analysis on all platforms (shadow scan enabled) ==='
-    The line 12 should equal '--- ORCHESTRATOR: Analyzing with platform: next ---'
-    The line 13 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
-    The line 14 should equal 'poetry run pip install pysonar'
-    The line 16 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
-    The line 19 should equal '--- ORCHESTRATOR: Analyzing with platform: sqc-us ---'
-    The line 20 should equal 'Using Sonar platform: sqc-us (URL: https://sonarqube-us.com)'
-    The line 21 should equal 'poetry run pip install pysonar'
-    The line 23 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarqube-us.com -Dsonar.token=sqc-us-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
-    The line 26 should equal '--- ORCHESTRATOR: Analyzing with platform: sqc-eu ---'
-    The line 27 should equal 'Using Sonar platform: sqc-eu (URL: https://sonarcloud.io)'
-    The line 28 should equal 'poetry run pip install pysonar'
-    The line 30 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=sqc-eu-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
-    The line 32 should equal '=== Completed Sonar analysis on all platforms ==='
+    The line 5 should equal '::group::Set project version'
+    The line 6 should equal '::endgroup::'
+    The line 7 should equal '======= Building main branch ======='
+    The line 13 should equal 'poetry build'
+    The line 14 should equal '::endgroup::'
+    The line 15 should equal 'run_sonar_analysis()'
+    The line 16 should equal '=== Running Sonar analysis on all platforms (shadow scan enabled) ==='
+    The line 17 should equal '::group::Sonar analysis on next'
+    The line 18 should equal '--- ORCHESTRATOR: Analyzing with platform: next ---'
+    The line 19 should equal 'Using Sonar platform: next (URL: https://next.sonarqube.com)'
+    The line 20 should equal 'poetry run pip install pysonar'
+    The line 22 should equal 'poetry run pysonar -Dsonar.host.url=https://next.sonarqube.com -Dsonar.token=next-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
+    The line 23 should equal '::endgroup::'
+    The line 24 should equal '::group::Sonar analysis on sqc-us'
+    The line 25 should equal '--- ORCHESTRATOR: Analyzing with platform: sqc-us ---'
+    The line 26 should equal 'Using Sonar platform: sqc-us (URL: https://sonarqube-us.com)'
+    The line 27 should equal 'poetry run pip install pysonar'
+    The line 29 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarqube-us.com -Dsonar.token=sqc-us-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
+    The line 30 should equal '::endgroup::'
+    The line 31 should equal '::group::Sonar analysis on sqc-eu'
+    The line 32 should equal '--- ORCHESTRATOR: Analyzing with platform: sqc-eu ---'
+    The line 33 should equal 'Using Sonar platform: sqc-eu (URL: https://sonarcloud.io)'
+    The line 34 should equal 'poetry run pip install pysonar'
+    The line 36 should equal 'poetry run pysonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.token=sqc-eu-token -Dsonar.analysis.buildNumber=42 -Dsonar.analysis.pipeline=dummy-run-id -Dsonar.analysis.repository=my-org/my-repo'
+    The line 37 should equal '::endgroup::'
+    The line 38 should equal '=== Completed Sonar analysis on all platforms ==='
     The status should be success
   End
 
@@ -494,17 +555,22 @@ Describe 'build_poetry()'
     The line 2 should equal 'Branch: main'
     The line 3 should equal 'Pull Request: '
     The line 4 should equal 'Deploy Pull Request: false'
-    The line 5 should equal '======= Building main branch ======='
-    The line 8 should equal 'poetry build'
-    The line 9 should equal 'run_sonar_analysis()'
-    The line 10 should equal "=== Sonar platform set to 'none'. Skipping Sonar analysis."
-    The line 11 should equal 'jf config remove repox'
-    The line 12 should equal 'jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>'
-    The line 13 should include '/dist'
-    The line 14 should equal 'jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42'
-    The line 16 should equal 'jf rt build-collect-env my-repo 42'
-    The line 17 should include 'jf rt build-publish my-repo 42'
-    The line 18 should equal '=== Build completed successfully ==='
+    The line 5 should equal '::group::Set project version'
+    The line 6 should equal '::endgroup::'
+    The line 7 should equal '======= Building main branch ======='
+    The line 13 should equal 'poetry build'
+    The line 14 should equal '::endgroup::'
+    The line 15 should equal 'run_sonar_analysis()'
+    The line 16 should equal "=== Sonar platform set to 'none'. Skipping Sonar analysis."
+    The line 17 should equal '::group::Publish to Artifactory'
+    The line 18 should equal 'jf config remove repox'
+    The line 19 should equal 'jf config add repox --artifactory-url https://dummy.repox --access-token <deploy token>'
+    The line 20 should include '/dist'
+    The line 21 should equal 'jf rt upload ./ <deploy repo>/poetry/1.0.0.42/ --module=poetry:1.0.0.42 --build-name=my-repo --build-number=42'
+    The line 23 should equal 'jf rt build-collect-env my-repo 42'
+    The line 24 should include 'jf rt build-publish my-repo 42'
+    The line 25 should equal '::endgroup::'
+    The line 26 should equal '=== Build completed successfully ==='
     The status should be success
   End
 

--- a/spec/promote_spec.sh
+++ b/spec/promote_spec.sh
@@ -76,12 +76,15 @@ Describe 'promote/promote.sh'
   It 'fails on working branch'
     When run script promote/promote.sh
     The status should be failure
-    The line 1 should include "gh"
+    The line 1 should equal "::group::Check tools"
     The line 2 should include "gh"
-    The line 3 should include "jq"
+    The line 3 should include "gh"
     The line 4 should include "jq"
-    The line 5 should include "jf"
+    The line 5 should include "jq"
     The line 6 should include "jf"
+    The line 7 should include "jf"
+    The line 8 should equal "::endgroup::"
+    The line 9 should equal "::group::Configure promotion"
     The error should start with "Promotion is only available for"
   End
 
@@ -93,19 +96,27 @@ Describe 'promote/promote.sh'
     export PROMOTE_PULL_REQUEST="true"
     When run script promote/promote.sh
     The status should be success
-    The lines of stdout should equal 12
-    The line 1 should include "gh"
+    The lines of stdout should equal 20
+    The line 1 should equal "::group::Check tools"
     The line 2 should include "gh"
-    The line 3 should include "jq"
+    The line 3 should include "gh"
     The line 4 should include "jq"
-    The line 5 should include "jf"
+    The line 5 should include "jq"
     The line 6 should include "jf"
-    The line 7 should equal "jf config remove repox"
-    The line 8 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token dummy promote token"
-    The line 9 should equal "Promoting build dummy-project/$BUILD_NUMBER (version: 1.2.3.42)"
-    The line 10 should equal "Target repository: $ARTIFACTORY_TARGET_REPO"
-    The line 11 should equal "jf rt bpr --status it-passed-pr dummy-project $BUILD_NUMBER $ARTIFACTORY_TARGET_REPO"
-    The line 12 should include "gh api -X POST"
+    The line 7 should include "jf"
+    The line 8 should equal "::endgroup::"
+    The line 9 should equal "::group::Configure promotion"
+    The line 10 should equal "jf config remove repox"
+    The line 11 should equal "jf config add repox --artifactory-url https://dummy.repox --access-token dummy promote token"
+    The line 12 should equal "::endgroup::"
+    The line 13 should equal "::group::Promote build artifacts"
+    The line 14 should equal "Promoting build dummy-project/$BUILD_NUMBER (version: 1.2.3.42)"
+    The line 15 should equal "Target repository: $ARTIFACTORY_TARGET_REPO"
+    The line 16 should equal "jf rt bpr --status it-passed-pr dummy-project $BUILD_NUMBER $ARTIFACTORY_TARGET_REPO"
+    The line 17 should equal "::endgroup::"
+    The line 18 should equal "::group::Notify GitHub"
+    The line 19 should include "gh api -X POST"
+    The line 20 should equal "::endgroup::"
   End
 
   It 'skips promotion on pull_request when promotion is disabled'
@@ -363,9 +374,18 @@ Describe 'promote()'
     export GITHUB_REF_NAME="main"
     When call promote
     The status should be success
-    The line 1 should equal "ARTIFACTORY_DEPLOY_REPO=sonarsource-deploy-qa"
-    The line 2 should equal "Promoting build dummy-project/$BUILD_NUMBER (version: 1.2.3.42)"
-    The line 3 should equal "Target repository: sonarsource-deploy-builds"
+    The line 1 should equal "::group::Check tools"
+    The line 2 should equal "::endgroup::"
+    The line 3 should equal "::group::Configure promotion"
+    The line 4 should equal "::endgroup::"
+    The line 5 should equal "::group::Promote build artifacts"
+    The line 6 should equal "ARTIFACTORY_DEPLOY_REPO=sonarsource-deploy-qa"
+    The line 7 should equal "Promoting build dummy-project/$BUILD_NUMBER (version: 1.2.3.42)"
+    The line 8 should equal "Target repository: sonarsource-deploy-builds"
+    The line 9 should equal "jf rt bpr --status it-passed dummy-project 42 sonarsource-deploy-builds"
+    The line 10 should equal "::endgroup::"
+    The line 11 should equal "::group::Notify GitHub"
+    The line 12 should equal "::endgroup::"
   End
 
   It 'customizes the build name with BUILD_NAME not equal to the repository name'
@@ -375,8 +395,10 @@ Describe 'promote()'
     When call promote
     The status should be success
     The variable BUILD_NAME should equal "dummy-project-abc"
-    The line 2 should equal "Promoting build $BUILD_NAME/$BUILD_NUMBER (version: 1.2.3.42)"
-    The line 3 should equal "Target repository: sonarsource-deploy-builds"
-    The line 4 should equal "jf rt bpr --status it-passed dummy-project-abc 42 sonarsource-deploy-builds"
+    The line 5 should equal "::group::Promote build artifacts"
+    The line 7 should equal "Promoting build $BUILD_NAME/$BUILD_NUMBER (version: 1.2.3.42)"
+    The line 8 should equal "Target repository: sonarsource-deploy-builds"
+    The line 9 should equal "jf rt bpr --status it-passed dummy-project-abc 42 sonarsource-deploy-builds"
+    The line 10 should equal "::endgroup::"
   End
 End

--- a/spec/set_gradle_project_version_spec.sh
+++ b/spec/set_gradle_project_version_spec.sh
@@ -173,12 +173,16 @@ Describe 'main()'
   It 'runs tool checks and calls set_project_version'
     When run script config-gradle/set_gradle_project_version.sh
     The status should be success
-    The lines of output should equal 5
-    The line 1 should include "gradle"
-    The line 2 should equal "version: 1.2.4-SNAPSHOT"
-    The line 3 should equal "CURRENT_VERSION=1.2.4-SNAPSHOT"
-    The line 4 should equal "Replacing version 1.2.4-SNAPSHOT with 1.2.4.42"
-    The line 5 should equal "PROJECT_VERSION=1.2.4.42"
+    The lines of output should equal 9
+    The line 1 should equal "::group::Check tools"
+    The line 2 should include "gradle"
+    The line 3 should equal "version: 1.2.4-SNAPSHOT"
+    The line 4 should equal "::endgroup::"
+    The line 5 should equal "::group::Set project version"
+    The line 6 should equal "CURRENT_VERSION=1.2.4-SNAPSHOT"
+    The line 7 should equal "Replacing version 1.2.4-SNAPSHOT with 1.2.4.42"
+    The line 8 should equal "PROJECT_VERSION=1.2.4.42"
+    The line 9 should equal "::endgroup::"
   End
 
   It 'uses provided CURRENT_VERSION and PROJECT_VERSION without changes'
@@ -199,7 +203,7 @@ Describe 'main()'
 
     When run script config-gradle/set_gradle_project_version.sh
     The status should be success
-    The lines of output should equal 5
+    The lines of output should equal 9
   End
 
   It 'proceeds normally when only PROJECT_VERSION is provided'
@@ -207,6 +211,6 @@ Describe 'main()'
 
     When run script config-gradle/set_gradle_project_version.sh
     The status should be success
-    The lines of output should equal 5
+    The lines of output should equal 9
   End
 End

--- a/spec/set_maven_project_version_spec.sh
+++ b/spec/set_maven_project_version_spec.sh
@@ -169,14 +169,18 @@ Describe 'main()'
   It 'runs tool checks and calls set_project_version'
     When run script config-maven/set_maven_project_version.sh
     The status should be success
-    The lines of output should equal 7
-    The line 1 should include "mvn"
-    The line 2 should equal "mvn --version"
-    The line 3 should equal "CURRENT_VERSION=1.2.3-SNAPSHOT (from pom.xml)"
-    The line 4 should equal "Replacing version 1.2.3-SNAPSHOT with 1.2.3.1"
-    The line 5 should start with "Maven command:"
-    The line 6 should equal "mvn versions"
-    The line 7 should equal "PROJECT_VERSION=1.2.3.1"
+    The lines of output should equal 11
+    The line 1 should equal "::group::Check tools"
+    The line 2 should include "mvn"
+    The line 3 should equal "mvn --version"
+    The line 4 should equal "::endgroup::"
+    The line 5 should equal "::group::Set project version"
+    The line 6 should equal "CURRENT_VERSION=1.2.3-SNAPSHOT (from pom.xml)"
+    The line 7 should equal "Replacing version 1.2.3-SNAPSHOT with 1.2.3.1"
+    The line 8 should start with "Maven command:"
+    The line 9 should equal "mvn versions"
+    The line 10 should equal "PROJECT_VERSION=1.2.3.1"
+    The line 11 should equal "::endgroup::"
   End
 
   It 'uses provided CURRENT_VERSION and PROJECT_VERSION without changes'
@@ -199,7 +203,7 @@ Describe 'main()'
 
     When run script config-maven/set_maven_project_version.sh
     The status should be success
-    The lines of output should equal 7
+    The lines of output should equal 11
   End
 
   It 'proceeds normally when only PROJECT_VERSION is provided'
@@ -208,6 +212,6 @@ Describe 'main()'
 
     When run script config-maven/set_maven_project_version.sh
     The status should be success
-    The lines of output should equal 7
+    The lines of output should equal 11
   End
 End


### PR DESCRIPTION
Wrap verbose operations in `::group::`/`::endgroup::` across all build scripts so GitHub Actions logs are folded by default, showing a compact summary of build steps with expandable details.

## Test Plan
Temporary PRs have been generated for the dummy repos that test these changes! See below:
Repo | Actions tested | PR
-- | -- | --
sonar-dummy-gradle-oss | build-gradle, config-gradle, get-build-number, promote | https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/332
sonar-dummy-maven-enterprise | build-maven, config-maven, get-build-number, promote | https://github.com/SonarSource/sonar-dummy-maven-enterprise/pull/120
sonar-dummy | build-maven, get-build-number, promote | https://github.com/SonarSource/sonar-dummy/pull/556
sonar-dummy-js | build-npm, config-npm, promote | https://github.com/SonarSource/sonar-dummy-js/pull/119
sonar-dummy-python-oss | build-poetry, promote | https://github.com/SonarSource/sonar-dummy-python-oss/pull/79
sonar-dummy-yarn | build-yarn, promote | https://github.com/SonarSource/sonar-dummy-yarn/pull/44

