### PR TITLE
BUILD-11438: Make SCA check look for issues on master, main, and active PR branches

### DIFF
--- a/check-sca/action.yml
+++ b/check-sca/action.yml
@@ -85,6 +85,7 @@ runs:
         POLL_TIMEOUT: ${{ inputs.poll-timeout }}
         POLL_INTERVAL: ${{ inputs.poll-interval }}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        PULL_REQUEST: ${{ github.event.pull_request.number || '' }}
         NEXT_URL: ${{ fromJSON(steps.secrets.outputs.vault).NEXT_URL }}
         NEXT_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).NEXT_TOKEN }}
         SQC_US_URL: ${{ fromJSON(steps.secrets.outputs.vault).SQC_US_URL }}

--- a/check-sca/check-sca.sh
+++ b/check-sca/check-sca.sh
@@ -16,6 +16,7 @@
 #   PROJECT_KEY_INPUT             - Explicit project key (additional to discovered keys)
 #   POLL_TIMEOUT                  - Max polling time in seconds (default: 300)
 #   POLL_INTERVAL                 - Seconds between polls (default: 15)
+#   PULL_REQUEST                  - PR number; when set, also checks PR-specific analysis
 #   WORKING_DIRECTORY             - Directory to search for config files (default: .)
 
 set -euo pipefail
@@ -23,7 +24,7 @@ set -euo pipefail
 : "${NEXT_URL:?}" "${NEXT_TOKEN:?}" "${SQC_US_URL:?}" "${SQC_US_TOKEN:?}" "${SQC_EU_URL:?}" "${SQC_EU_TOKEN:?}"
 : "${GITHUB_REPOSITORY:?}" "${GITHUB_OUTPUT:?}"
 : "${POLL_TIMEOUT:=300}" "${POLL_INTERVAL:=15}" "${WORKING_DIRECTORY:=.}"
-: "${PROJECT_KEY_INPUT:=}"
+: "${PROJECT_KEY_INPUT:=}" "${PULL_REQUEST:=}"
 
 readonly ENDGROUP="::endgroup::"
 
