### PR TITLE
BUILD-10835 Use warp-custom-ubuntu-24-04 instead of github-ubuntu-latest-s

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,5 @@
 # Configuration for https://github.com/rhysd/actionlint run by pre-commit
 self-hosted-runner:
   labels:
-    - github-ubuntu-latest-s
+    - warp-custom-ubuntu-24-04
     - github-windows-latest-s

--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   PullRequestClosed_job:
     name: Pull Request Closed
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   verify-sca:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       actions: write  # Required for deleting caches and artifacts
     steps:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ permissions:
   contents: read
 jobs:
   pre-commit:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: ./config-npm

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -10,7 +10,7 @@ permissions:
   checks: read
 jobs:
   notify:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - name: Send Slack Notification
         env:

--- a/.github/workflows/test-build-number.yml
+++ b/.github/workflows/test-build-number.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-build-number-generation:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read
@@ -43,7 +43,7 @@ jobs:
 
   test-build-number-reuse-from-cache:
     needs: test-build-number-generation
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read
@@ -84,7 +84,7 @@ jobs:
 
   test-build-number-reuse-from-env:
     needs: test-build-number-generation
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read
@@ -115,8 +115,16 @@ jobs:
       - test-build-number-reuse-from-cache
       - test-build-number-reuse-from-cache-windows
       - test-build-number-reuse-from-env
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: ./config-npm
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.4.23
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test-pr-cleanup.yml
+++ b/.github/workflows/test-pr-cleanup.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   # Create a cache entry and an artifact when a PR is opened or updated
   test-resources:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       # Create test file and directory for cache
@@ -29,7 +29,7 @@ jobs:
           retention-days: 1
 
   test-cleanup:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     needs: test-resources
     permissions:
       actions: write  # Required for cache/artifact operations

--- a/.github/workflows/test-shell-scripts.yml
+++ b/.github/workflows/test-shell-scripts.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-shell-scripts:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unified-platform-dogfooding:
-    runs-on: github-ubuntu-latest-s
+    runs-on: warp-custom-ubuntu-24-04
     name: Unified Platform Dogfooding
     permissions:
       id-token: write

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,8 @@ pre-commit = "4.2.0"
 shellcheck = "0.10.0"
 shellspec = "0.28.1"
 jfrog-cli = "2.96.0"
+node = "24.15.0"
+python = "3.14"
 "npm:markdownlint-cli" = "0.39.0"
 
 [env]


### PR DESCRIPTION
BUILD-10835

## Purpose

Use `warp-custom-ubuntu-24-04` (WarpBuild) instead of `github-ubuntu-latest-s` across shared workflows and actionlint allowlist.

## Scope

- `.github/workflows/*` (all jobs that still referenced `github-ubuntu-latest-s`, including `check-sca.yml` from `master`)
- `.github/actionlint.yaml` self-hosted runner label list

## Notes

README / internal migration notes under `.cursor/` still mention the old GitHub-hosted label in places; say if you want those updated in a follow-up.