### PR TITLE
PREQ-4933 Use plain poetry install to respect lock file

### DIFF
--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -132,6 +132,7 @@ runs:
           ${{ (inputs.sonar-platform != 'none' || inputs.run-shadow-scans == 'true') && 'development/kv/data/sonarcloud url | SQC_EU_URL;' || '' }}
           ${{ (inputs.sonar-platform != 'none' || inputs.run-shadow-scans == 'true') && 'development/kv/data/sonarcloud token | SQC_EU_TOKEN;' || '' }}
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} access_token | ARTIFACTORY_ACCESS_TOKEN;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_USERNAME;
           ${{ inputs.deploy != 'false' && inputs.run-shadow-scans != 'true' && format('development/artifactory/token/{{REPO_OWNER_NAME_DASH}}-{0} access_token | ARTIFACTORY_DEPLOY_ACCESS_TOKEN;', env.ARTIFACTORY_DEPLOYER_ROLE) || '' }}
       # yamllint enable rule:line-length
     - name: Build, Analyze and deploy
@@ -152,6 +153,7 @@ runs:
         ARTIFACTORY_DEPLOY_REPO: ${{ inputs.artifactory-deploy-repo != '' && inputs.artifactory-deploy-repo ||
           github.event.repository.visibility == 'public' && 'sonarsource-pypi-public-qa' || 'sonarsource-pypi-private-qa' }}
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+        ARTIFACTORY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}
         ARTIFACTORY_DEPLOY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_DEPLOY_ACCESS_TOKEN }}
         POETRY_VIRTUALENVS_PATH: ${{ github.workspace }}/${{ inputs.poetry-virtualenvs-path }}
         POETRY_CACHE_DIR: ${{ github.workspace }}/${{ inputs.poetry-cache-dir }}

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -45,7 +45,7 @@ set -euo pipefail
 # shellcheck source=../shared/common-functions.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../shared/common-functions.sh"
 
-: "${ARTIFACTORY_URL:?}" "${ARTIFACTORY_PYPI_REPO:?}" "${ARTIFACTORY_ACCESS_TOKEN:?}" "${RUN_SHADOW_SCANS:?}"
+: "${ARTIFACTORY_URL:?}" "${ARTIFACTORY_PYPI_REPO:?}" "${ARTIFACTORY_ACCESS_TOKEN:?}" "${ARTIFACTORY_USERNAME:?}" "${RUN_SHADOW_SCANS:?}"
 : "${ARTIFACTORY_DEPLOY_REPO:?}" "${DEPLOY_PULL_REQUEST:=false}"
 : "${GITHUB_REF_NAME:?}" "${BUILD_NUMBER:?}" "${GITHUB_REPOSITORY:?}" "${GITHUB_EVENT_NAME:?}" "${GITHUB_EVENT_PATH:?}"
 : "${PULL_REQUEST?}" "${DEFAULT_BRANCH:?}" "${GITHUB_ENV:?}" "${GITHUB_OUTPUT:?}" "${GITHUB_SHA:?}" "${GITHUB_RUN_ID:?}"
@@ -267,10 +267,8 @@ jfrog_poetry_install() {
   jf config add repox --url "${ARTIFACTORY_URL%/artifactory*}" --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_ACCESS_TOKEN"
   jf config use repox
   jf poetry-config --server-id-resolve repox --repo-resolve "$ARTIFACTORY_PYPI_REPO"
-  # Use plain `poetry install` to respect the lock file.
-  # `jf poetry install` internally runs `poetry update`, which re-resolves all
-  # dependencies and can fail when pyproject.toml constraints don't match what
-  # is available on the configured indexes (PREQ-4933).
+  export POETRY_HTTP_BASIC_REPOX_USERNAME="$ARTIFACTORY_USERNAME"
+  export POETRY_HTTP_BASIC_REPOX_PASSWORD="$ARTIFACTORY_ACCESS_TOKEN"
   poetry install
 }
 

