### PR TITLE
BUILD-11393: Fix check-sca failures caused by local-ref

### DIFF
--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -13,6 +13,4 @@ jobs:
     runs-on: warp-custom-ubuntu-24-04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          sparse-checkout: check-sca
-      - uses: ./check-sca
+      - uses: SonarSource/ci-github-actions/check-sca@master


### PR DESCRIPTION
## Context
- Repos are experiencing failures like [this one](https://github.com/SonarSource/sonarcloud-cleancode/actions/runs/25926961431/job/76213098621) - `Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/sonarcloud-cleancode/sonarcloud-cleancode/check-sca'. Did you forget to run actions/checkout before running your local action?`
  - This was caused by this commit - https://github.com/SonarSource/ci-github-actions/commit/9456e3aab93a6c6d0c459b977aaa594bda102e29#diff-c12f6b4c7fa14717502e927e2a8baeb299a09138c09390c127fba9e2c8766371R16-R18

## What Changed?
- Fixed by changing ref back to the full repo + action@master rather than local ref, as the local ref doesn't work when called from the ruleset.