### PR TITLE
BUILD-10774: Pin `gh-action_cache` version to `v1.4.2`

### DIFF
--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -111,7 +111,7 @@ runs:
       with:
         host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
     - name: Cache local Poetry cache
-      uses: SonarSource/gh-action_cache@0fe268e0b670dfb7aea67a0578b317d5a2e26212 # v1.4.1
+      uses: SonarSource/gh-action_cache@eaf3a34501712f8a246749c4abf837a2b4d67521 # v1.4.2
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ github.workspace }}/${{ inputs.poetry-cache-dir }}

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -122,7 +122,7 @@ runs:
         working_directory: ${{ inputs.working-directory }}
 
     - name: Cache Yarn dependencies
-      uses: SonarSource/gh-action_cache@0fe268e0b670dfb7aea67a0578b317d5a2e26212 # v1.4.1
+      uses: SonarSource/gh-action_cache@eaf3a34501712f8a246749c4abf837a2b4d67521 # v1.4.2
       if: ${{ inputs.cache-yarn == 'true' && inputs.disable-caching != 'true' }}
       with:
         path: |

--- a/cache/action.yml
+++ b/cache/action.yml
@@ -36,7 +36,7 @@ runs:
         echo "::warning:: This action is deprecated and will be removed in future releases." \
           "Please migrate to using the SonarSource/gh-action_cache action directly." >&2
 
-    - uses: SonarSource/gh-action_cache@0fe268e0b670dfb7aea67a0578b317d5a2e26212 # v1.4.1
+    - uses: SonarSource/gh-action_cache@eaf3a34501712f8a246749c4abf837a2b4d67521 # v1.4.2
       id: cache
       with:
         path: ${{ inputs.path }}

--- a/code-signing/action.yml
+++ b/code-signing/action.yml
@@ -24,7 +24,7 @@ runs:
         echo "JSIGN_CACHE_PATH=/tmp/jsign-cache" >> "$GITHUB_ENV"
 
     - name: Cache code signing tools
-      uses: SonarSource/gh-action_cache@0fe268e0b670dfb7aea67a0578b317d5a2e26212 # v1.4.1
+      uses: SonarSource/gh-action_cache@eaf3a34501712f8a246749c4abf837a2b4d67521 # v1.4.2
       id: tools-cache
       with:
         path: |

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -169,7 +169,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Gradle Cache
-      uses: SonarSource/gh-action_cache@0fe268e0b670dfb7aea67a0578b317d5a2e26212 # v1.4.1
+      uses: SonarSource/gh-action_cache@eaf3a34501712f8a246749c4abf837a2b4d67521 # v1.4.2
       if: steps.config-gradle-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -180,7 +180,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache local Maven repository
-      uses: SonarSource/gh-action_cache@0fe268e0b670dfb7aea67a0578b317d5a2e26212 # v1.4.1
+      uses: SonarSource/gh-action_cache@eaf3a34501712f8a246749c4abf837a2b4d67521 # v1.4.2
       if: steps.config-maven-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -125,7 +125,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache NPM dependencies
-      uses: SonarSource/gh-action_cache@0fe268e0b670dfb7aea67a0578b317d5a2e26212 # v1.4.1
+      uses: SonarSource/gh-action_cache@eaf3a34501712f8a246749c4abf837a2b4d67521 # v1.4.2
       if: steps.config-npm-completed.outputs.skip != 'true' && inputs.disable-caching != 'true' && inputs.cache-npm == 'true'
       with:
         path: ~/.npm

--- a/config-pip/action.yml
+++ b/config-pip/action.yml
@@ -100,7 +100,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache pip dependencies
-      uses: SonarSource/gh-action_cache@0fe268e0b670dfb7aea67a0578b317d5a2e26212 # v1.4.1
+      uses: SonarSource/gh-action_cache@eaf3a34501712f8a246749c4abf837a2b4d67521 # v1.4.2
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}


### PR DESCRIPTION
## What Changed?

- Pins the `gh-action_cache` version  to `v1.4.2` for all actions in this repo
  - [Release Notes for this version](https://github.com/SonarSource/gh-action_cache/releases/tag/v1.4.2)
  - This will enable `fallback-to-default-branch: true` on all actions in this repo, which has been extensively tested