### PR TITLE
BUILD-11091: Adds check-sca action for enforcing that SCA is active

### DIFF
--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -1,0 +1,15 @@
+---
+name: Required SCA Check
+on:
+  pull_request_target:
+  merge_group:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  verify-sca:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/ci-github-actions/check-sca@master

--- a/check-sca/action.yml
+++ b/check-sca/action.yml
@@ -1,0 +1,109 @@
+---
+name: Check SCA
+description: >-
+  Verify that SonarQube SCA (Software Composition Analysis) ran for the project.
+  Discovers project keys from config files, polls all three SonarQube instances,
+  and fails if SCA data is missing after timeout.
+
+inputs:
+  project-key:
+    description: >-
+      Explicit SonarQube project key to include when checking SCA results.
+      The action also discovers additional project keys from
+      .sonarlint/connectedMode.json, sonar-project.properties, pom.xml,
+      build.gradle(.kts), and GITHUB_REPOSITORY. The explicit key is checked first.
+    default: ''
+  poll-timeout:
+    description: Maximum time in seconds to poll for SCA results before failing.
+    default: '300'
+  poll-interval:
+    description: Time in seconds between polling attempts.
+    default: '15'
+  working-directory:
+    description: Relative path under github.workspace to look for project config files.
+    default: .
+
+outputs:
+  sca-verified:
+    description: Whether SCA was verified on at least one platform (true or false)
+    value: ${{ steps.check.outputs.sca-verified || steps.vault-fail.outputs.sca-verified || 'false' }}
+  platform:
+    description: The SonarQube platform where SCA was found (next, sqc-us, or sqc-eu)
+    value: ${{ steps.check.outputs.platform }}
+  project-key:
+    description: The project key where SCA was verified
+    value: ${{ steps.check.outputs.project-key }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set local action paths
+      shell: bash
+      run: |
+        ACTION_PATH_CHECK_SCA="${{ github.action_path }}"
+        echo "ACTION_PATH_CHECK_SCA=$ACTION_PATH_CHECK_SCA" >> "$GITHUB_ENV"
+
+    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+      id: secrets
+      continue-on-error: true
+      with:
+        secrets: |
+          development/kv/data/next url | NEXT_URL;
+          development/kv/data/next token | NEXT_TOKEN;
+          development/kv/data/sonarqube-us url | SQC_US_URL;
+          development/kv/data/sonarqube-us token | SQC_US_TOKEN;
+          development/kv/data/sonarcloud url | SQC_EU_URL;
+          development/kv/data/sonarcloud token | SQC_EU_TOKEN;
+
+    - name: Fail on missing Vault access
+      if: steps.secrets.outcome == 'failure'
+      id: vault-fail
+      shell: bash
+      # yamllint disable rule:line-length
+      run: |
+        echo "sca-verified=false" >> "$GITHUB_OUTPUT"
+        SUMMARY="$GITHUB_STEP_SUMMARY"
+        echo "## SCA Verification" >> "$SUMMARY"
+        echo "SCA verification **FAILED** — this repository does not have Vault access to SonarQube credentials." >> "$SUMMARY"
+        echo "" >> "$SUMMARY"
+        echo "This means the repository cannot authenticate to SonarQube, so SCA is not running." >> "$SUMMARY"
+        DOCS="https://xtranet-sonarsource.atlassian.net/wiki/x/ooAenQ"
+        echo "To fix this, ensure the repository has a Vault role provisioned (see [Vault End-User docs]($DOCS))." >> "$SUMMARY"
+        echo "If this repository should be exempt from SCA checks, disable this workflow in the org ruleset." >> "$SUMMARY"
+        MSG="Vault authentication failed — this repo cannot access SonarQube credentials."
+        MSG="$MSG SCA is not running on this repository."
+        echo "::error title=SCA check failed::$MSG"
+        exit 1
+      # yamllint enable rule:line-length
+
+    - name: Verify SCA ran
+      if: steps.secrets.outcome == 'success'
+      id: check
+      shell: bash
+      env:
+        PROJECT_KEY_INPUT: ${{ inputs.project-key }}
+        POLL_TIMEOUT: ${{ inputs.poll-timeout }}
+        POLL_INTERVAL: ${{ inputs.poll-interval }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        NEXT_URL: ${{ fromJSON(steps.secrets.outputs.vault).NEXT_URL }}
+        NEXT_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).NEXT_TOKEN }}
+        SQC_US_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_URL }}
+        SQC_US_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_TOKEN }}
+        SQC_EU_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_EU_URL }}
+        SQC_EU_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SQC_EU_TOKEN }}
+      run: ${ACTION_PATH_CHECK_SCA}/check-sca.sh
+
+    - name: Generate workflow summary
+      if: always() && steps.vault-fail.outcome != 'failure'
+      shell: bash
+      env:
+        SCA_VERIFIED: ${{ steps.check.outputs.sca-verified }}
+        SCA_PLATFORM: ${{ steps.check.outputs.platform }}
+        SCA_PROJECT_KEY: ${{ steps.check.outputs.project-key }}
+      run: |
+        echo "## SCA Verification" >> "$GITHUB_STEP_SUMMARY"
+        if [[ "$SCA_VERIFIED" == "true" ]]; then
+          echo "SCA verified on **${SCA_PLATFORM}** for project \`${SCA_PROJECT_KEY}\`" >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "SCA verification **FAILED** - no SCA data found on any platform" >> "$GITHUB_STEP_SUMMARY"
+        fi

