### PR TITLE
BUILD-10625: fix artifact cleanup timeout by scoping lookup to PR branch runs

### DIFF
--- a/pr_cleanup/artifact_template.tpl
+++ b/pr_cleanup/artifact_template.tpl
@@ -1,5 +1,7 @@
+{{- if .artifacts -}}
 {{tablerow "NAME" "ID" "SIZE (BYTES)" "BRANCH" "HEAD_SHA" "RUN_ID"}}
   {{- range .artifacts -}}
     {{- tablerow .name .id .size_in_bytes .workflow_run.head_branch .workflow_run.head_sha .workflow_run.id -}}
   {{- end -}}
 {{- tablerender -}}
+{{- end -}}

--- a/pr_cleanup/cleanup.sh
+++ b/pr_cleanup/cleanup.sh
@@ -38,10 +38,7 @@ echo "::endgroup::"
 
 echo "::group::Artifact Cleanup"
 echo "Fetching list of artifacts on $GITHUB_REPOSITORY for $GITHUB_HEAD_REF"
-tpl_tmp_file="$(mktemp)"
-# shellcheck disable=SC2016
-envsubst '$GITHUB_HEAD_REF' < "$CURDIR"/artifact_template.tpl > "$tpl_tmp_file"
-ARTIFACT_TEMPLATE="$(cat "$tpl_tmp_file")"
+ARTIFACT_TEMPLATE="$(cat "$CURDIR"/artifact_template.tpl)"
 
 RUNS_API_URL="/repos/$GITHUB_REPOSITORY/actions/runs"
 

--- a/pr_cleanup/cleanup.sh
+++ b/pr_cleanup/cleanup.sh
@@ -47,7 +47,7 @@ RUNS_API_URL="/repos/$GITHUB_REPOSITORY/actions/runs"
 
 # List workflow runs scoped to the PR branch instead of paginating all repo artifacts.
 # This avoids timeouts in large repositories with many accumulated artifacts.
-runIds="$(gh api "${RUNS_API_URL}?branch=${GITHUB_HEAD_REF}&per_page=100" --paginate --jq '.workflow_runs[].id')"
+runIds="$(gh api "$RUNS_API_URL" -f branch="$GITHUB_HEAD_REF" -f per_page=100 --paginate --jq '.workflow_runs[].id')"
 
 for runId in $runIds; do
   gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$runId/artifacts" --paginate --template "$ARTIFACT_TEMPLATE"

--- a/pr_cleanup/cleanup.sh
+++ b/pr_cleanup/cleanup.sh
@@ -44,7 +44,7 @@ RUNS_API_URL="/repos/$GITHUB_REPOSITORY/actions/runs"
 
 # List workflow runs scoped to the PR branch instead of paginating all repo artifacts.
 # This avoids timeouts in large repositories with many accumulated artifacts.
-runIds="$(gh api "$RUNS_API_URL" -f branch="$GITHUB_HEAD_REF" -f per_page=100 --paginate --jq '.workflow_runs[].id')"
+runIds="$(gh api -X GET "$RUNS_API_URL" -f branch="$GITHUB_HEAD_REF" -f per_page=100 --paginate --jq '.workflow_runs[].id')"
 
 for runId in $runIds; do
   gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$runId/artifacts" --paginate --template "$ARTIFACT_TEMPLATE"

--- a/pr_cleanup/cleanup.sh
+++ b/pr_cleanup/cleanup.sh
@@ -43,19 +43,30 @@ tpl_tmp_file="$(mktemp)"
 envsubst '$GITHUB_HEAD_REF' < "$CURDIR"/artifact_template.tpl > "$tpl_tmp_file"
 ARTIFACT_TEMPLATE="$(cat "$tpl_tmp_file")"
 
-ARTIFACT_API_URL="/repos/$GITHUB_REPOSITORY/actions/artifacts"
-gh api "$ARTIFACT_API_URL" --paginate --template "$ARTIFACT_TEMPLATE"
+RUNS_API_URL="/repos/$GITHUB_REPOSITORY/actions/runs"
+
+# List workflow runs scoped to the PR branch instead of paginating all repo artifacts.
+# This avoids timeouts in large repositories with many accumulated artifacts.
+runIds="$(gh api "${RUNS_API_URL}?branch=${GITHUB_HEAD_REF}&per_page=100" --paginate --jq '.workflow_runs[].id')"
+
+for runId in $runIds; do
+  gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$runId/artifacts" --paginate --template "$ARTIFACT_TEMPLATE"
+done
 echo
 
