### PR TITLE
PREQ-5794 Fix check-sca Gradle Kotlin DSL projectKey parsing

### DIFF
--- a/check-sca/check-sca.sh
+++ b/check-sca/check-sca.sh
@@ -116,7 +116,13 @@ discover_project_keys() {
   for gradle_file in "$work_dir/build.gradle" "$work_dir/build.gradle.kts"; do
     if [[ -f "$gradle_file" ]]; then
       local key
-      key=$(perl -ne 'print $1 if /sonar\.projectKey[^"]*"([^"]+)"/' "$gradle_file" 2>/dev/null | head -1 || true)
+      key=$(perl -ne '
+        if (/sonar\.projectKey\s*[=:]\s*["\x27]([^"\x27]+)["\x27]/ ||
+            /sonar\.projectKey["\x27]\s*,\s*["\x27]([^"\x27]+)["\x27]/) {
+          print "$1\n";
+          exit;
+        }
+      ' "$gradle_file" 2>/dev/null || true)
       if [[ -n "$key" ]]; then
         keys+=("$key")
       fi

--- a/spec/check-sca_spec.sh
+++ b/spec/check-sca_spec.sh
@@ -140,6 +140,13 @@ Describe 'discover_project_keys()'
     The output should include "FromGradle"
   End
 
+  It 'reads from build.gradle.kts property syntax'
+    export PROJECT_KEY_INPUT=""
+    printf 'property("sonar.projectKey", "org.sonarsource.php:php")\n' > "$TEST_DIR/build.gradle.kts"
+    When call discover_project_keys
+    The output should include "org.sonarsource.php:php"
+  End
+
   It 'derives key from GITHUB_REPOSITORY as fallback'
     export PROJECT_KEY_INPUT=""
     export GITHUB_REPOSITORY="SonarSource/my-repo"


### PR DESCRIPTION
## Context

Surfaced via [PREQ-5794](https://sonarsource.atlassian.net/browse/PREQ-5794) — Nils, while preparing the SCA check workflow on `SonarSource/sonar-php` (`nw/sca` branch), reported that `check-sca` ignores `sonar.projectKey` in `build.gradle.kts` and falls back to a derived key that doesn't match the actual Sonar project key.

Originating action: introduced in [BUILD-11091](https://sonarsource.atlassian.net/browse/BUILD-11091).

## Root cause

The Gradle key-extraction regex in `check-sca/check-sca.sh`:

```perl
sonar\.projectKey[^"]*"([^"]+)"
```

is too loose for Kotlin DSL. On the typical KTS form:

```kotlin
property(\"sonar.projectKey\", \"org.sonarsource.php:php\")
```

it matches but captures `, ` (the literal `\", \"` between the two arguments), not the project key. The action then queries the Sonar API with garbage and falls back to `SonarSource_<repo>` — which does not exist for analyzers using Maven-style keys.

Reproduction:

```console
$ echo '    property(\"sonar.projectKey\", \"org.sonarsource.php:php\")' \
    | perl -ne 'print \"[\$1]\n\" if /sonar\.projectKey[^\"]*\"([^\"]+)\"/'
[, ]
```

## Fix

Tighten the regex to two well-defined shapes:

1. `sonar.projectKey = \"value\"` / `sonar.projectKey: \"value\"` (Groovy assignment / KTS map literal).
2. `(\"sonar.projectKey\", \"value\")` (KTS `property(...)` / `set(...)` calls, including single-quoted Groovy form).

Both single (`'`) and double (`\"`) quotes are accepted.

## Validation

Manual matrix run on the new pattern:

| Input | Captured |
|---|---|
| `property(\"sonar.projectKey\", \"org.sonarsource.php:php\")` | `org.sonarsource.php:php` |
| `set(\"sonar.projectKey\", \"k1\")` | `k1` |
| `sonar.projectKey = \"k3\"` | `k3` |
| `sonar.projectKey: \"k4\"` | `k4` |
| `property('sonar.projectKey', 'k5')` | `k5` |
| `properties[\"sonar.projectKey\"] = \"k2\"` | _no match_ (known gap) |

Regression test added in `spec/check-sca_spec.sh` for the `property(\"sonar.projectKey\", ...)` KTS form.

## Known limitations / non-goals

- `properties[\"sonar.projectKey\"] = \"...\"` indexed-property form still not detected (uncommon in our analyzers, can be added if needed).
- Comments containing `sonar.projectKey = \"...\"` would still be matched — same behaviour as before, no regression.
- Did not try to parse `settings.gradle.kts` or composite-build root projects.

## Workaround already used downstream

`sonar-php` `nw/sca` branch sets the `project-key:` input explicitly, which is the supported override and unblocks the requester:

```yaml
- uses: SonarSource/ci-github-actions/check-sca@v1
  with:
    project-key: \"org.sonarsource.php:php\"
```

So this PR is **not urgent** — it removes a foot-gun before broad onboarding.

## Test plan

- [x] Owner (`@sonarsource/platform-eng-xp-squad`, ideally Brian as the original author of `check-sca`) confirms regex shape covers all KTS variants you care about for v1.
- [x] CI `check-sca.yml` self-test still green.
- [ ] Optional: dry-run on `sonar-php` `nw/sca` after removing the explicit `project-key:` input.

[PREQ-5794]: https://sonarsource.atlassian.net/browse/PREQ-5794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11091]: https://sonarsource.atlassian.net/browse/BUILD-11091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