### PR TITLE
BUILD-10827: make config-npm skip path safe from template parsing error

### DIFF
--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -106,7 +106,7 @@ runs:
       env:
         ARTIFACTORY_URL: ${{ inputs.repox-artifactory-url != '' && inputs.repox-artifactory-url ||
           format('{0}/artifactory', inputs.repox-url) }}
-        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+        ARTIFACTORY_ACCESS_TOKEN: ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN || '' }}
       run: |
         $ACTION_PATH_CONFIG_NPM/npm_config.sh
 


### PR DESCRIPTION
## Summary

Fix noisy `##[error]` annotations when `config-npm` is invoked a second time in the same job (e.g. via `SonarSource/sonarqube-cloud-github-actions/parse-cdk-nag-output@master`, which nests a call to `config-npm`).

**Root cause.** In `config-npm/action.yml`, the `Configure NPM authentication` step declares:

```yaml
env:
  ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
```

On the skip path (when `CONFIG_NPM_COMPLETED` is already set), the `secrets` step is gated out by `if: steps.config-npm-completed.outputs.skip != 'true'` and therefore does not produce any output. GitHub Actions still evaluates the step-level `env` expression, so `fromJSON('')` raises a template parsing error (`Error reading JToken from JsonReader`). The job may still pass, but the `##[error]` annotation is reported and can hide real failures.

**Fix.** Make the expression null-safe using the exact same pattern already used in `config-maven/action.yml`, `config-gradle/action.yml` and `get-build-number/action.yml`:

```yaml
ARTIFACTORY_ACCESS_TOKEN: ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN || '' }}
```

When `steps.secrets.outputs.vault` is empty (skip path), the expression short-circuits to `''` and `fromJSON` is never called. First-invocation behaviour is unchanged because `steps.secrets.outputs.vault` is always a non-empty JSON string when the secrets step runs.

JIRA: https://sonarsource.atlassian.net/browse/BUILD-10827

## Notes on test coverage

- The existing `spec/config-npm_spec.sh` ShellSpec suite covers the shell scripts (`npm_config.sh`, `npm_set_project_version.sh`), not the composite action's YAML. There is no existing harness for double-invocation of the composite action itself, so this fix is verified by workflow-level observation rather than unit tests.
- The equivalent null-safe pattern in `config-maven`/`config-gradle` was introduced for the same reason and has been stable since; this change brings `config-npm` in line with them.

## Test plan

- [ ] Merge-queue / PR CI: `test-shell-scripts.yml` still passes (first-invocation path unchanged).
- [ ] Manual: trigger a workflow that calls `config-npm` twice in the same job (e.g. via `SonarSource/sonarqube-cloud-github-actions/parse-cdk-nag-output`) and confirm:
  - [ ] No `##[error]Error reading JToken from JsonReader` annotation on the second call.
  - [ ] Second call logs `Action already called by ..., execution skipped.` and exits cleanly.
  - [ ] First call still configures `~/.npmrc` and `jf` correctly with the Artifactory token.