--- a/build-poetry/build.sh
+++ b/build-poetry/build.sh
@@ -267,7 +267,11 @@ jfrog_poetry_install() {
   jf config add repox --url "${ARTIFACTORY_URL%/artifactory*}" --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_ACCESS_TOKEN"
   jf config use repox
   jf poetry-config --server-id-resolve repox --repo-resolve "$ARTIFACTORY_PYPI_REPO"
-  jf poetry install --build-name="$PROJECT" --build-number="$BUILD_NUMBER"
+  # Use plain `poetry install` to respect the lock file.
+  # `jf poetry install` internally runs `poetry update`, which re-resolves all
+  # dependencies and can fail when pyproject.toml constraints don't match what
+  # is available on the configured indexes (PREQ-4933).
+  poetry install
 }
 
 jfrog_poetry_publish() {

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -100,7 +100,7 @@ Describe 'build-poetry/build.sh'
       The line 28 should equal "jf config add repox --url https://dummy.repox --artifactory-url https://dummy.repox --access-token dummy access token"
       The line 29 should equal "jf config use repox"
       The line 30 should equal "jf poetry-config --server-id-resolve repox --repo-resolve <repox pypi repo>"
-      The line 31 should equal "jf poetry install --build-name=my-repo --build-number=42"
+      The line 31 should equal "poetry install"
       The line 32 should equal "::endgroup::"
       The line 33 should equal "::group::Build project"
       The line 35 should equal "poetry build"
@@ -302,12 +302,12 @@ End
 
 Describe 'jfrog_poetry_install()'
   export PROJECT="my-repo"
-  It 'installs Poetry dependencies using JFrog CLI'
+  It 'configures JFrog and installs with plain poetry install'
     When call jfrog_poetry_install
     The line 1 should include "jf config add repox"
     The line 2 should include "jf config use repox"
     The line 3 should include "jf poetry-config"
-    The line 4 should include "jf poetry install"
+    The line 4 should equal "poetry install"
   End
 End
 

--- a/spec/build-poetry_spec.sh
+++ b/spec/build-poetry_spec.sh
@@ -16,6 +16,7 @@ export GITHUB_ENV=/dev/null
 export ARTIFACTORY_URL="https://dummy.repox"
 export ARTIFACTORY_PYPI_REPO="<repox pypi repo>"
 export ARTIFACTORY_ACCESS_TOKEN="dummy access token"
+export ARTIFACTORY_USERNAME="dummy-user"
 export ARTIFACTORY_DEPLOY_REPO="<deploy repo>"
 export ARTIFACTORY_DEPLOY_ACCESS_TOKEN="<deploy token>"
 export GITHUB_REPOSITORY="my-org/my-repo"


### PR DESCRIPTION
## Summary
- Replace `jf poetry install` with plain `poetry install` in the `build-poetry` action
- The JFrog CLI command internally runs `poetry update`, which ignores the lock file and re-resolves all dependencies — breaking builds when `pyproject.toml` constraints reference versions absent from the configured Repox indexes (e.g. `syrupy 5.*`)
- `jf poetry-config` is kept to configure the Repox registry; only the install step changes
- Retrieve `ARTIFACTORY_USERNAME` from Vault and export `POETRY_HTTP_BASIC_REPOX_USERNAME` / `_PASSWORD` so that plain `poetry install` can authenticate to Repox (credentials were previously handled internally by `jf poetry install`)

## Context
- Ticket: [PREQ-4933](https://sonarsource.atlassian.net/browse/PREQ-4933)
- Root cause: [jfrog-cli-artifactory poetry.go L302-L317](https://github.com/jfrog/jfrog-cli-artifactory/blob/ad6064f2f373/artifactory/commands/python/poetry.go#L302-L317) unconditionally calls `poetry update` after configuring the repo
- Failing run: https://github.com/SonarSource/sonarcloud-common-cdk-constructs/actions/runs/23643279945/job/68869068236
- Regression introduced by BUILD-10591 (JFrog CLI bump from 2.77.0 to 2.96.0)

## Changes

### `build-poetry/build.sh`
- `jfrog_poetry_install()`: replace `jf poetry install --build-name --build-number` with `poetry install`
- Export `POETRY_HTTP_BASIC_REPOX_USERNAME` and `POETRY_HTTP_BASIC_REPOX_PASSWORD` before install so Poetry can authenticate to the Repox source configured by `jf poetry-config`
- Add `ARTIFACTORY_USERNAME` to required env vars

### `build-poetry/action.yml`
- Retrieve `ARTIFACTORY_USERNAME` from the same Vault path as `ARTIFACTORY_ACCESS_TOKEN`
- Pass `ARTIFACTORY_USERNAME` as env var to the build step

### `spec/build-poetry_spec.sh`
- Add `ARTIFACTORY_USERNAME` to test env
- Update assertions to expect `poetry install` instead of `jf poetry install`

## Trade-off
Dependency-level build info tracking in JFrog is lost (`jf poetry install --build-name --build-number`). The artifact upload, `build-collect-env`, and `build-publish` in the publish step still capture what matters for promotion and traceability.

## Test plan
- [x] All 28 shell spec tests pass locally
- [x] Integration test via [sonarcloud-common-cdk-constructs#350](https://github.com/SonarSource/sonarcloud-common-cdk-constructs/pull/350) — [build is green](https://github.com/SonarSource/sonarcloud-common-cdk-constructs/actions/runs/23648632442)
- [x] SonarQube Quality Gate passed (100% coverage on new code)

[PREQ-4933]: https://sonarsource.atlassian.net/browse/PREQ-4933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