### PR TITLE
PREQ-4918: Support unique artifact names for matrix jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,21 @@ See also [`config-gradle`](#config-gradle) input environment variables.
 | `provenance`                | Whether to generate provenance attestation for built artifacts                                                               | `false`                                                                                     |
 | `provenance-artifact-paths` | Relative paths of artifacts for provenance attestation (glob pattern). See [Provenance Attestation](#provenance-attestation) | (optional)                                                                                  |
 | `generate-summary`          | Whether to generate a workflow summary after the build                                                                       | `true`                                                                                      |
+| `job-identifier`            | Unique identifier for the problems-report artifact name. Set to a matrix dimension (e.g. `${{ matrix.module }}`) when using this action inside a reusable workflow invoked in a matrix. Auto-generated UUID when omitted. | (optional) |
+
+> [!TIP]
+> When using this action inside a reusable workflow that is itself called in a matrix, set
+> `job-identifier` to a matrix dimension to produce readable artifact names:
+>
+> ```yaml
+> - uses: SonarSource/ci-github-actions/build-gradle@v1
+>   with:
+>     job-identifier: ${{ matrix.module }}
+> ```
+>
+> Without this, a UUID is generated automatically — artifact names will be unique but opaque.
+
+<!-- -->
 
 > [!TIP]
 > When using `working-directory`, Java must be available at root due to a limitation

--- a/README.md
+++ b/README.md
@@ -972,6 +972,19 @@ See also [`config-npm`](#config-npm) input environment variables.
 | `provenance`                | Whether to generate provenance attestation for built artifacts                                                               | `false`                                                                                      |
 | `provenance-artifact-paths` | Relative paths of artifacts for provenance attestation (glob pattern). See [Provenance Attestation](#provenance-attestation) | (optional)                                                                                   |
 | `generate-summary`          | Whether to generate a workflow summary after the build                                                                       | `true`                                                                                       |
+| `job-identifier`            | Unique identifier for the npm-logs artifact name. Set to a matrix dimension (e.g. `${{ matrix.module }}`) when using this action inside a reusable workflow invoked in a matrix. Auto-generated UUID when omitted. | (optional) |
+
+> [!TIP]
+> When using this action inside a reusable workflow that is itself called in a matrix, set
+> `job-identifier` to a matrix dimension to produce readable artifact names:
+>
+> ```yaml
+> - uses: SonarSource/ci-github-actions/build-npm@v1
+>   with:
+>     job-identifier: ${{ matrix.module }}
+> ```
+>
+> Without this, a UUID is generated automatically — artifact names will be unique but opaque.
 
 ### Outputs
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -67,6 +67,14 @@ inputs:
   generate-summary:
     description: Whether to generate a workflow summary after the build.
     default: 'true'
+  artifact-name:
+    description: >-
+      Suffix appended to the problems-report artifact name: `problems-report-<artifact-name>`.
+      Defaults to `<github.job><strategy.job-index>`, which is unique for direct matrix jobs but
+      collides when this action is called from a reusable workflow (where `github.job` is always
+      the called workflow's job id). Override with a unique value (e.g. the module name) when
+      using this action inside a reusable workflow that is invoked in a matrix.
+    default: ''
 
 outputs:
   project-version:
@@ -179,7 +187,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: problems-report-${{ github.job }}${{ strategy.job-index }}
+        name: problems-report-${{ inputs.artifact-name != '' && inputs.artifact-name || format('{0}{1}', github.job, strategy.job-index) }}
         path: build/reports/problems/problems-report.html
         if-no-files-found: ignore
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -67,13 +67,12 @@ inputs:
   generate-summary:
     description: Whether to generate a workflow summary after the build.
     default: 'true'
-  artifact-name:
+  job-identifier:
     description: >-
-      Suffix appended to the problems-report artifact name: `problems-report-<artifact-name>`.
-      Defaults to `<github.job><strategy.job-index>`, which is unique for direct matrix jobs but
-      collides when this action is called from a reusable workflow (where `github.job` is always
-      the called workflow's job id). Override with a unique value (e.g. the module name) when
-      using this action inside a reusable workflow that is invoked in a matrix.
+      Unique identifier appended to the artifact name (`problems-report-<job-identifier>`).
+      Set this to a matrix dimension (e.g. `${{ matrix.module }}`) when calling this action
+      from a reusable workflow that is invoked in a matrix, to produce human-readable artifact
+      names. When omitted, a UUID is generated automatically to guarantee uniqueness.
     default: ''
 
 outputs:
@@ -183,11 +182,17 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: $ACTION_PATH_BUILD_GRADLE/build.sh
 
+    - name: Generate unique job ID
+      id: uid
+      if: always()
+      shell: bash
+      run: echo "value=$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_OUTPUT
+
     - name: Archive problems report
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: problems-report-${{ inputs.artifact-name != '' && inputs.artifact-name || format('{0}{1}', github.job, strategy.job-index) }}
+        name: problems-report-${{ inputs.job-identifier != '' && inputs.job-identifier || steps.uid.outputs.value }}
         path: build/reports/problems/problems-report.html
         if-no-files-found: ignore
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -72,7 +72,7 @@ inputs:
       Unique identifier appended to the artifact name (`problems-report-<job-identifier>`).
       Set this to a matrix dimension value (e.g. the value of `matrix.module`) when calling this action
       from a reusable workflow that is invoked in a matrix, to produce human-readable artifact
-      names. When omitted, a UUID is generated automatically to guarantee uniqueness.
+      names. When omitted, the run ID and runner name are used to guarantee uniqueness.
     default: ''
 
 outputs:
@@ -182,17 +182,11 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: $ACTION_PATH_BUILD_GRADLE/build.sh
 
-    - name: Generate unique job ID
-      id: uid
-      if: always()
-      shell: bash
-      run: echo "value=$(python3 -c 'import uuid; print(uuid.uuid4())')" >> "$GITHUB_OUTPUT"
-
     - name: Archive problems report
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: problems-report-${{ inputs.job-identifier != '' && inputs.job-identifier || steps.uid.outputs.value }}
+        name: problems-report-${{ inputs.job-identifier != '' && inputs.job-identifier || format('{0}-{1}', github.run_id, runner.name) }}
         path: build/reports/problems/problems-report.html
         if-no-files-found: ignore
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -186,7 +186,7 @@ runs:
       id: uid
       if: always()
       shell: bash
-      run: echo "value=$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_OUTPUT
+      run: echo "value=$(python3 -c 'import uuid; print(uuid.uuid4())')" >> "$GITHUB_OUTPUT"
 
     - name: Archive problems report
       if: always()

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -72,7 +72,7 @@ inputs:
       Unique identifier appended to the artifact name (`problems-report-<job-identifier>`).
       Set this to a matrix dimension value (e.g. the value of `matrix.module`) when calling this action
       from a reusable workflow that is invoked in a matrix, to produce human-readable artifact
-      names. When omitted, the run ID and runner name are used to guarantee uniqueness.
+      names. When omitted, a random value is generated to guarantee uniqueness.
     default: ''
 
 outputs:
@@ -182,11 +182,17 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: $ACTION_PATH_BUILD_GRADLE/build.sh
 
+    - name: Generate unique job ID
+      id: uid
+      if: always()
+      shell: bash
+      run: echo "value=$RANDOM$RANDOM" >> "$GITHUB_OUTPUT"
+
     - name: Archive problems report
       if: always()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: problems-report-${{ inputs.job-identifier != '' && inputs.job-identifier || format('{0}-{1}', github.run_id, runner.name) }}
+        name: problems-report-${{ inputs.job-identifier != '' && inputs.job-identifier || steps.uid.outputs.value }}
         path: build/reports/problems/problems-report.html
         if-no-files-found: ignore
 

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -70,7 +70,7 @@ inputs:
   job-identifier:
     description: >-
       Unique identifier appended to the artifact name (`problems-report-<job-identifier>`).
-      Set this to a matrix dimension (e.g. `${{ matrix.module }}`) when calling this action
+      Set this to a matrix dimension value (e.g. the value of `matrix.module`) when calling this action
       from a reusable workflow that is invoked in a matrix, to produce human-readable artifact
       names. When omitted, a UUID is generated automatically to guarantee uniqueness.
     default: ''

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -64,7 +64,7 @@ inputs:
       Unique identifier appended to the artifact name (`npm-logs-<job-identifier>`).
       Set this to a matrix dimension value (e.g. the value of `matrix.module`) when calling this action
       from a reusable workflow that is invoked in a matrix, to produce human-readable artifact
-      names. When omitted, a UUID is generated automatically to guarantee uniqueness.
+      names. When omitted, the run ID and runner name are used to guarantee uniqueness.
     default: ''
 
 outputs:
@@ -180,17 +180,11 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: $ACTION_PATH_BUILD_NPM/build.sh
 
-    - name: Generate unique job ID
-      id: uid
-      if: always()
-      shell: bash
-      run: echo "value=$(python3 -c 'import uuid; print(uuid.uuid4())')" >> "$GITHUB_OUTPUT"
-
     - name: Archive logs
       if: failure()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: npm-logs-${{ inputs.job-identifier != '' && inputs.job-identifier || steps.uid.outputs.value }}
+        name: npm-logs-${{ inputs.job-identifier != '' && inputs.job-identifier || format('{0}-{1}', github.run_id, runner.name) }}
         path: ~/.npm/_logs/
         if-no-files-found: ignore
 

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -59,6 +59,13 @@ inputs:
   generate-summary:
     description: Whether to generate a workflow summary after the build.
     default: 'true'
+  job-identifier:
+    description: >-
+      Unique identifier appended to the artifact name (`npm-logs-<job-identifier>`).
+      Set this to a matrix dimension (e.g. `${{ matrix.module }}`) when calling this action
+      from a reusable workflow that is invoked in a matrix, to produce human-readable artifact
+      names. When omitted, a UUID is generated automatically to guarantee uniqueness.
+    default: ''
 
 outputs:
   BUILD_NUMBER:
@@ -173,11 +180,17 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: $ACTION_PATH_BUILD_NPM/build.sh
 
+    - name: Generate unique job ID
+      id: uid
+      if: always()
+      shell: bash
+      run: echo "value=$(python3 -c 'import uuid; print(uuid.uuid4())')" >> "$GITHUB_OUTPUT"
+
     - name: Archive logs
       if: failure()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: npm-logs-${{ github.job }}${{ strategy.job-index }}
+        name: npm-logs-${{ inputs.job-identifier != '' && inputs.job-identifier || steps.uid.outputs.value }}
         path: ~/.npm/_logs/
         if-no-files-found: ignore
 

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -62,7 +62,7 @@ inputs:
   job-identifier:
     description: >-
       Unique identifier appended to the artifact name (`npm-logs-<job-identifier>`).
-      Set this to a matrix dimension (e.g. `${{ matrix.module }}`) when calling this action
+      Set this to a matrix dimension value (e.g. the value of `matrix.module`) when calling this action
       from a reusable workflow that is invoked in a matrix, to produce human-readable artifact
       names. When omitted, a UUID is generated automatically to guarantee uniqueness.
     default: ''

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -64,7 +64,7 @@ inputs:
       Unique identifier appended to the artifact name (`npm-logs-<job-identifier>`).
       Set this to a matrix dimension value (e.g. the value of `matrix.module`) when calling this action
       from a reusable workflow that is invoked in a matrix, to produce human-readable artifact
-      names. When omitted, the run ID and runner name are used to guarantee uniqueness.
+      names. When omitted, a random value is generated to guarantee uniqueness.
     default: ''
 
 outputs:
@@ -180,11 +180,17 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: $ACTION_PATH_BUILD_NPM/build.sh
 
+    - name: Generate unique job ID
+      id: uid
+      if: always()
+      shell: bash
+      run: echo "value=$RANDOM$RANDOM" >> "$GITHUB_OUTPUT"
+
     - name: Archive logs
       if: failure()
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        name: npm-logs-${{ inputs.job-identifier != '' && inputs.job-identifier || format('{0}-{1}', github.run_id, runner.name) }}
+        name: npm-logs-${{ inputs.job-identifier != '' && inputs.job-identifier || steps.uid.outputs.value }}
         path: ~/.npm/_logs/
         if-no-files-found: ignore
 


### PR DESCRIPTION
## What Changed?

Adds a `job-identifier` input to `build-gradle` and `build-npm` to avoid artifact name collisions in matrix jobs ([example 409 error](https://github.com/SonarSource/sonarcloud-analyzers-shared-services/actions/runs/23616480743/job/68785143990?pr=63#annotation:5:2019)).

### `build-gradle`
- New optional input `job-identifier`: appended to the `problems-report-<job-identifier>` artifact name
- When omitted, a `$RANDOM`-based value is generated per job to guarantee uniqueness

### `build-npm`
- Same `job-identifier` input added for the `npm-logs-<job-identifier>` artifact

### When to use `job-identifier`
The default `$RANDOM` fallback is sufficient for most cases. Set `job-identifier` explicitly when you want human-readable artifact names — e.g. when calling from a reusable workflow invoked in a matrix:

```yaml
- uses: SonarSource/ci-github-actions/build-gradle@v1
  with:
    job-identifier: ${{ matrix.module }}
```

This produces `problems-report-my-module` instead of `problems-report-<random>`.

## Background

The original hardcoded `github.job + strategy.job-index` naming collides when the action is called from a reusable workflow that is itself invoked in a matrix — `github.job` is always the reusable workflow's fixed job ID there, causing 409 conflicts.