### PR TITLE
PREQ-4284 Add `generate-summary` input to build-maven action

### DIFF
--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -72,6 +72,9 @@ inputs:
   mixed-privacy:
     description: Whether the repository contains both public and private modules
     default: 'false'
+  generate-summary:
+    description: Whether to generate a workflow summary after the build.
+    default: 'true'
 
 outputs:
   project-version:
@@ -230,7 +233,7 @@ runs:
         show-summary: true
 
     - name: Generate workflow summary
-      if: always()
+      if: always() && inputs.generate-summary != 'false'
       shell: bash
       run: |
         build_name="${GITHUB_REPOSITORY#*/}"


### PR DESCRIPTION
## Summary
- Add a `generate-summary` input (default `'true'`) to `build-maven/action.yml` so users can disable the workflow summary step by setting it to `'false'`
- Update the "Generate workflow summary" step's `if:` condition to respect the new input

## Test plan
- [x] Verify default behavior unchanged (summary still generated when input is omitted)
- [x] Set `generate-summary: 'false'` and confirm the summary step is skipped

## Test Results
Default behavior: https://github.com/SonarSource/sonar-pli/actions/runs/22218128717?pr=286
Disabled summary: https://github.com/SonarSource/sonar-pli/actions/runs/22218203043?pr=286

🤖 Generated with [Claude Code](https://claude.com/claude-code)