### PR TITLE
BUILD-10724 fix host paths

### DIFF
--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -50,14 +50,12 @@ runs:
     - name: Set local action paths
       id: set-path
       shell: bash
-      env:
-        HOST_ACTIONS_ROOT: ${{ inputs.host-actions-root }}
       run: |
         echo "::group::Fix for using local actions"
         echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
         echo "github.action_path=${{ github.action_path }}"
         ACTION_PATH_CONFIG_GRADLE="${{ github.action_path }}"
-        host_actions_root="${HOST_ACTIONS_ROOT}"
+        host_actions_root="${{ inputs.host-actions-root }}"
         if [[ -z "$host_actions_root" ]]; then
           host_actions_root="$(dirname "$ACTION_PATH_CONFIG_GRADLE")"
         else

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -51,14 +51,12 @@ runs:
     - name: Set local action paths
       id: set-path
       shell: bash
-      env:
-        HOST_ACTIONS_ROOT: ${{ inputs.host-actions-root }}
       run: |
         echo "::group::Fix for using local actions"
         echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
         echo "github.action_path=${{ github.action_path }}"
         ACTION_PATH_CONFIG_MAVEN="${{ github.action_path }}"
-        host_actions_root="${HOST_ACTIONS_ROOT}"
+        host_actions_root="${{ inputs.host-actions-root }}"
         if [[ -z "$host_actions_root" ]]; then
           host_actions_root="$(dirname "$ACTION_PATH_CONFIG_MAVEN")"
         else

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -53,13 +53,12 @@ runs:
         ARTIFACTORY_READER_ROLE: ${{ inputs.artifactory-reader-role != '' && inputs.artifactory-reader-role ||
           (github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader') }}
         CACHE_NPM: ${{ inputs.cache-npm }}
-        HOST_ACTIONS_ROOT: ${{ inputs.host-actions-root }}
       run: |
         echo "::group::Fix for using local actions"
         echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
         echo "github.action_path=${{ github.action_path }}"
         ACTION_PATH_CONFIG_NPM="${{ github.action_path }}"
-        host_actions_root="${HOST_ACTIONS_ROOT}"
+        host_actions_root="${{ inputs.host-actions-root }}"
         if [[ -z "$host_actions_root" ]]; then
           host_actions_root="$(dirname "$ACTION_PATH_CONFIG_NPM")"
         else

--- a/config-pip/action.yml
+++ b/config-pip/action.yml
@@ -37,14 +37,12 @@ runs:
     - name: Set local action paths
       id: set-path
       shell: bash
-      env:
-        HOST_ACTIONS_ROOT: ${{ inputs.host-actions-root }}
       run: |
         echo "::group::Fix for using local actions"
         echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
         echo "github.action_path=${{ github.action_path }}"
         ACTION_PATH_CONFIG_PIP="${{ github.action_path }}"
-        host_actions_root="${HOST_ACTIONS_ROOT}"
+        host_actions_root="${{ inputs.host-actions-root }}"
         if [[ -z "$host_actions_root" ]]; then
           host_actions_root="$(dirname "$ACTION_PATH_CONFIG_PIP")"
         else

--- a/get-build-number/action.yml
+++ b/get-build-number/action.yml
@@ -16,14 +16,12 @@ runs:
     - name: Set local action paths
       id: set-path
       shell: bash
-      env:
-        HOST_ACTIONS_ROOT: ${{ inputs.host-actions-root }}
       run: |
         echo "::group::Fix for using local actions"
         echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
         echo "github.action_path=${{ github.action_path }}"
         ACTION_PATH_GET_BUILD_NUMBER="${{ github.action_path }}"
-        host_actions_root="${HOST_ACTIONS_ROOT}"
+        host_actions_root="${{ inputs.host-actions-root }}"
         if [[ -z "$host_actions_root" ]]; then
           host_actions_root="$(dirname "$ACTION_PATH_GET_BUILD_NUMBER")"
         else


### PR DESCRIPTION
The host path cannot be passed as an env, it is modified by the runner hooks.