-artifactIds="$(gh api "$ARTIFACT_API_URL" --paginate --jq '.artifacts[] | select(.workflow_run.head_branch == "'"$GITHUB_HEAD_REF"'") | .id')"
 echo "Deleting artifacts..."
-for artifactId in $artifactIds
-do
-  echo "Deleting artifact: $artifactId"
-  gh api -X DELETE "$ARTIFACT_API_URL/$artifactId" || true
+for runId in $runIds; do
+  artifactIds="$(gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$runId/artifacts" --paginate --jq '.artifacts[].id')"
+  for artifactId in $artifactIds
+  do
+    echo "Deleting artifact: $artifactId"
+    gh api -X DELETE "/repos/$GITHUB_REPOSITORY/actions/artifacts/$artifactId" || true
+  done
 done
 echo
 
 echo "Fetching list of artifacts after deletion"
-gh api "$ARTIFACT_API_URL" --paginate --template "$ARTIFACT_TEMPLATE"
+for runId in $runIds; do
+  gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$runId/artifacts" --paginate --template "$ARTIFACT_TEMPLATE"
+done
 echo "::endgroup::"

--- a/spec/pr_cleanup_spec.sh
+++ b/spec/pr_cleanup_spec.sh
@@ -19,7 +19,9 @@ Describe "cleanup.sh"
         cat "$CACHE_KEY_TO_DELETE"
       elif [[ "$*" =~ "cache delete" ]]; then
         echo "" > "$CACHE_KEY_TO_DELETE"
-      elif [[ "$*" =~ "api /repos/".*/actions/artifacts.*--paginate ]]; then
+      elif [[ "$*" =~ "branch=" ]]; then
+        echo "123456789"
+      elif [[ "$*" =~ actions/runs/[0-9]+/artifacts ]]; then
         cat "$ARTIFACT_TO_DELETE"
       elif [[ "$*" =~ "api -X DELETE" ]]; then
         echo "" > "$ARTIFACT_TO_DELETE"


### PR DESCRIPTION
## Summary

- The `pr_cleanup/cleanup.sh` script was paginating **all** repository artifacts (`/repos/.../actions/artifacts --paginate`) to find ones matching the closed PR's head branch. In `sonar-enterprise` this means iterating ~199,000 artifacts across ~2,000 API pages, causing the job to time out on every PR close.
- **Fix**: replaced full-repo artifact pagination with a branch-scoped two-step lookup:
  1. Fetch workflow run IDs for `$GITHUB_HEAD_REF` via `/actions/runs?branch=<branch>` — bounded by the number of CI runs for that branch, typically a few dozen API pages at most.
  2. For each run, list and delete its artifacts via `/actions/runs/<runId>/artifacts --paginate` — ensures all artifacts are captured even when a run has more than 30.
- Also fixed: artifact display template now suppresses empty header rows for runs with no artifacts (previously printed one empty table header per run ID after deletion).
- Updated `spec/pr_cleanup_spec.sh` to mock the new API call pattern.

Fixes: https://sonarsource.atlassian.net/browse/BUILD-10625  
Related: https://sonarsource.atlassian.net/browse/PREQ-4580

## Test plan

- [x] Shell spec passes locally: `shellspec --shell bash spec/pr_cleanup_spec.sh` — 1 example, 0 failures
- [x] Validated via `workflow_dispatch` on a test branch in `sonar-enterprise` against multiple PRs:
  - PR [#16460](https://github.com/SonarSource/sonar-enterprise/pull/16460) (`task/mm/backport-qa-fixes-to-2026.1`) — completed in **37 seconds**, no timeout: https://github.com/SonarSource/sonar-enterprise/actions/runs/22870515338/job/66348740082
  - PR [#16472](https://github.com/SonarSource/sonar-enterprise/pull/16472) (`dm/fix-test`) — completed in **1m17s**, deleted 30+ artifacts, nothing listed after deletion: https://github.com/SonarSource/sonar-enterprise/actions/runs/22895060312/job/66426961279
  - PR [#16364](https://github.com/SonarSource/sonar-enterprise/pull/16364) (`tz/sca-1542/add-risk-report-to-regulatory-report`) — completed in **1m4s**, nothing listed after deletion: https://github.com/SonarSource/sonar-enterprise/actions/runs/22905720053/job/66463711676
- [x] "Fetching list of artifacts after deletion" section is empty after successful deletion (no stale entries, no spurious headers)