### PR TITLE
BUILD-10503 Sanitize workflow name in cache keys

### DIFF
--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -157,13 +157,21 @@ runs:
 
         rm -f gradle-md5-sums.txt
 
+    - name: Sanitize workflow name for cache key
+      id: sanitize_workflow
+      if: steps.config-gradle-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
+      shell: bash
+      env:
+        WORKFLOW_NAME: ${{ github.workflow }}
+      run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
+
     - name: Gradle Cache
       uses: SonarSource/gh-action_cache@v1
       if: steps.config-gradle-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}
-        key: gradle-${{ runner.os }}-${{ github.workflow }}-${{ env.GRADLE_CACHE_KEY }}
-        restore-keys: gradle-${{ runner.os }}-${{ github.workflow }}-
+        key: gradle-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-${{ env.GRADLE_CACHE_KEY }}
+        restore-keys: gradle-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-
 
     # $GRADLE_USER_HOME is typically set to ~/.gradle/ by gradle/actions/setup-gradle
     - name: Configure Gradle Authentication

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -168,13 +168,23 @@ runs:
           fi
         fi
 
+    - name: Sanitize workflow name for cache key
+      id: sanitize_workflow
+      if: steps.config-maven-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
+      shell: bash
+      env:
+        WORKFLOW_NAME: ${{ github.workflow }}
+      run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
+
     - name: Cache local Maven repository
       uses: SonarSource/gh-action_cache@v1
       if: steps.config-maven-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}
-        key: maven-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles(format('{0}/**/pom.xml', inputs.working-directory)) }}
-        restore-keys: maven-${{ runner.os }}-${{ github.workflow }}-
+        # yamllint disable rule:line-length
+        key: maven-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-${{ hashFiles(format('{0}/**/pom.xml', inputs.working-directory)) }}
+        # yamllint enable rule:line-length
+        restore-keys: maven-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-
 
     - name: Update project version and set current-version and project-version variables
       id: set-version

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -97,13 +97,21 @@ runs:
         rmdir "${{ steps.setup.outputs.MISE_BACKUP }}"
         echo "::endgroup::"
 
+    - name: Sanitize workflow name for cache key
+      id: sanitize_workflow
+      if: ${{ inputs.cache-npm == 'true' }}
+      shell: bash
+      env:
+        WORKFLOW_NAME: ${{ github.workflow }}
+      run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
+
     - name: Cache NPM dependencies
       uses: SonarSource/gh-action_cache@v1
       if: ${{ inputs.cache-npm == 'true' }}
       with:
         path: ~/.npm
-        key: npm-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: npm-${{ runner.os }}-${{ github.workflow }}-
+        key: npm-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: npm-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-
 
     - name: Check for package.json
       id: check_package_json

--- a/config-pip/action.yml
+++ b/config-pip/action.yml
@@ -91,12 +91,22 @@ runs:
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
       run: $ACTION_PATH_CONFIG_PIP/config.sh
 
+    - name: Sanitize workflow name for cache key
+      id: sanitize_workflow
+      if: inputs.disable-caching == 'false'
+      shell: bash
+      env:
+        WORKFLOW_NAME: ${{ github.workflow }}
+      run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
+
     - name: Cache pip dependencies
       uses: SonarSource/gh-action_cache@v1
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}
-        key: pip-${{ runner.os }}-${{ github.workflow }}-${{ hashFiles(format('{0}/requirements*.txt', inputs.working-directory),
+        # yamllint disable rule:line-length
+        key: pip-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-${{ hashFiles(format('{0}/requirements*.txt', inputs.working-directory),
           format('{0}/Pipfile.lock', inputs.working-directory), format('{0}/poetry.lock', inputs.working-directory),
           format('{0}/pyproject.toml', inputs.working-directory)) }}
-        restore-keys: pip-${{ runner.os }}-${{ github.workflow }}-
+        # yamllint enable rule:line-length
+        restore-keys: pip-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-


### PR DESCRIPTION
## Problem

Spaces in GitHub workflow names cause cache save/restore failures. The workflow name is included in the S3 cache key, and spaces in the key result in malformed pre-signed URLs — the request hits an error response instead of the actual S3 object, which doesn't support HTTP range requests:

```
Warning: Download attempt 1 failed: Range request not supported by server.
Warning: Download attempt 2 failed: Range request not supported by server.
Warning: Failed to restore: Range request not supported by server
```

## Fix

Added a sanitize step before each cache step that replaces spaces in the workflow name with `-` before it is used in the cache key. The step uses an explicit `WORKFLOW_NAME` env var sourced from `github.workflow` (rather than `$GITHUB_WORKFLOW`) to ensure the value is consistent with what would have been interpolated directly.

All four actions use the same pattern: the sanitize step outputs `workflow_name`, which is then referenced directly in the `key:` and `restore-keys:` expressions of the cache step. For actions where the resulting `key:` line exceeds the 140-character yamllint limit (`config-maven`, `config-pip`), a `# yamllint disable/enable rule:line-length` block is used.

## Changes

- `config-npm/action.yml` — sanitize workflow name in NPM cache key
- `config-maven/action.yml` — sanitize workflow name in Maven cache key
- `config-gradle/action.yml` — sanitize workflow name in Gradle cache key
- `config-pip/action.yml` — sanitize workflow name in Pip cache key

## Jira

https://sonarsource.atlassian.net/browse/BUILD-10503

## Testing
https://github.com/SonarSource/sonar-dummy/actions/runs/22349083633/job/64671224433#step:4:740 after
https://github.com/SonarSource/sonar-dummy/actions/runs/22348992658/job/64670914225#step:4:717 before