--- a/check-sca/check-sca.sh
+++ b/check-sca/check-sca.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+# Verify that SonarQube SCA (Software Composition Analysis) ran for the project.
+#
+# Discovers project keys from config files, polls the SonarQube measures API
+# on all three instances (next, sqc-us, sqc-eu), and fails if SCA data is
+# missing after timeout.
+#
+# Required environment variables:
+#   NEXT_URL, NEXT_TOKEN         - SonarQube Next credentials
+#   SQC_US_URL, SQC_US_TOKEN     - SonarCloud US credentials
+#   SQC_EU_URL, SQC_EU_TOKEN     - SonarCloud EU credentials
+#   GITHUB_REPOSITORY            - GitHub repo (e.g. SonarSource/my-repo)
+#   GITHUB_OUTPUT                - GitHub Actions output file
+#
+# Optional environment variables:
+#   PROJECT_KEY_INPUT             - Explicit project key (additional to discovered keys)
+#   POLL_TIMEOUT                  - Max polling time in seconds (default: 300)
+#   POLL_INTERVAL                 - Seconds between polls (default: 15)
+#   WORKING_DIRECTORY             - Directory to search for config files (default: .)
+
+set -euo pipefail
+
+: "${NEXT_URL:?}" "${NEXT_TOKEN:?}" "${SQC_US_URL:?}" "${SQC_US_TOKEN:?}" "${SQC_EU_URL:?}" "${SQC_EU_TOKEN:?}"
+: "${GITHUB_REPOSITORY:?}" "${GITHUB_OUTPUT:?}"
+: "${POLL_TIMEOUT:=300}" "${POLL_INTERVAL:=15}" "${WORKING_DIRECTORY:=.}"
+: "${PROJECT_KEY_INPUT:=}"
+
+readonly ENDGROUP="::endgroup::"
+
+# Platform definitions: name:url_var:token_var
+PLATFORMS=(
+  "next:NEXT_URL:NEXT_TOKEN"
+  "sqc-us:SQC_US_URL:SQC_US_TOKEN"
+  "sqc-eu:SQC_EU_URL:SQC_EU_TOKEN"
+)
+
+# Discover candidate SonarQube project keys from config files.
+# Returns one key per line, deduplicated, in priority order.
+discover_project_keys() {
+  local keys=()
+  local work_dir="${WORKING_DIRECTORY:-.}"
+
+  # 1. Explicit input takes highest priority
+  if [[ -n "${PROJECT_KEY_INPUT:-}" ]]; then
+    keys+=("$PROJECT_KEY_INPUT")
+  fi
+
+  # 2. .sonarlint/connectedMode.json
+  local sonarlint_file="$work_dir/.sonarlint/connectedMode.json"
+  if [[ -f "$sonarlint_file" ]]; then
+    local key
+    key=$(jq -r '.projectKey // empty' "$sonarlint_file" 2>/dev/null || true)
+    if [[ -n "$key" ]]; then
+      keys+=("$key")
+    fi
+  fi
+
+  # 3. sonar-project.properties
+  local sonar_props="$work_dir/sonar-project.properties"
+  if [[ -f "$sonar_props" ]]; then
+    local key
+    key=$(grep -E '^sonar\.projectKey=' "$sonar_props" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '[:space:]')
+    if [[ -n "$key" ]]; then
+      keys+=("$key")
+    fi
+  fi
+
+  # 4. pom.xml
+  local pom_file="$work_dir/pom.xml"
+  if [[ -f "$pom_file" ]]; then
+    local key
+    key=$(perl -ne 'print $1 if /<sonar\.projectKey>([^<]+)/' "$pom_file" 2>/dev/null | head -1 || true)
+    if [[ -n "$key" ]]; then
+      keys+=("$key")
+    fi
+  fi
+
+  # 5. build.gradle / build.gradle.kts
+  local gradle_file
+  for gradle_file in "$work_dir/build.gradle" "$work_dir/build.gradle.kts"; do
+    if [[ -f "$gradle_file" ]]; then
+      local key
+      key=$(perl -ne 'print $1 if /sonar\.projectKey[^"]*"([^"]+)"/' "$gradle_file" 2>/dev/null | head -1 || true)
+      if [[ -n "$key" ]]; then
+        keys+=("$key")
+      fi
+    fi
+  done
+
+  # 6. Derive from GITHUB_REPOSITORY (e.g. SonarSource/repo-name -> SonarSource_repo-name)
+  if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+    local derived_key="${GITHUB_REPOSITORY/\//_}"
+    keys+=("$derived_key")
+  fi
+
+  # Deduplicate while preserving order
+  local seen=()
+  for k in "${keys[@]+"${keys[@]}"}"; do
+    local is_dup=false
+    for s in "${seen[@]+"${seen[@]}"}"; do
+      if [[ "$s" == "$k" ]]; then
+        is_dup=true
+        break
+      fi
+    done
+    if [[ "$is_dup" == "false" ]]; then
+      seen+=("$k")
+      echo "$k"
+    fi
+  done
+  return 0
+}
+
+# Check if the sca_count_any_issue metric exists for a project on a SonarQube instance.
+# Writes "platform_name:project_key" to result_file on success.
+# Args: url token project_key platform_name result_dir
+check_sca_metric() {
+  local url="${1:?}" token="${2:?}" project_key="${3:?}" platform_name="${4:?}" result_dir="${5:?}"
+
+  local api_url="${url}/api/measures/component?component=${project_key}&metricKeys=sca_count_any_issue"
+
+  local response http_code body
+  response=$(curl -s --max-time 10 -w "\n%{http_code}" \
+    -H "Authorization: Bearer ${token}" \
+    "${api_url}" 2>/dev/null) || return 1
+
+  http_code=$(echo "$response" | tail -1)
+  body=$(echo "$response" | sed '$d')
+
+  if [[ "$http_code" != "200" ]]; then
+    return 1
+  fi
+
+  local metric_value
+  metric_value=$(echo "$body" | jq -r '
+    .component.measures[]?
+    | select(.metric == "sca_count_any_issue")
+    | .value // empty
+  ' 2>/dev/null) || return 1
+
+  if [[ -n "$metric_value" ]]; then
+    echo "${platform_name}:${project_key}" > "${result_dir}/match"
+    return 0
+  fi
+
+  return 1
+}
+
+main() {
+  echo "::group::Discover project keys"
+  local project_keys=()
+  while IFS= read -r line; do
+    project_keys+=("$line")
+  done < <(discover_project_keys)
+
+  if [[ ${#project_keys[@]} -eq 0 ]]; then
+    echo "::error title=No project keys::Could not discover any SonarQube project keys" >&2
+    echo "$ENDGROUP"
+    echo "sca-verified=false" >> "$GITHUB_OUTPUT"
+    exit 1
+  fi
+
+  echo "Discovered project keys:"
+  for key in "${project_keys[@]}"; do
+    echo "  - $key"
+  done
+  echo "$ENDGROUP"
+
+  echo "::group::Poll for SCA data"
+  local start_time
+  start_time=$(date +%s)
+  local attempt=0
+  local result_dir
+  result_dir=$(mktemp -d)
+
+  while true; do
+    attempt=$((attempt + 1))
+    local elapsed=$(( $(date +%s) - start_time ))
+
+    if [[ $elapsed -ge $POLL_TIMEOUT ]]; then
+      echo "::error title=SCA check timeout::Timed out after ${POLL_TIMEOUT}s waiting for SCA data" >&2
+      echo "$ENDGROUP"
+      echo "sca-verified=false" >> "$GITHUB_OUTPUT"
+      rm -rf "$result_dir"
+      exit 1
+    fi
+
+    echo "--- Poll attempt $attempt (${elapsed}s / ${POLL_TIMEOUT}s) ---"
+
+    # Run all checks in parallel
+    rm -f "${result_dir}/match"
+    local pids=()
+    for key in "${project_keys[@]}"; do
+      for platform_def in "${PLATFORMS[@]}"; do
+        IFS=':' read -r platform_name url_var token_var <<< "$platform_def"
+        local url="${!url_var}" token="${!token_var}"
+
+        echo "  Checking $platform_name / $key ..."
+        check_sca_metric "$url" "$token" "$key" "$platform_name" "$result_dir" &
+        pids+=($!)
+      done
+    done
+
+    # Wait for all background jobs to finish
+    for pid in "${pids[@]}"; do
+      wait "$pid" 2>/dev/null || true
+    done
+
+    # Check if any succeeded
+    if [[ -f "${result_dir}/match" ]]; then
+      local match
+      match=$(cat "${result_dir}/match")
+      local found_platform="${match%%:*}"
+      local found_key="${match#*:}"
+      echo "  SCA verified on $found_platform for project key: $found_key"
+      echo "$ENDGROUP"
+      {
+        echo "sca-verified=true"
+        echo "platform=$found_platform"
+        echo "project-key=$found_key"
+      } >> "$GITHUB_OUTPUT"
+      rm -rf "$result_dir"
+      exit 0
+    fi
+
+    echo "SCA data not yet available. Waiting ${POLL_INTERVAL}s..."
+    sleep "$POLL_INTERVAL"
+  done
+  return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main
+fi

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.projectName=ci-github-actions
 
 sonar.sourceEncoding=UTF-8
 
-sonar.sources=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-maven,config-npm,build-npm,build-yarn,shared,config-pip,cache,code-signing,config-gradle,config-maven
+sonar.sources=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-maven,config-npm,build-npm,build-yarn,shared,config-pip,cache,code-signing,config-gradle,config-maven,check-sca
 sonar.tests=spec
 
 sonar.coverageReportPaths=coverage/coverage_data/sonar_coverage.xml

--- a/spec/check-sca_spec.sh
+++ b/spec/check-sca_spec.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+# shellcheck disable=SC2317  # ShellSpec DSL (Describe/It/Mock/End) is invoked indirectly
+eval "$(shellspec - -c) exit 1"
+
+# Minimal environment variables
+export NEXT_URL="https://next.sonarqube.com"
+export NEXT_TOKEN="next-token"
+export SQC_US_URL="https://sonarqube-us.example.com"
+export SQC_US_TOKEN="sqc-us-token"
+export SQC_EU_URL="https://sonarcloud.io"
+export SQC_EU_TOKEN="sqc-eu-token"
+export GITHUB_REPOSITORY="SonarSource/test-repo"
+export GITHUB_OUTPUT=/dev/null
+export POLL_TIMEOUT="300"
+export POLL_INTERVAL="15"
+export WORKING_DIRECTORY="."
+export PROJECT_KEY_INPUT=""
+
+# shellcheck disable=SC2329  # Functions invoked indirectly by BeforeEach/AfterEach
+setup_main() {
+  TEST_DIR=$(mktemp -d)
+  export WORKING_DIRECTORY="$TEST_DIR"
+  GITHUB_OUTPUT=$(mktemp)
+  export GITHUB_OUTPUT
+  return 0
+}
+# shellcheck disable=SC2329  # Functions invoked indirectly by BeforeEach/AfterEach
+teardown_main() {
+  rm -rf "$TEST_DIR"
+  rm -f "$GITHUB_OUTPUT"
+  return 0
+}
+
+Describe 'check-sca/check-sca.sh'
+  It 'does not run main when sourced'
+    When run source check-sca/check-sca.sh
+    The status should be success
+    The output should equal ""
+  End
+End
+
+Describe 'discover_project_keys()'
+  Include check-sca/check-sca.sh
+
+  # shellcheck disable=SC2329  # Function invoked indirectly by BeforeEach
+  setup() {
+    TEST_DIR=$(mktemp -d)
+    export WORKING_DIRECTORY="$TEST_DIR"
+    return 0
+  }
+  # shellcheck disable=SC2329  # Function invoked indirectly by AfterEach
+  teardown() {
+    rm -rf "$TEST_DIR"
+    return 0
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  It 'uses explicit PROJECT_KEY_INPUT when provided'
+    export PROJECT_KEY_INPUT="my-explicit-key"
+    When call discover_project_keys
+    The line 1 should equal "my-explicit-key"
+  End
+
+  It 'reads from .sonarlint/connectedMode.json'
+    export PROJECT_KEY_INPUT=""
+    mkdir -p "$TEST_DIR/.sonarlint"
+    echo '{"projectKey": "FromSonarlint"}' > "$TEST_DIR/.sonarlint/connectedMode.json"
+    Mock jq
+      echo "FromSonarlint"
+    End
+    When call discover_project_keys
+    The output should include "FromSonarlint"
+  End
+
+  It 'reads from sonar-project.properties'
+    export PROJECT_KEY_INPUT=""
+    echo "sonar.projectKey=FromProperties" > "$TEST_DIR/sonar-project.properties"
+    When call discover_project_keys
+    The output should include "FromProperties"
+  End
+
+  It 'reads from pom.xml'
+    export PROJECT_KEY_INPUT=""
+    printf '<project>\n  <properties>\n    <sonar.projectKey>FromPom</sonar.projectKey>\n  </properties>\n</project>\n' \
+      > "$TEST_DIR/pom.xml"
+    When call discover_project_keys
+    The output should include "FromPom"
+  End
+
+  It 'reads from build.gradle'
+    export PROJECT_KEY_INPUT=""
+    printf 'sonar.projectKey = "FromGradle"\n' > "$TEST_DIR/build.gradle"
+    When call discover_project_keys
+    The output should include "FromGradle"
+  End
+
+  It 'derives key from GITHUB_REPOSITORY as fallback'
+    export PROJECT_KEY_INPUT=""
+    export GITHUB_REPOSITORY="SonarSource/my-repo"
+    When call discover_project_keys
+    The output should include "SonarSource_my-repo"
+  End
+
+  It 'deduplicates keys'
+    export PROJECT_KEY_INPUT="SonarSource_test-repo"
+    export GITHUB_REPOSITORY="SonarSource/test-repo"
+    When call discover_project_keys
+    The lines of output should equal 1
+    The line 1 should equal "SonarSource_test-repo"
+  End
+
+  It 'returns keys from multiple sources in priority order'
+    export PROJECT_KEY_INPUT="explicit-key"
+    mkdir -p "$TEST_DIR/.sonarlint"
+    echo '{"projectKey": "sonarlint-key"}' > "$TEST_DIR/.sonarlint/connectedMode.json"
+    echo "sonar.projectKey=props-key" > "$TEST_DIR/sonar-project.properties"
+    export GITHUB_REPOSITORY="SonarSource/test-repo"
+    When call discover_project_keys
+    The line 1 should equal "explicit-key"
+    The line 2 should equal "sonarlint-key"
+    The line 3 should equal "props-key"
+    The line 4 should equal "SonarSource_test-repo"
+  End
+
+  It 'returns empty when no sources available'
+    export PROJECT_KEY_INPUT=""
+    export GITHUB_REPOSITORY=""
+    When call discover_project_keys
+    The output should equal ""
+  End
+End
+
+Describe 'check_sca_metric()'
+  Include check-sca/check-sca.sh
+
+  Mock jq
+    input=$(cat)
+    if echo "$input" | grep -q '"sca_count_any_issue"'; then
+      echo "$input" | grep -o '"value":"[^"]*"' | head -1 | cut -d'"' -f4
+    fi
+  End
+
+  # shellcheck disable=SC2329  # Function invoked indirectly by BeforeEach
+  setup() {
+    RESULT_DIR=$(mktemp -d)
+    return 0
+  }
+  # shellcheck disable=SC2329  # Function invoked indirectly by AfterEach
+  teardown() {
+    rm -rf "$RESULT_DIR"
+    return 0
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  It 'returns success when sca_count_any_issue metric is present'
+    Mock curl
+      printf '{"component":{"measures":[{"metric":"sca_count_any_issue","value":"3"}]}}\n200'
+    End
+    When call check_sca_metric "https://next.sonarqube.com" "token" "good-key" "next" "$RESULT_DIR"
+    The status should be success
+    The contents of file "${RESULT_DIR}/match" should equal "next:good-key"
+  End
+
+  It 'returns success when sca_count_any_issue value is 0'
+    Mock curl
+      printf '{"component":{"measures":[{"metric":"sca_count_any_issue","value":"0"}]}}\n200'
+    End
+    When call check_sca_metric "https://next.sonarqube.com" "token" "zero-key" "sqc-eu" "$RESULT_DIR"
+    The status should be success
+    The contents of file "${RESULT_DIR}/match" should equal "sqc-eu:zero-key"
+  End
+
+  It 'returns failure when measures array is empty'
+    Mock curl
+      printf '{"component":{"measures":[]}}\n200'
+    End
+    When call check_sca_metric "https://next.sonarqube.com" "token" "no-sca-key" "next" "$RESULT_DIR"
+    The status should be failure
+  End
+
+  It 'returns failure on HTTP 404'
+    Mock curl
+      printf '{"errors":[{"msg":"Component not found"}]}\n404'
+    End
+    When call check_sca_metric "https://next.sonarqube.com" "token" "not-found" "next" "$RESULT_DIR"
+    The status should be failure
+  End
+
+  It 'returns failure when curl fails'
+    Mock curl
+      return 1
+    End
+    When call check_sca_metric "https://next.sonarqube.com" "token" "bad-key" "next" "$RESULT_DIR"
+    The status should be failure
+  End
+End
+
+Describe 'main() success'
+  Mock curl
+    printf '{"component":{"measures":[{"metric":"sca_count_any_issue","value":"5"}]}}\n200'
+  End
+
+  BeforeEach 'setup_main'
+  AfterEach 'teardown_main'
+
+  It 'succeeds when SCA metric is found on first attempt'
+    export PROJECT_KEY_INPUT="SonarSource_test-repo"
+    export GITHUB_REPOSITORY="SonarSource/test-repo"
+    export POLL_TIMEOUT="300"
+    When run script check-sca/check-sca.sh
+    The status should be success
+    The output should include "SCA verified on"
+    The output should include "for project key: SonarSource_test-repo"
+    The contents of file "$GITHUB_OUTPUT" should include "sca-verified=true"
+    The contents of file "$GITHUB_OUTPUT" should include "project-key=SonarSource_test-repo"
+  End
+End
+
+Describe 'main() timeout'
+  Mock curl
+    printf '{"component":{"measures":[]}}\n200'
+  End
+
+  BeforeEach 'setup_main'
+  AfterEach 'teardown_main'
+
+  It 'fails immediately when timeout is 0 and SCA metric is not found'
+    export PROJECT_KEY_INPUT="my-project"
+    export POLL_TIMEOUT="0"
+    When run script check-sca/check-sca.sh
+    The status should be failure
+    The output should include "::group::Poll for SCA data"
+    The stderr should include "::error title=SCA check timeout"
+    The contents of file "$GITHUB_OUTPUT" should include "sca-verified=false"
+  End
+End


### PR DESCRIPTION
## Context
We (EngXP) are trying to add enforcement of SonarQube SCA Scanning for GitHub repos in the SonarSource GitHub organization. We first thought of using a quality gate for this, but confirmed with the SCA Product Manager that this is not possible for checking whether a SonarQube project has been scanned by SCA or not ([see slack convo](https://sonarsource.slack.com/archives/C0ASVL4SNGP/p1776790242441969?thread_ts=1776789994.742989&cid=C0ASVL4SNGP)).

We decided to go with this alternative solution of having a GitHub Action that is configured as a required check as part of a Ruleset at the SonarSource GitHub org level. This PR implements that check and tests it with GitHub repos that we expect to pass or fail. 
- [See here the github org ruleset](https://github.com/organizations/SonarSource/settings/rules/15360984) I used to test this

## What Changed?
- Implements the `check-sca` action, which when applied to a GitHub repo, checks if the GitHub repo that makes the commit has ever had its dependencies scanned by SCA in any of the three internal SQ instances (SQC-EU, SQC-US, and SQS-Next). If dependencies have never been scanned for the GitHub Repo's correlating SQ Project in any of the three instances, then the check fails and prevents the PR from being merged

## Test Plan
- ✅ Set the SCA Enforcement ruleset to target `portkey-admin-automation`, which we expect to pass the check
  - [Link to Check being triggered in a PR Commit and passing](https://github.com/SonarSource/portkey-admin-automation/actions/runs/24798970761/attempts/1#summary-72576186148)
- ✅ Set the SCA Enforcement ruleset to target `peachee-cfamily-sources`, which we expect to fail the check
  - [Link to Check being triggered in a PR Commit and **failing**](https://github.com/SonarSource/peachee-cfamily-sources/actions/runs/24798942818/attempts/1#summary-72576088842)
- ✅ Set the github action in this PR towards the `master` branch instead of this feature branch
  - **Note:** Unfortunately, this will cause the action to fail locally on this branch until we merge it in to master the first time. We need the action is live in `.github/workflows` to be called by the branch ruleset, so this is necessary and the SCA check should succeed on the commit of this PR to `master`
  - See screenshot at the bottom to see proof that this was passing on this repo before changing the ref from this branch to master:
- Merge PR
- Remove check from ruleset since testing is complete. Ruleset will be created in terraform separately so that we can manage the repo exemptions via IaC.


<img width="504" height="42" alt="Screenshot 2026-04-22 at 3 01 24 PM" src="https://github.com/user-attachments/assets/6d3e8d72-ef91-47b8-90c2-52c41e97c57b" />