@@ -183,11 +184,12 @@ discover_project_keys() {
 
 # Check if the sca_count_any_issue metric exists for a project on a SonarQube instance.
 # Writes "platform_name:project_key" to result_file on success.
-# Args: url token project_key platform_name result_dir
+# Args: url token project_key platform_name result_dir [qualifiers]
+#   qualifiers - optional extra query parameters (e.g. "&pullRequest=123")
 check_sca_metric() {
-  local url="${1:?}" token="${2:?}" project_key="${3:?}" platform_name="${4:?}" result_dir="${5:?}"
+  local url="${1:?}" token="${2:?}" project_key="${3:?}" platform_name="${4:?}" result_dir="${5:?}" qualifiers="${6:-}"
 
-  local api_url="${url}/api/measures/component?component=${project_key}&metricKeys=sca_count_any_issue"
+  local api_url="${url}/api/measures/component?component=${project_key}&metricKeys=sca_count_any_issue${qualifiers}"
 
   local response http_code body
   response=$(curl -s --max-time 10 -w "\n%{http_code}" \
@@ -265,9 +267,24 @@ main() {
         IFS=':' read -r platform_name url_var token_var <<< "$platform_def"
         local url="${!url_var}" token="${!token_var}"
 
+        # Check SQ project's primary branch (no qualifier = SQ default, may differ from main/master)
         echo "  Checking $platform_name / $key ..."
         check_sca_metric "$url" "$token" "$key" "$platform_name" "$result_dir" &
         pids+=($!)
+
+        # Also check well-known branch names explicitly
+        for branch_name in main master; do
+          echo "  Checking $platform_name / $key (branch: $branch_name) ..."
+          check_sca_metric "$url" "$token" "$key" "$platform_name" "$result_dir" "&branch=${branch_name}" &
+          pids+=($!)
+        done
+
+        # Check PR-specific analysis when running on a pull request
+        if [[ -n "${PULL_REQUEST:-}" ]]; then
+          echo "  Checking $platform_name / $key (PR #${PULL_REQUEST}) ..."
+          check_sca_metric "$url" "$token" "$key" "$platform_name" "$result_dir" "&pullRequest=${PULL_REQUEST}" &
+          pids+=($!)
+        fi
       done
     done
 

--- a/spec/check-sca_spec.sh
+++ b/spec/check-sca_spec.sh
@@ -284,6 +284,12 @@ Describe 'check_sca_metric()'
     return 0
   }
 
+  # shellcheck disable=SC2329  # Function invoked indirectly by ShellSpec assertions
+  first_match_contents() {
+    [[ -f "${RESULT_DIR}/match" ]] && cat "${RESULT_DIR}/match"
+    return 0
+  }
+
   BeforeEach 'setup'
   AfterEach 'teardown'
 
@@ -293,7 +299,7 @@ Describe 'check_sca_metric()'
     End
     When call check_sca_metric "https://next.sonarqube.com" "token" "good-key" "next" "$RESULT_DIR"
     The status should be success
-    The contents of file "${RESULT_DIR}/match" should equal "next:good-key"
+    The result of "first_match_contents()" should equal "next:good-key"
   End
 
   It 'returns success when sca_count_any_issue value is 0'
@@ -302,7 +308,7 @@ Describe 'check_sca_metric()'
     End
     When call check_sca_metric "https://next.sonarqube.com" "token" "zero-key" "sqc-eu" "$RESULT_DIR"
     The status should be success
-    The contents of file "${RESULT_DIR}/match" should equal "sqc-eu:zero-key"
+    The result of "first_match_contents()" should equal "sqc-eu:zero-key"
   End
 
   It 'returns failure when measures array is empty'
@@ -328,6 +334,21 @@ Describe 'check_sca_metric()'
     When call check_sca_metric "https://next.sonarqube.com" "token" "bad-key" "next" "$RESULT_DIR"
     The status should be failure
   End
+
+  It 'passes qualifiers to the API URL'
+    Mock curl
+      # Capture the URL argument (last positional param to curl)
+      for arg; do :; done
+      if echo "$arg" | grep -q 'pullRequest=42'; then
+        printf '{"component":{"measures":[{"metric":"sca_count_any_issue","value":"1"}]}}\n200'
+      else
+        printf '{"component":{"measures":[]}}\n200'
+      fi
+    End
+    When call check_sca_metric "https://next.sonarqube.com" "token" "pr-key" "next" "$RESULT_DIR" "&pullRequest=42"
+    The status should be success
+    The result of "first_match_contents()" should equal "next:pr-key"
+  End
 End
 
 Describe 'main() success'
@@ -348,6 +369,58 @@ Describe 'main() success'
     The output should include "for project key: SonarSource_test-repo"
     The contents of file "$GITHUB_OUTPUT" should include "sca-verified=true"
     The contents of file "$GITHUB_OUTPUT" should include "project-key=SonarSource_test-repo"
+  End
+End
+
+Describe 'main() success via branch analysis'
+  Mock curl
+    # Return SCA data only when branch=main is in the URL
+    for arg; do :; done
+    if echo "$arg" | grep -q 'branch=main'; then
+      printf '{"component":{"measures":[{"metric":"sca_count_any_issue","value":"4"}]}}\n200'
+    else
+      printf '{"component":{"measures":[]}}\n200'
+    fi
+  End
+
+  BeforeEach 'setup_main'
+  AfterEach 'teardown_main'
+
+  It 'succeeds when SCA metric is found on a named branch'
+    export PROJECT_KEY_INPUT="SonarSource_test-repo"
+    export GITHUB_REPOSITORY="SonarSource/test-repo"
+    export POLL_TIMEOUT="300"
+    When run script check-sca/check-sca.sh
+    The status should be success
+    The output should include "SCA verified on"
+    The contents of file "$GITHUB_OUTPUT" should include "sca-verified=true"
+  End
+End
+
+Describe 'main() success via PR analysis'
+  Mock curl
+    # Return SCA data only when pullRequest= is in the URL
+    for arg; do :; done
+    if echo "$arg" | grep -q 'pullRequest='; then
+      printf '{"component":{"measures":[{"metric":"sca_count_any_issue","value":"2"}]}}\n200'
+    else
+      printf '{"component":{"measures":[]}}\n200'
+    fi
+  End
+
+  BeforeEach 'setup_main'
+  AfterEach 'teardown_main'
+
+  It 'succeeds when SCA metric is found only on PR analysis'
+    export PROJECT_KEY_INPUT="SonarSource_test-repo"
+    export GITHUB_REPOSITORY="SonarSource/test-repo"
+    export PULL_REQUEST="42"
+    export POLL_TIMEOUT="300"
+    When run script check-sca/check-sca.sh
+    The status should be success
+    The output should include "SCA verified on"
+    The output should include "PR #42"
+    The contents of file "$GITHUB_OUTPUT" should include "sca-verified=true"
   End
 End
 


### PR DESCRIPTION
## Context

Full details in [BUILD-11438](https://sonarsource.atlassian.net/browse/BUILD-11438)

## What Changed?

The following branches will now be inspected in parallel for a non-null value of `sca_count_any_issue` on the consumer repo:
- `master`
- `main`
- Branch of the Active PR
- Branch that is set as a SonarQube project's primary branch (already scanned)

[BUILD-11438]: https://sonarsource.atlassian.net/browse/BUILD-11438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