### PR TITLE
PREQ-5738: Adds maven-style project key extraction to check-sca

### DIFF
--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -1,5 +1,5 @@
 ---
-name: Required SCA Check
+name: SCA Check
 on:
   pull_request:
   merge_group:

--- a/README.md
+++ b/README.md
@@ -1401,7 +1401,7 @@ action fails with a link to the
 ### Usage
 
 ```yaml
-name: Required SCA Check
+name: SCA Check
 on:
   pull_request:
   merge_group:
@@ -1412,7 +1412,7 @@ permissions:
 
 jobs:
   verify-sca:
-    runs-on: sonar-xs  # Private repos default; use github-ubuntu-latest-s for public repos
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: SonarSource/ci-github-actions/check-sca@v1

--- a/check-sca/check-sca.sh
+++ b/check-sca/check-sca.sh
@@ -68,10 +68,46 @@ discover_project_keys() {
   # 4. pom.xml
   local pom_file="$work_dir/pom.xml"
   if [[ -f "$pom_file" ]]; then
+    # 4a. Explicit sonar.projectKey property (highest priority within pom.xml)
     local key
-    key=$(perl -ne 'print $1 if /<sonar\.projectKey>([^<]+)/' "$pom_file" 2>/dev/null | head -1 || true)
+    key=$(perl -0777 -ne '
+      if (/<sonar\.projectKey>([^<]+)/s) {
+        my $key = $1;
+        $key =~ s/^\s+|\s+$//g;
+        print $key;
+      }
+    ' "$pom_file" 2>/dev/null || true)
     if [[ -n "$key" ]]; then
       keys+=("$key")
+    fi
+
+    # 4b. Derive groupId:artifactId (Maven default project key)
+    local maven_key
+    maven_key=$(perl -0777 -ne '
+      sub trim {
+        my ($value) = @_;
+        $value = "" unless defined $value;
+        $value =~ s/^\s+|\s+$//g;
+        return $value;
+      }
+
+      my $parent_gid = ($_ =~ /<parent>.*?<groupId>([^<]+)/s) ? $1 : "";
+      (my $proj = $_) =~ s/<parent>.*?<\/parent>//s;
+      $proj =~ s/<dependencyManagement>.*?<\/dependencyManagement>//s;
+      $proj =~ s/<dependencies>.*?<\/dependencies>//sg;
+      $proj =~ s/<build>.*?<\/build>//s;
+      $proj =~ s/<profiles>.*?<\/profiles>//s;
+      $proj =~ s/<reporting>.*?<\/reporting>//s;
+      $proj =~ s/<modules>.*?<\/modules>//s;
+      $parent_gid = trim($parent_gid);
+      my $gid = ($proj =~ /<groupId>([^<]+)/s) ? $1 : $parent_gid;
+      my $aid = ($proj =~ /<artifactId>([^<]+)/s) ? $1 : "";
+      $gid = trim($gid);
+      $aid = trim($aid);
+      print "$gid:$aid" if $gid ne "" && $aid ne "";
+    ' "$pom_file" 2>/dev/null || true)
+    if [[ -n "$maven_key" ]]; then
+      keys+=("$maven_key")
     fi
   fi
 

--- a/spec/check-sca_spec.sh
+++ b/spec/check-sca_spec.sh
@@ -89,6 +89,50 @@ Describe 'discover_project_keys()'
     The output should include "FromPom"
   End
 
+  It 'derives groupId:artifactId from pom.xml with project-level groupId'
+    export PROJECT_KEY_INPUT=""
+    printf '<project>\n  <parent>\n    <groupId>org.sonarsource.parent</groupId>\n    <artifactId>parent</artifactId>\n    <version>1.0</version>\n  </parent>\n  <groupId>org.sonarsource.plugins.cayc</groupId>\n  <artifactId>sonar-cayc-plugin</artifactId>\n</project>\n' \
+      > "$TEST_DIR/pom.xml"
+    When call discover_project_keys
+    The output should include "org.sonarsource.plugins.cayc:sonar-cayc-plugin"
+  End
+
+  It 'derives groupId:artifactId from pom.xml with inherited parent groupId'
+    export PROJECT_KEY_INPUT=""
+    printf '<project>\n  <parent>\n    <groupId>org.jenkins-ci.plugins</groupId>\n    <artifactId>plugin</artifactId>\n    <version>4.0</version>\n  </parent>\n  <artifactId>sonar</artifactId>\n</project>\n' \
+      > "$TEST_DIR/pom.xml"
+    When call discover_project_keys
+    The output should include "org.jenkins-ci.plugins:sonar"
+  End
+
+  It 'prefers sonar.projectKey over groupId:artifactId from pom.xml'
+    export PROJECT_KEY_INPUT=""
+    printf '<project>\n  <groupId>com.example</groupId>\n  <artifactId>my-app</artifactId>\n  <properties>\n    <sonar.projectKey>ExplicitKey</sonar.projectKey>\n  </properties>\n</project>\n' \
+      > "$TEST_DIR/pom.xml"
+    When call discover_project_keys
+    The line 1 should equal "ExplicitKey"
+    The line 2 should equal "com.example:my-app"
+  End
+
+  It 'trims whitespace when reading pom.xml project keys'
+    export PROJECT_KEY_INPUT=""
+    printf '<project>\n  <groupId>\n    com.example\n  </groupId>\n  <artifactId>\n    my-app\n  </artifactId>\n  <properties>\n    <sonar.projectKey>\n      ExplicitKey\n    </sonar.projectKey>\n  </properties>\n</project>\n' \
+      > "$TEST_DIR/pom.xml"
+    When call discover_project_keys
+    The line 1 should equal "ExplicitKey"
+    The line 2 should equal "com.example:my-app"
+  End
+
+  It 'does not derive Maven key when pom.xml has only parent block'
+    export PROJECT_KEY_INPUT=""
+    export GITHUB_REPOSITORY=""
+    printf '<project>\n  <parent>\n    <groupId>org.sonarsource.parent</groupId>\n    <artifactId>parent</artifactId>\n    <version>1.0</version>\n  </parent>\n</project>\n' \
+      > "$TEST_DIR/pom.xml"
+    When call discover_project_keys
+    The output should not include "org.sonarsource.parent:parent"
+    The output should equal ""
+  End
+
   It 'reads from build.gradle'
     export PROJECT_KEY_INPUT=""
     printf 'sonar.projectKey = "FromGradle"\n' > "$TEST_DIR/build.gradle"


### PR DESCRIPTION
## Summary

- Enhanced `discover_project_keys()` to extract Maven-style `groupId:artifactId`
  project keys from `pom.xml`, in addition to the existing `<sonar.projectKey>`
  property extraction
- This fixes `check-sca` failures for repos analyzed on SonarQube Next whose
  project keys follow the Maven default convention (e.g.,
  `org.sonarsource.plugins.cayc:sonar-cayc-plugin`) rather than the
  `SonarSource_<repo-name>` convention
- Additionally, as part of BUILD-11387, removed the "Required" verbiage from the check name

## Context

Two repos (`sonar-cayc-stats-plugin` and `sonar-scanner-jenkins`) fail the
`check-sca` action because they don't define an explicit `<sonar.projectKey>`
in their pom.xml. SonarQube generates their project keys from Maven coordinates
(`groupId:artifactId`), but the action couldn't discover these keys and fell
back to the `GITHUB_REPOSITORY`-derived key which doesn't match anything.

See: PREQ-5738

## How it works

After checking for an explicit `<sonar.projectKey>` property (step 4a), the
script now also extracts the project-level `<groupId>` and `<artifactId>` from
pom.xml (step 4b). It handles:

- **Project-level groupId**: uses the project's own `<groupId>` when present
- **Inherited groupId**: falls back to the parent's `<groupId>` when the
  project doesn't define its own (standard Maven inheritance)
- **Dependency/build noise**: strips `<parent>`, `<dependencyManagement>`,
  `<dependencies>`, `<build>`, `<profiles>`, `<reporting>`, and `<modules>`
  blocks before extracting, so dependency groupIds aren't matched

Both keys are emitted as candidates (deduplication handles overlap), so the
polling loop tries all of them against all platforms.

## Test plan

- [x] `derives groupId:artifactId from pom.xml with project-level groupId` —
  pom with parent + its own groupId → `org.sonarsource.plugins.cayc:sonar-cayc-plugin`
- [x] `derives groupId:artifactId from pom.xml with inherited parent groupId` —
  pom with no project-level groupId → `org.jenkins-ci.plugins:sonar`
- [x] `prefers sonar.projectKey over groupId:artifactId from pom.xml` —
  both explicit key and Maven key appear as candidates
- [x] `does not derive Maven key when pom.xml has only parent block` —
  no project-level artifactId → no key emitted
- [x] Verified extraction against actual pom.xml files from both affected repos via `gh api`
- [x] All 21 ShellSpec tests pass (16 existing + 5 new including the existing sonar.projectKey test)