### PR TITLE
RP-949 Update jdx/mise-action to v4 in promote action

### DIFF
--- a/promote/action.yml
+++ b/promote/action.yml
@@ -57,9 +57,9 @@ runs:
         secrets: |
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-promoter access_token | ARTIFACTORY_PROMOTE_ACCESS_TOKEN;
           development/github/token/{REPO_OWNER_NAME_DASH}-promotion token | GITHUB_TOKEN;
-    - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+    - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
-        version: 2026.3.7
+        version: 2026.4.0
     - name: Promote artifacts
       shell: bash
       env:


### PR DESCRIPTION
Updating mise-action to v4 to fix failing python 3.13 installation. This version of the action also uses Node.js 24 for the upcomming deprecation of Node.js 20 in GHA runners.