### PR TITLE
BUILD-11295 test gh-action_cache@feat/.../BUILD-11295-metricsFeatureFlag

### DIFF
--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -111,7 +111,7 @@ runs:
       with:
         host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
     - name: Cache local Poetry cache
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@master # dogfood
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ github.workspace }}/${{ inputs.poetry-cache-dir }}

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -111,7 +111,7 @@ runs:
       with:
         host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
     - name: Cache local Poetry cache
-      uses: SonarSource/gh-action_cache@master # dogfood
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11417-extract-symlink-keeper # TEST ONLY — BUILD-11417
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ github.workspace }}/${{ inputs.poetry-cache-dir }}

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -122,7 +122,7 @@ runs:
         working_directory: ${{ inputs.working-directory }}
 
     - name: Cache Yarn dependencies
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@master # dogfood
       if: ${{ inputs.cache-yarn == 'true' && inputs.disable-caching != 'true' }}
       with:
         path: |

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -122,7 +122,7 @@ runs:
         working_directory: ${{ inputs.working-directory }}
 
     - name: Cache Yarn dependencies
-      uses: SonarSource/gh-action_cache@master # dogfood
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11417-extract-symlink-keeper # TEST ONLY — BUILD-11417
       if: ${{ inputs.cache-yarn == 'true' && inputs.disable-caching != 'true' }}
       with:
         path: |

--- a/cache/action.yml
+++ b/cache/action.yml
@@ -36,7 +36,7 @@ runs:
         echo "::warning:: This action is deprecated and will be removed in future releases." \
           "Please migrate to using the SonarSource/gh-action_cache action directly." >&2
 
-    - uses: SonarSource/gh-action_cache@master # dogfood
+    - uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11417-extract-symlink-keeper # TEST ONLY — BUILD-11417
       id: cache
       with:
         path: ${{ inputs.path }}

--- a/cache/action.yml
+++ b/cache/action.yml
@@ -36,7 +36,7 @@ runs:
         echo "::warning:: This action is deprecated and will be removed in future releases." \
           "Please migrate to using the SonarSource/gh-action_cache action directly." >&2
 
-    - uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+    - uses: SonarSource/gh-action_cache@master # dogfood
       id: cache
       with:
         path: ${{ inputs.path }}

--- a/code-signing/action.yml
+++ b/code-signing/action.yml
@@ -24,7 +24,7 @@ runs:
         echo "JSIGN_CACHE_PATH=/tmp/jsign-cache" >> "$GITHUB_ENV"
 
     - name: Cache code signing tools
-      uses: SonarSource/gh-action_cache@master # dogfood
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11417-extract-symlink-keeper # TEST ONLY — BUILD-11417
       id: tools-cache
       with:
         path: |

--- a/code-signing/action.yml
+++ b/code-signing/action.yml
@@ -24,7 +24,7 @@ runs:
         echo "JSIGN_CACHE_PATH=/tmp/jsign-cache" >> "$GITHUB_ENV"
 
     - name: Cache code signing tools
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@master # dogfood
       id: tools-cache
       with:
         path: |

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -169,7 +169,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Gradle Cache
-      uses: SonarSource/gh-action_cache@master # dogfood
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11417-extract-symlink-keeper # TEST ONLY — BUILD-11417
       if: steps.config-gradle-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -169,7 +169,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Gradle Cache
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@master # dogfood
       if: steps.config-gradle-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -180,7 +180,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache local Maven repository
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@master # dogfood
       if: steps.config-maven-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -180,7 +180,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache local Maven repository
-      uses: SonarSource/gh-action_cache@master # dogfood
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11417-extract-symlink-keeper # TEST ONLY — BUILD-11417
       if: steps.config-maven-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -125,7 +125,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache NPM dependencies
-      uses: SonarSource/gh-action_cache@master # dogfood
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11417-extract-symlink-keeper # TEST ONLY — BUILD-11417
       if: steps.config-npm-completed.outputs.skip != 'true' && inputs.disable-caching != 'true' && inputs.cache-npm == 'true'
       with:
         path: ~/.npm

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -125,7 +125,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache NPM dependencies
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@master # dogfood
       if: steps.config-npm-completed.outputs.skip != 'true' && inputs.disable-caching != 'true' && inputs.cache-npm == 'true'
       with:
         path: ~/.npm

--- a/config-pip/action.yml
+++ b/config-pip/action.yml
@@ -100,7 +100,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache pip dependencies
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@master # dogfood
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-pip/action.yml
+++ b/config-pip/action.yml
@@ -100,7 +100,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache pip dependencies
-      uses: SonarSource/gh-action_cache@master # dogfood
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11417-extract-symlink-keeper # TEST ONLY — BUILD-11417
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}


### PR DESCRIPTION
## Purpose

**TEST ONLY — DO NOT MERGE.** Resurrection of #262 (closed), retargeted to the BUILD-11295 branch of `gh-action_cache` so we can validate the new CI-metrics gate end-to-end through `sonar-dummy` CI on `sonar-dev` runners.

## Changes

8 sub-action `action.yml` files updated:

```
SonarSource/gh-action_cache@bdecdb71... # v1.5.0
  → SonarSource/gh-action_cache@feat/jcarsique/BUILD-11295-metricsFeatureFlag # TEST ONLY — BUILD-11295
```

Affected: `cache`, `build-poetry`, `build-yarn`, `code-signing`, `config-gradle`, `config-maven`, `config-npm`, `config-pip`.

## Validation chain

- end-to-end validator (TEST, DO NOT MERGE): https://github.com/SonarSource/sonar-dummy/pull/592
  - transitive pin (TEST, DO NOT MERGE): https://github.com/SonarSource/ci-github-actions/pull/267 — this PR
  - cache-action gate: https://github.com/SonarSource/gh-action_cache/pull/71
  - runner pre-job hook (deployed with `deploy-dev` label): https://github.com/SonarSource/github-runners-infra/pull/410

## Links

- Jira: https://sonarsource.atlassian.net/browse/BUILD-11295
- Design comment: https://sonarsource.atlassian.net/browse/BUILD-11295?focusedCommentId=919695

----
## Summary by Gitar

- **CI Configuration:**
  - Updated `gh-action_cache` reference across eight sub-actions to use the `feat/jcarsique/BUILD-11417-extract-symlink-keeper` branch.

<sub>This will update automatically on new commits.</sub>