### PR TITLE
BUILD-10215 Standardize GitHub Actions output logging

### DIFF
--- a/build-gradle/build.sh
+++ b/build-gradle/build.sh
@@ -97,7 +97,7 @@ should_deploy() {
 
   # Disable deployment when shadow scans are enabled to prevent duplicate artifacts
   if [[ "${RUN_SHADOW_SCANS}" = "true" ]]; then
-    echo "Shadow scans enabled - disabling deployment" >&2
+    echo "::warning title=Deployment disabled::Shadow scans enabled - disabling deployment" >&2
     return 1
   fi
 
@@ -179,7 +179,7 @@ set_gradle_cmd() {
   elif check_tool gradle --version; then
     export GRADLE_CMD="gradle"
   else
-    echo "Neither ./gradlew nor gradle command found!" >&2
+    echo "::error title=Gradle not found::Neither ./gradlew nor gradle command found!" >&2
     exit 1
   fi
 }
@@ -253,7 +253,7 @@ export_built_artifacts() {
   fi
 
   if [[ -z "$artifacts" ]]; then
-    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
+    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories" >&2
     echo "::endgroup::"
     return 0
   fi

--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -107,7 +107,7 @@ git_fetch_unshallow() {
 
 check_settings_xml() {
   if [ ! -f "$HOME/.m2/settings.xml" ]; then
-    echo "::error title=Missing Maven settings.xml::Maven settings.xml file not found at $HOME/.m2/settings.xml"
+    echo "::error title=Missing Maven settings.xml::Maven settings.xml file not found at $HOME/.m2/settings.xml" >&2
     exit 1
   fi
 }
@@ -120,7 +120,7 @@ should_deploy() {
 
   # Disable deployment when shadow scans are enabled to prevent duplicate artifacts
   if [[ "${RUN_SHADOW_SCANS}" = "true" ]]; then
-    echo "Shadow scans enabled - disabling deployment" >&2
+    echo "::warning title=Deployment disabled::Shadow scans enabled - disabling deployment" >&2
     return 1
   fi
 
@@ -245,7 +245,7 @@ export_built_artifacts() {
   fi
 
   if [[ -z "$artifacts" ]]; then
-    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
+    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories" >&2
     echo "::endgroup::"
     return 0
   fi

--- a/build-maven/deploy-artifacts.sh
+++ b/build-maven/deploy-artifacts.sh
@@ -24,7 +24,7 @@ for artifact in $INSTALLED_ARTIFACTS; do
   elif [[ $artifact == "com/"* ]]; then
     private_artifacts+=("$artifact")
   else
-    echo "WARN: Unrecognized artifact path: $artifact" >&2
+    echo "::warning title=Unrecognized artifact::Unrecognized artifact path: $artifact" >&2
   fi
 done
 

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -246,7 +246,7 @@ export_built_artifacts() {
   artifacts=$(/usr/bin/find .attestation-artifacts -name '*.tgz' -type f 2>/dev/null || true)
 
   if [[ -z "$artifacts" ]]; then
-    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
+    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories" >&2
     echo "::endgroup::"
     return 0
   fi

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -98,7 +98,7 @@ set_sonar_platform_vars() {
       return 0
       ;;
     *)
-      echo "ERROR: Unknown sonar platform '$platform'. Expected: next, sqc-us, sqc-eu, or none" >&2
+      echo "::error title=Invalid Sonar platform::Unknown sonar platform '$platform'. Expected: next, sqc-us, sqc-eu, or none" >&2
       return 1
       ;;
   esac
@@ -166,7 +166,7 @@ set_project_version() {
   local current_version release_version digit_count
 
   if ! current_version=$(poetry version -s); then
-    echo "Could not get version from Poetry project ('poetry version -s')" >&2
+    echo "::error title=Invalid project version::Could not get version from Poetry project ('poetry version -s')" >&2
     echo "$current_version" >&2
     return 1
   fi
@@ -180,7 +180,7 @@ set_project_version() {
   fi
   if [[ "$digit_count" -gt 3 && $release_version =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
     release_version="${BASH_REMATCH[0]}"
-    echo "WARN: version was truncated to $release_version because it had more than 3 digits"
+    echo "::warning title=Version truncated::Version was truncated to $release_version because it had more than 3 digits" >&2
   fi
   release_version="$release_version.${BUILD_NUMBER}"
 
@@ -323,7 +323,7 @@ export_built_artifacts() {
   artifacts=$(/usr/bin/find dist -type f \( -name '*.tar.gz' -o -name '*.whl' -o -name '*.json' \) 2>/dev/null || true)
 
   if [[ -z "$artifacts" ]]; then
-    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
+    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories" >&2
     echo "::endgroup::"
     return 0
   fi

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -81,11 +81,11 @@ set_build_env() {
 
   # Validate required files exist
   if [ ! -f "package.json" ]; then
-    echo "ERROR: package.json file not found in current directory." >&2
+    echo "::error title=Missing package.json::package.json file not found in current directory." >&2
     exit 1
   fi
   if [ ! -f "yarn.lock" ]; then
-    echo "ERROR: yarn.lock file not found. This is required for yarn --immutable installs." >&2
+    echo "::error title=Missing yarn.lock::yarn.lock file not found. This is required for yarn --immutable installs." >&2
     exit 1
   fi
 
@@ -114,7 +114,7 @@ set_project_version() {
 
   current_version=$(jq -r .version "$PACKAGE_JSON")
   if [ -z "${current_version}" ] || [ "${current_version}" == "null" ]; then
-    echo "Could not get version from ${PACKAGE_JSON}" >&2
+    echo "::error file=${PACKAGE_JSON},title=Invalid project version::Could not get version from ${PACKAGE_JSON}" >&2
     exit 1
   fi
   export CURRENT_VERSION=$current_version
@@ -129,7 +129,7 @@ set_project_version() {
   elif [[ "$digit_count" -eq 2 ]]; then
     release_version="${release_version}.0"
   elif [[ "$digit_count" -ne 3 ]]; then
-    echo "ERROR: Unsupported version '$current_version' with $digit_count digits. Expected 1-3 digits (e.g., '1', '1.2', or '1.2.3')." >&2
+    echo "::error file=${PACKAGE_JSON},title=Unsupported version format::Unsupported version '$current_version' with $digit_count digits. Expected 1-3 digits (e.g., '1', '1.2', or '1.2.3')." >&2
     return 1
   fi
   release_version="${release_version}-${BUILD_NUMBER}"
@@ -322,7 +322,7 @@ export_built_artifacts() {
   artifacts=$(/usr/bin/find "$PWD/.attestation-artifacts/" -name '*.tgz' -type f 2>/dev/null || true)
 
   if [[ -z "$artifacts" ]]; then
-    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
+    echo "::warning title=No artifacts found::No artifacts found for attestation in build output directories" >&2
     echo "::endgroup::"
     return 0
   fi

--- a/cache/action.yml
+++ b/cache/action.yml
@@ -34,7 +34,7 @@ runs:
       shell: bash
       run: |
         echo "::warning:: This action is deprecated and will be removed in future releases. " \
-          "Please migrate to using the SonarSource/gh-action_cache action directly."
+          "Please migrate to using the SonarSource/gh-action_cache action directly." >&2
 
     - uses: SonarSource/gh-action_cache@v1
       id: cache

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -118,7 +118,8 @@ runs:
           fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN || '' }}
       run: |
         if [[ "${DEVELOCITY_ACCESS_KEY:-}" == "${{ steps.develocity-hostname.outputs.hostname }}=" ]]; then
-          echo "::warning title=Found invalid DEVELOCITY_ACCESS_KEY::DEVELOCITY_ACCESS_KEY should not be set manually in the environment."
+          echo "::warning title=Found invalid DEVELOCITY_ACCESS_KEY::DEVELOCITY_ACCESS_KEY should not be set manually" \
+            "in the environment." >&2
           echo "[WARNING] DEVELOCITY_ACCESS_KEY is set in the environment with an empty token. This is a deprecated configuration." \
           "The Develocity token is configured by config-gradle. Please remove external configuration of DEVELOCITY_ACCESS_KEY."
         fi
@@ -195,7 +196,7 @@ runs:
       shell: bash
       run: |
         echo "::warning title=Deactivating UseContainerSupport::The GitHub-hosted Ubuntu runners have an issue with Java's" \
-          "UseContainerSupport feature."
+          "UseContainerSupport feature." >&2
         echo "JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS:=-XX:-UseContainerSupport}" >> "$GITHUB_ENV"
 
     - name: Set Config Gradle completed

--- a/config-gradle/set_gradle_project_version.sh
+++ b/config-gradle/set_gradle_project_version.sh
@@ -26,7 +26,7 @@ set_gradle_cmd() {
   elif check_tool gradle --version; then
     export GRADLE_CMD="gradle"
   else
-    echo "Neither ./gradlew nor gradle command found!" >&2
+    echo "::error title=Gradle not found::Neither ./gradlew nor gradle command found!" >&2
     exit 1
   fi
 }
@@ -37,7 +37,7 @@ set_project_version() {
   if ! current_version=$($GRADLE_CMD "${GRADLE_CMD_PARAMS[@]}" |grep 'version:' | cut -d ":" -f 2 | tr -d "[:space:]") || \
       [[ -z "$current_version" || "$current_version" == "unspecified" ]]; then
     current_version=$($GRADLE_CMD properties --no-scan --no-daemon --console plain 2>&1 || true)
-    echo -e "::error title=Gradle project version::Could not get valid version from Gradle properties\nERROR: $current_version"
+    printf "%s\n%s\n" "::error title=Gradle project version::Could not get valid version from Gradle properties" "ERROR: $current_version" >&2
     return 1
   fi
 

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -119,7 +119,8 @@ runs:
           fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN || '' }}
       run: |
         if [[ "${DEVELOCITY_ACCESS_KEY:-}" == "${{ steps.develocity-hostname.outputs.hostname }}=" ]]; then
-          echo "::warning title=Found invalid DEVELOCITY_ACCESS_KEY::DEVELOCITY_ACCESS_KEY should not be set manually in the environment."
+          echo "::warning title=Found invalid DEVELOCITY_ACCESS_KEY::DEVELOCITY_ACCESS_KEY should not be set manually" \
+            "in the environment." >&2
           echo "[WARNING] DEVELOCITY_ACCESS_KEY is set in the environment with an empty token. This is a deprecated configuration." \
           "The Develocity token is configured by config-maven. Please remove external configuration of DEVELOCITY_ACCESS_KEY."
         fi
@@ -199,7 +200,7 @@ runs:
       shell: bash
       run: |
         echo "::warning title=Deactivating UseContainerSupport::The GitHub-hosted Ubuntu runners have an issue with Java's" \
-          "UseContainerSupport feature."
+          "UseContainerSupport feature." >&2
         echo "JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS:=-XX:-UseContainerSupport}" >> "$GITHUB_ENV"
 
     - name: Create mvn wrapper function with common Maven flags and set MAVEN_OPTS

--- a/config-maven/set_maven_project_version.sh
+++ b/config-maven/set_maven_project_version.sh
@@ -23,7 +23,7 @@ get_current_version() {
   local expression="project.version"
   if ! command mvn --quiet --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec 2>/dev/null \
       -Dexec.executable="echo" -Dexec.args="\${$expression}"; then
-    echo "Failed to evaluate Maven expression '$expression'" >&2
+    echo "::error title=Maven expression evaluation failed::Failed to evaluate Maven expression '$expression'" >&2
     command mvn --debug --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec \
       -Dexec.executable="echo" -Dexec.args="\${$expression}"
     return 1
@@ -56,7 +56,7 @@ set_project_version() {
   elif [[ "$dots_count" -eq 1 ]]; then
     release_version="${release_version}.0"
   elif [[ "$dots_count" -ne 2 ]]; then
-    echo "::error file=pom.xml,title=Maven project version::Unsupported version '$current_version' with $((dots_count + 1)) digits."
+    echo "::error file=pom.xml,title=Maven project version::Unsupported version '$current_version' with $((dots_count + 1)) digits." >&2
     return 1
   fi
   release_version="${release_version}.${BUILD_NUMBER}"

--- a/config-npm/npm_set_project_version.sh
+++ b/config-npm/npm_set_project_version.sh
@@ -25,7 +25,7 @@ check_version_format() {
   local version="$1"
   # Check if version follows semantic versioning pattern (X.Y.Z or X.Y.Z-something)
   if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
-    echo "WARN: Version '${version}' does not match semantic versioning format (e.g., '1.2.3' or '1.2.3-beta.1')." >&2
+    echo "::warning title=Non-standard version format::Version '${version}' does not match semantic versioning format (e.g., '1.2.3' or '1.2.3-beta.1')." >&2
   fi
   return 0
 }
@@ -42,7 +42,7 @@ set_project_version() {
   local current_version release_version digit_count
   current_version=$(jq -r .version "$PACKAGE_JSON")
   if [[ -z "${current_version}" ]] || [[ "${current_version}" == "null" ]]; then
-    echo "Could not get version from ${PACKAGE_JSON}" >&2
+    echo "::error file=${PACKAGE_JSON},title=Invalid project version::Could not get version from ${PACKAGE_JSON}" >&2
     exit 1
   fi
   echo "current-version=$current_version" >> "$GITHUB_OUTPUT"

--- a/get-build-number/get_build_number.sh
+++ b/get-build-number/get_build_number.sh
@@ -12,7 +12,7 @@ PROPERTIES_API_URL="repos/${GITHUB_REPOSITORY}/properties/values"
 BUILD_NUMBER=$(gh api -H "$GH_API_VERSION_HEADER" "$PROPERTIES_API_URL" --jq '.[] | select(.property_name == "build_number") | .value')
 echo "Current build number from repo: ${BUILD_NUMBER:=0}"
 if ! [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
-  echo "Error: Build number '${BUILD_NUMBER}' is not a valid positive integer."
+  echo "::error title=Invalid build number::Build number '${BUILD_NUMBER}' is not a valid positive integer." >&2
   exit 1
 fi
 

--- a/promote/promote.sh
+++ b/promote/promote.sh
@@ -64,7 +64,7 @@ check_branch() {
   fi
 
   if ! (is_pull_request || is_default_branch || is_maintenance_branch || is_dogfood_branch); then
-    echo "Promotion is only available for pull requests, main branch, maintenance branches, or dogfood branches." >&2
+    echo "::error title=Promotion unavailable::Promotion is only available for pull requests, main branch, maintenance branches, or dogfood branches." >&2
     echo "Current branch: ${GITHUB_REF_NAME} (GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME})" >&2
     return 1
   fi
@@ -98,7 +98,7 @@ get_build_info_property() {
   fi
   property_value=$(jq -r ".buildInfo.properties.\"buildInfo.env.$property\"" "$BUILD_INFO_FILE")
   if [[ "$property_value" == "null" || -z "$property_value" || "$property_value" == "unspecified" ]]; then
-    echo "Failed to retrieve $property from buildInfo for build ${BUILD_NAME}/${BUILD_NUMBER}" >&2
+    echo "::error title=Build info retrieval failed::Failed to retrieve $property from buildInfo for build ${BUILD_NAME}/${BUILD_NUMBER}" >&2
     jq -r '.errors' "$BUILD_INFO_FILE" >&2
     return 1
   fi

--- a/shared/common-functions.sh
+++ b/shared/common-functions.sh
@@ -38,7 +38,7 @@ set_sonar_platform_vars() {
       return 0
       ;;
     *)
-      echo "ERROR: Invalid Sonar platform '$platform'. Must be one of: next, sqc-us, sqc-eu, none" >&2
+      echo "::error title=Invalid Sonar platform::Invalid Sonar platform '$platform'. Must be one of: next, sqc-us, sqc-eu, none" >&2
       return 1
       ;;
   esac
@@ -86,7 +86,7 @@ orchestrate_sonar_platforms() {
 check_tool() {
   # Check if a command is available and runs it, typically: 'some_tool --version'
   if ! command -v "$1"; then
-    echo "$1 is not installed." >&2
+    echo "::error title=Missing tool::$1 is not installed." >&2
     return 1
   fi
   "$@"

--- a/spec/build-gradle_spec.sh
+++ b/spec/build-gradle_spec.sh
@@ -184,7 +184,7 @@ Describe 'should_deploy'
     When call should_deploy
     The status should be failure
     The lines of stderr should equal 1
-    The line 1 of stderr should equal "Shadow scans enabled - disabling deployment"
+    The line 1 of stderr should equal "::warning title=Deployment disabled::Shadow scans enabled - disabling deployment"
   End
 End
 
@@ -343,7 +343,7 @@ Describe 'gradle_build'
     The output should include "Gradle command:"
     The output should include "Gradle executed with:"
     The output should not include "=== ORCHESTRATOR:"
-
+    The stderr should include "::warning title=No artifacts found::"
 
     rm -f gradle-mock gradle.properties
   End
@@ -454,17 +454,17 @@ Describe 'set_gradle_cmd()'
     # Mock check_tool to fail for gradle
     Mock check_tool
       if [[ "$1" == "gradle" ]]; then
-        echo "gradle is not installed." >&2
+        echo "::error title=Missing tool::gradle is not installed." >&2
         false
       else
-        echo "$1 is not installed." >&2
+        echo "::error title=Missing tool::$1 is not installed." >&2
         false
       fi
     End
 
     When run set_gradle_cmd
     The status should be failure
-    The stderr should include "Neither ./gradlew nor gradle command found!"
+    The stderr should include "::error title=Gradle not found::Neither ./gradlew nor gradle command found!"
 
     rm -f ./gradlew
   End
@@ -505,5 +505,6 @@ Describe 'script execution'
     When run script build-gradle/build.sh
     The status should be success
     The output should include "PROJECT: my-repo"
+    The stderr should include "::warning title=No artifacts found::"
   End
 End

--- a/spec/build-maven_deploy-artifacts_spec.sh
+++ b/spec/build-maven_deploy-artifacts_spec.sh
@@ -56,7 +56,7 @@ com/sonarsource/private/app/1.0/app-1.0.pom"
 
     When run script build-maven/deploy-artifacts.sh
     The status should be success
-    The stderr should include "WARN: Unrecognized artifact path: unknown/artifact/path.jar"
+    The stderr should include "::warning title=Unrecognized artifact::Unrecognized artifact path: unknown/artifact/path.jar"
     The output should include "org/sonarsource/app/1.0/app-1.0.pom"
     The output should include "com/sonarsource/private/app/1.0/app-1.0.pom"
 

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -191,11 +191,11 @@ Describe 'export_built_artifacts()'
 
     When call export_built_artifacts
     The status should be success
-    The lines of stdout should equal 4
+    The lines of stdout should equal 3
     The line 1 should equal "::group::Capturing built artifacts for attestation"
     The line 2 should equal "Scanning for artifacts in: */target/*"
-    The line 3 should equal "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
-    The line 4 should equal "::endgroup::"
+    The line 3 should equal "::endgroup::"
+    The stderr should include "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
     The lines of contents of file "$GITHUB_OUTPUT" should equal 4
     The line 1 of contents of file "$GITHUB_OUTPUT" should equal "$DEPLOYED_OUTPUT_KEY=true"
     rm -rf target "$GITHUB_OUTPUT"
@@ -286,8 +286,8 @@ Describe 'check_settings_xml()'
     mkdir -p "$HOME/.m2"
     When run check_settings_xml
     The status should be failure
-    The lines of output should equal 1
-    The output should include "Missing Maven settings.xml::Maven settings.xml file not found at $HOME/.m2/settings.xml"
+    The lines of output should equal 0
+    The stderr should include "Missing Maven settings.xml::Maven settings.xml file not found at $HOME/.m2/settings.xml"
 
     rm -rf "$temp_home"
   End
@@ -298,8 +298,8 @@ Describe 'check_settings_xml()'
     export HOME="$temp_home"
     When run check_settings_xml
     The status should be failure
-    The lines of output should equal 1
-    The output should include "Missing Maven settings.xml::Maven settings.xml file not found at $HOME/.m2/settings.xml"
+    The lines of output should equal 0
+    The stderr should include "Missing Maven settings.xml::Maven settings.xml file not found at $HOME/.m2/settings.xml"
 
     rm -rf "$temp_home"
   End
@@ -561,7 +561,7 @@ Describe 'build_maven()'
     It 'disables deployment when shadow scans are enabled'
       When call build_maven
       The status should be success
-      The stderr should include "Shadow scans enabled - disabling deployment"
+      The stderr should include "::warning title=Deployment disabled::Shadow scans enabled - disabling deployment"
       The output should include "Maven command: mvn install"
       The output should not include "Maven command: mvn deploy"
     End
@@ -569,7 +569,7 @@ Describe 'build_maven()'
     It 'excludes release and sign profiles when shadow scans are enabled'
       When call build_maven
       The status should be success
-      The stderr should include "Shadow scans enabled - disabling deployment"
+      The stderr should include "::warning title=Deployment disabled::Shadow scans enabled - disabling deployment"
       The output should include "Maven command: mvn install -Pcoverage"
       The output should not include "release"
       The output should not include "sign"
@@ -583,7 +583,7 @@ Describe 'build_maven()'
     It 'excludes release profile when shadow scans are enabled'
       When call build_maven
       The status should be success
-      The stderr should include "Shadow scans enabled - disabling deployment"
+      The stderr should include "::warning title=Deployment disabled::Shadow scans enabled - disabling deployment"
       The output should include "Maven command: mvn install"
       The output should not include "release"
     End

--- a/spec/build-npm_spec.sh
+++ b/spec/build-npm_spec.sh
@@ -103,6 +103,7 @@ Describe 'build-npm/build.sh'
     When run script build-npm/build.sh
     The status should be success
     The output should include "=== NPM Build, Deploy, and Analyze ==="
+    The stderr should include "::warning title=No artifacts found::"
   End
 End
 

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -195,10 +195,10 @@ Describe 'export_built_artifacts()'
 
     When call export_built_artifacts
     The status should be success
-    The lines of stdout should equal 3
+    The lines of stdout should equal 2
     The line 1 should equal "::group::Capturing built artifacts for attestation"
-    The line 2 should equal "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
-    The line 3 should equal "::endgroup::"
+    The line 2 should equal "::endgroup::"
+    The stderr should include "::warning title=No artifacts found::No artifacts found for attestation in build output directories"
     The lines of contents of file "$GITHUB_OUTPUT" should equal 1
     The line 1 of contents of file "$GITHUB_OUTPUT" should equal "should-deploy=true"
   End
@@ -218,7 +218,7 @@ Describe 'set_sonar_platform_vars() - poetry specific'
   It 'fails with unknown platform'
     When call set_sonar_platform_vars "unknown"
     The status should be failure
-    The stderr should include "ERROR: Unknown sonar platform 'unknown'. Expected: next, sqc-us, sqc-eu, or none"
+    The stderr should include "::error title=Invalid Sonar platform::Unknown sonar platform 'unknown'. Expected: next, sqc-us, sqc-eu, or none"
   End
 End
 
@@ -274,8 +274,8 @@ Describe 'set_project_version()'
       fi
     End
     When call set_project_version
-    The line 1 should equal "WARN: version was truncated to 1.2.3 because it had more than 3 digits"
-    The line 2 should equal "Replacing version 1.2.3.41 with 1.2.3.42"
+    The line 1 of error should equal "::warning title=Version truncated::Version was truncated to 1.2.3 because it had more than 3 digits"
+    The line 1 should equal "Replacing version 1.2.3.41 with 1.2.3.42"
     The variable CURRENT_VERSION should equal "1.2.3.41"
     The variable PROJECT_VERSION should equal "1.2.3.42"
   End
@@ -290,7 +290,7 @@ Describe 'set_project_version()'
       fi
     End
     When call set_project_version
-    The line 1 of error should equal "Could not get version from Poetry project ('poetry version -s')"
+    The line 1 of error should equal "::error title=Invalid project version::Could not get version from Poetry project ('poetry version -s')"
     The line 2 of error should equal "Failed to get version"
     The variable CURRENT_VERSION should be undefined
     The variable PROJECT_VERSION should be undefined
@@ -592,7 +592,11 @@ Describe 'build_poetry()'
         echo "Python 3.11.0"
       End
       Mock poetry
-        echo "Poetry (version 1.8.0)"
+        if [[ "$*" == "version -s" ]]; then
+          echo "1.8.0"
+        else
+          echo "Poetry (version 1.8.0)"
+        fi
       End
       Mock jf
         echo "jf version 2.77.0"
@@ -623,7 +627,11 @@ Describe 'build_poetry()'
         echo "Python 3.11.0"
       End
       Mock poetry
-        echo "Poetry (version 1.8.0)"
+        if [[ "$*" == "version -s" ]]; then
+          echo "1.8.0"
+        else
+          echo "Poetry (version 1.8.0)"
+        fi
       End
       Mock jf
         echo "jf version 2.77.0"

--- a/spec/build-yarn_spec.sh
+++ b/spec/build-yarn_spec.sh
@@ -103,7 +103,7 @@ Describe 'build-yarn/build.sh'
       mv package.json package.json.backup
       When run set_build_env
       The status should be failure
-      The stderr should include "ERROR: package.json file not found in current directory."
+      The stderr should include "::error title=Missing package.json::package.json file not found in current directory."
       The stdout should include "PROJECT: test-project"
       mv package.json.backup package.json
     End
@@ -112,7 +112,7 @@ Describe 'build-yarn/build.sh'
       mv yarn.lock yarn.lock.backup
       When run set_build_env
       The status should be failure
-      The stderr should include "ERROR: yarn.lock file not found. This is required for yarn --immutable installs."
+      The stderr should include "::error title=Missing yarn.lock::yarn.lock file not found. This is required for yarn --immutable installs."
       The stdout should include "PROJECT: test-project"
       mv yarn.lock.backup yarn.lock
     End
@@ -214,7 +214,7 @@ Describe 'build-yarn/build.sh'
       export MOCK_VERSION="null"
       When run set_project_version
       The status should be failure
-      The stderr should include "Could not get version from package.json"
+      The stderr should include "::error file=package.json,title=Invalid project version::Could not get version from package.json"
       The variable CURRENT_VERSION should be undefined
       The variable PROJECT_VERSION should be undefined
     End
@@ -223,7 +223,7 @@ Describe 'build-yarn/build.sh'
       export MOCK_VERSION="1.2.3.4-SNAPSHOT"
       When call set_project_version
       The status should be failure
-      The stderr should include "Unsupported version"
+      The stderr should include "::error file=package.json,title=Unsupported version format::Unsupported version"
       The variable CURRENT_VERSION should equal "1.2.3.4-SNAPSHOT"
       The variable PROJECT_VERSION should be undefined
     End
@@ -390,6 +390,7 @@ Describe 'build-yarn/build.sh'
       When call build_yarn
       The status should be success
       The output should include "======= Building maintenance branch ======="
+      The stderr should include "::warning title=No artifacts found::"
     End
 
     It 'builds pull request with deploy enabled'
@@ -399,6 +400,7 @@ Describe 'build-yarn/build.sh'
       The status should be success
       The output should include "======= Building pull request ======="
       The output should include "======= with deploy ======="
+      The stderr should include "::warning title=No artifacts found::"
     End
 
     It 'builds pull request without deploy'
@@ -415,6 +417,7 @@ Describe 'build-yarn/build.sh'
       When call build_yarn
       The status should be success
       The output should include "======= Build dogfood branch ======="
+      The stderr should include "::warning title=No artifacts found::"
     End
 
     It 'builds long-lived feature branch'
@@ -430,6 +433,7 @@ Describe 'build-yarn/build.sh'
       When run script build-yarn/build.sh
       The status should be success
       The output should include "=== Yarn Build, Deploy, and Analyze ==="
+      The stderr should include "::warning title=No artifacts found::"
     End
   End
 
@@ -444,6 +448,7 @@ Describe 'build-yarn/build.sh'
       The status should be success
       The output should include "Sonar Platform: none"
       The output should include "=== ORCHESTRATOR: Skipping Sonar analysis (platform: none) ==="
+      The stderr should include "::warning title=No artifacts found::"
     End
 
     It 'requires sonar variables when platform is not none'

--- a/spec/config-npm_spec.sh
+++ b/spec/config-npm_spec.sh
@@ -108,7 +108,7 @@ Describe 'check_version_format()'
   It 'warns about invalid version format'
     When call check_version_format "invalid-version"
     The status should be success
-    The stderr should include "WARN: Version 'invalid-version' does not match semantic versioning format"
+    The stderr should include "::warning title=Non-standard version format::Version 'invalid-version' does not match semantic versioning format"
   End
 
   It 'accepts valid semantic version without warning'
@@ -130,7 +130,7 @@ Describe 'set_project_version()'
     When run set_project_version
     The status should be failure
     The line 1 should equal "Setting project version..."
-    The stderr should include "Could not get version from package.json"
+    The stderr should include "::error file=package.json,title=Invalid project version::Could not get version from package.json"
     The variable CURRENT_VERSION should be undefined
     The variable PROJECT_VERSION should be undefined
   End
@@ -143,7 +143,7 @@ Describe 'set_project_version()'
     When run set_project_version
     The status should be failure
     The line 1 should equal "Setting project version..."
-    The stderr should include "Could not get version from package.json"
+    The stderr should include "::error file=package.json,title=Invalid project version::Could not get version from package.json"
     The variable CURRENT_VERSION should be undefined
     The variable PROJECT_VERSION should be undefined
   End

--- a/spec/get_build_number_spec.sh
+++ b/spec/get_build_number_spec.sh
@@ -38,7 +38,7 @@ Describe 'get_build_number.sh'
     When run script get-build-number/get_build_number.sh
     The status should be failure
     The line 2 should equal "Current build number from repo: notANumber"
-    The output should include "Error: Build number 'notANumber'"
+    The stderr should include "::error title=Invalid build number::Build number 'notANumber'"
   End
 
   It 'should handle empty build number'

--- a/spec/promote_spec.sh
+++ b/spec/promote_spec.sh
@@ -86,7 +86,7 @@ Describe 'promote/promote.sh'
     The line 7 should include "jf"
     The line 8 should equal "::endgroup::"
     The line 9 should equal "::group::Configure promotion"
-    The error should start with "Promotion is only available for"
+    The error should start with "::error title=Promotion unavailable::Promotion is only available for"
   End
 
   It 'runs promote() on pull_request when promotion is enabled'
@@ -173,7 +173,7 @@ Describe 'check_branch()'
     export GITHUB_REF_NAME="feat/jdoe/JIRA-123-something"
     When call check_branch
     The status should be failure
-    The error should start with "Promotion is only available for"
+    The error should start with "::error title=Promotion unavailable::Promotion is only available for"
   End
 End
 
@@ -247,7 +247,7 @@ Describe 'get_build_info_property()'
   It 'returns an error for a non-existing property'
     When call get_build_info_property "NON_EXISTING_PROPERTY"
     The status should be failure
-    The error should include "Failed to retrieve NON_EXISTING_PROPERTY from buildInfo for build dummy-project/42"
+    The error should include "::error title=Build info retrieval failed::Failed to retrieve NON_EXISTING_PROPERTY from buildInfo for build dummy-project/42"
   End
 End
 

--- a/spec/set_gradle_project_version_spec.sh
+++ b/spec/set_gradle_project_version_spec.sh
@@ -56,7 +56,7 @@ Describe 'set_gradle_cmd()'
     The status should be failure
     The lines of output should equal 0
     The lines of error should equal 1
-    The line 1 of error should equal "Neither ./gradlew nor gradle command found!"
+    The line 1 of error should equal "::error title=Gradle not found::Neither ./gradlew nor gradle command found!"
   End
 End
 
@@ -128,10 +128,9 @@ Describe 'set_project_version()'
     End
     When run set_project_version
     The status should be failure
-    The lines of output should equal 2
-    The line 1 should equal "::error title=Gradle project version::Could not get valid version from Gradle properties"
-    The line 2 should equal "ERROR: version:"
-    The lines of error should equal 0
+    The lines of output should equal 0
+    The line 1 of error should equal "::error title=Gradle project version::Could not get valid version from Gradle properties"
+    The line 2 of error should equal "ERROR: version:"
   End
 
   It 'fails when version is unspecified'
@@ -140,10 +139,9 @@ Describe 'set_project_version()'
     End
     When run set_project_version
     The status should be failure
-    The lines of output should equal 2
-    The line 1 should equal "::error title=Gradle project version::Could not get valid version from Gradle properties"
-    The line 2 should equal "ERROR: version: unspecified"
-    The lines of error should equal 0
+    The lines of output should equal 0
+    The line 1 of error should equal "::error title=Gradle project version::Could not get valid version from Gradle properties"
+    The line 2 of error should equal "ERROR: version: unspecified"
   End
 End
 

--- a/spec/set_maven_project_version_spec.sh
+++ b/spec/set_maven_project_version_spec.sh
@@ -35,7 +35,7 @@ Describe 'get_current_version()'
     When call get_current_version
     The status should be failure
     The lines of error should equal 1
-    The line 1 of error should equal "Failed to evaluate Maven expression 'project.version'"
+    The line 1 of error should equal "::error title=Maven expression evaluation failed::Failed to evaluate Maven expression 'project.version'"
   End
 End
 
@@ -123,9 +123,9 @@ Describe 'set_project_version()'
     End
     When call set_project_version
     The status should be failure
-    The lines of output should equal 2
+    The lines of output should equal 1
     The line 1 should equal "CURRENT_VERSION=1.2.3.4-SNAPSHOT (from pom.xml)"
-    The line 2 should include "Unsupported version '1.2.3.4-SNAPSHOT' with 4 digits."
+    The stderr should include "Unsupported version '1.2.3.4-SNAPSHOT' with 4 digits."
   End
 
   It 'handles Maven expression failure gracefully'

--- a/spec/shared-functions_spec.sh
+++ b/spec/shared-functions_spec.sh
@@ -46,7 +46,7 @@ Describe 'shared/common-functions.sh'
     It 'fails with invalid platform'
       When call set_sonar_platform_vars "invalid"
       The status should be failure
-      The stderr should include "ERROR: Invalid Sonar platform 'invalid'. Must be one of: next, sqc-us, sqc-eu, none"
+      The stderr should include "::error title=Invalid Sonar platform::Invalid Sonar platform 'invalid'. Must be one of: next, sqc-us, sqc-eu, none"
     End
 
     It 'correctly formats URL display removing protocol'
@@ -110,7 +110,7 @@ Describe 'shared/common-functions.sh'
     It 'reports not installed tool'
       When call check_tool some_tool
       The status should be failure
-      The line 1 of error should equal "some_tool is not installed."
+      The line 1 of error should equal "::error title=Missing tool::some_tool is not installed."
     End
     It 'executes existing command with arguments'
       When call check_tool echo "test message"


### PR DESCRIPTION
Convert all echo >&2 error/warning messages to use GitHub Actions workflow commands (::error and ::warning) so they appear as annotations at the top of the run page instead of being invisible in log output.

## Test Plan
Dummy PRs that succeed as normal (actions aren't failing even though `::error::` logs cause actions to fail)
- https://github.com/SonarSource/sonar-dummy/pull/562
- https://github.com/SonarSource/sonar-dummy-yarn/pull/47
- https://github.com/SonarSource/sonar-dummy-maven-enterprise/pull/126
- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/334
- https://github.com/SonarSource/sonar-dummy-js/pull/121
- https://github.com/SonarSource/sonar-dummy-python-oss/pull/84

Dummy PR that is purposely configured wrong so that an `::error::` log is thrown and thus the action fails:
- https://github.com/SonarSource/sonar-dummy-gradle-oss/pull/335
  - And [pipeline run with error log on Line 1354](https://github.com/SonarSource/sonar-dummy-gradle-oss/actions/runs/22648340090/job/65641664662?pr=335) 
