### PR TITLE
PREQ-5497: Bump mise to 2026.4.23 to fix jfrog-cli registry lookup

### DIFF
--- a/.github/workflows/test-shell-scripts.yml
+++ b/.github/workflows/test-shell-scripts.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: ./config-npm
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
         with:
-          version: 2026.3.17
+          version: 2026.4.23
       - name: Run ShellSpec tests
         # FIXME BUILD-8337: improve setup of kcov
         run: |

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -123,7 +123,7 @@ runs:
 
     - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
       with:
-        version: 2026.3.17
+        version: 2026.4.23
 
     - uses: ./.actions/config-npm
       id: config

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -119,7 +119,7 @@ runs:
         restore-keys: poetry-${{ runner.os }}-
     - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
       with:
-        version: 2026.3.17
+        version: 2026.4.23
     - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
       id: secrets
       # yamllint disable rule:line-length

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -118,7 +118,7 @@ runs:
 
     - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
       with:
-        version: 2026.3.17
+        version: 2026.4.23
         working_directory: ${{ inputs.working-directory }}
 
     - name: Cache Yarn dependencies

--- a/promote/action.yml
+++ b/promote/action.yml
@@ -59,7 +59,7 @@ runs:
           development/github/token/{REPO_OWNER_NAME_DASH}-promotion token | GITHUB_TOKEN;
     - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
       with:
-        version: 2026.3.17
+        version: 2026.4.23
     - name: Promote artifacts
       shell: bash
       env:


### PR DESCRIPTION
## Summary

- Bumps mise from `2026.3.17` to `2026.4.23` across all 5 files that pin the version
- Fixes intermittent `jfrog-cli` installation failures caused by `mise-versions.jdx.dev` returning empty/not-found responses
- Affects: `promote/action.yml`, `build-yarn/action.yml`, `build-poetry/action.yml`, `build-npm/action.yml`, `.github/workflows/test-shell-scripts.yml`

## Context

Jira: [PREQ-5497](https://sonarsource.atlassian.net/browse/PREQ-5497)

The `promote` workflow (and potentially other workflows) fails installing `jfrog-cli` via mise because `mise-versions.jdx.dev` intermittently returns empty / "Tool not found" for `jfrog-cli`. The reporter confirmed that mise `2026.4.23` resolves the issue.

## Test plan

- [ ] CI pipeline passes on this branch (mise installs `jfrog-cli` successfully)
- [ ] Verify promote workflow succeeds on a downstream repo (e.g. `sonar-scanner-integration-tester`)

[PREQ-5497]: https://sonarsource.atlassian.net/browse/PREQ-5497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