### PR TITLE
BUILD-11091: Fix vault path in downstream repos for check-sca by changing trigger to pull_request

### DIFF
--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -1,7 +1,7 @@
 ---
 name: Required SCA Check
 on:
-  pull_request_target:
+  pull_request:
   merge_group:
 
 permissions:


### PR DESCRIPTION
Having this `check-sca` action trigger on `pull_request_target` rather than `pull_request` broke the vault auth on downstream repos (i.e. [this run](https://github.com/SonarSource/portkey-admin-automation/actions/runs/24850704370?pr=19)) that have this check enforced in the github org ruleset for this check we are testing out. Also broke it on this repo as well.

Claude's explanation of problem:

> This is a Vault JWT auth policy issue, not a missing Vault role. The Vault role for portkey-admin-automation exists and previously worked, but it's bound to specific event_name claim values (e.g. push, pull_request) — and pull_request_target is a different event name that the Vault role isn't bound to allow.

Claude's full explanation and recommended change (which is made in this PR):
> ### Why Julien recommended it here
> For an org-level required workflow that needs Vault (id-token: write), pull_request_target ensures it works even for fork PRs. But this action doesn't run user code — it just calls the SonarQube API — so the security concern doesn't apply.
> 
> ### Why it doesn't matter for SonarSource
> All SonarSource repos are private/internal. There are no external fork PRs. Every PR is a branch PR from within the org, so pull_request always has full token access. pull_request_target buys you nothing here.
> 
> ### The real problem
> pull_request_target changes the JWT event_name claim from pull_request to pull_request_target. Vault roles are configured with bound_claims that list allowed event names. Every repo's Vault role was set up to allow push and pull_request — not pull_request_target. So Vault rejects the login.
> 
> Conclusion: Switch back to pull_request. Since all SonarSource repos are internal, there are no fork PRs, so pull_request works fine and matches existing Vault role bound claims. Want me to make that change?

## Test Plan
- `pull_request_target` is expected to fail here since it always runs the check from the target branch, while `pull_request_target` is what is causing the vault auth issues
- Merge PR
- Open new PR here to test as well as new commits in https://github.com/SonarSource/portkey-admin-automation/pull/19 and https://github.com/SonarSource/peachee-cfamily-sources/pull/7