### PR TITLE
PREQ-5827 fix(check-sca): declare `environment: dev` on verify-sca job

### DIFF
--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -11,6 +11,17 @@ permissions:
 jobs:
   verify-sca:
     runs-on: warp-custom-ubuntu-24-04
+    # `id-token: write` (above) makes GitHub mint an OIDC token, which the
+    # check-sca composite action exchanges with Vault for SonarQube
+    # credentials. Per the SonarSource OIDC standard, the `environment`
+    # claim is mandatory: Vault role bindings include it in
+    # `include_claim_keys` by default. A job with `id-token: write` but no
+    # `environment:` produces a token without the claim, and Vault rejects
+    # it: "OIDC error: the claim 'environment' cannot be null or empty".
+    # `dev` is the most widely-defined GitHub environment across consumer
+    # repos and is appropriate here — this is a pre-merge check, not a
+    # deployment.
+    environment: dev
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: SonarSource/ci-github-actions/check-sca@master


### PR DESCRIPTION
## Summary
The `verify-sca` job has `permissions: id-token: write` (which mints an OIDC token) but no `environment:` declaration, so the token it produces has no `environment` claim. Per the SonarSource OIDC standard, Vault role bindings include `environment` in `include_claim_keys` by default — they reject tokens without it:

```
OIDC error: the claim 'environment' cannot be `null` or empty.
The following claims specified by the `include_claim_keys` setting must be set: environment.
```

This makes the `check-sca` action fail at the Vault auth step (before it even reaches SonarQube) in every consumer repo whose role binding follows the standard.

This PR adds `environment: dev` so the OIDC token carries the required claim and Vault authentication succeeds.

## Why `dev`
- It's the most widely-defined GitHub environment across SonarSource consumer repos (`staging`, `prod` aren't universal).
- This is a pre-merge check, not a deployment, so any non-prod environment is semantically fine — the value just needs to exist as a claim.
- If a target repo doesn't have a `dev` environment, GitHub auto-creates it on first use; jobs without protection rules proceed normally.

## How this was found
First seen on [SonarSource/sonarsource-infra-scim-proxy#2](https://github.com/SonarSource/sonarsource-infra-scim-proxy/pull/2), where this OIDC error blocked every rebase-merge attempt. The ruleset rolling out org-wide (BUILD-10965) makes this bug surface on any production repo that hasn't been exempted via \`sca_scanning_exempt_repos.txt\`.

## Test plan
- [ ] PR CI passes on this repo
- [ ] Smoke-test on a consumer repo: confirm \`verify-sca\` reaches the SonarQube poll step instead of failing at Vault auth

## Refs
- BUILD-10965 — Enforce SCA and SAST scanning for all production repos
- SonarSource OIDC standard: mandatory claims \`['repo', 'environment']\`