### PR TITLE
PREQ-5981 Skip release/sign Maven profiles when deploy is false

### DIFF
--- a/build-maven/build.sh
+++ b/build-maven/build.sh
@@ -162,14 +162,14 @@ build_maven() {
   echo "::group::Maven build"
   if is_default_branch || is_maintenance_branch; then
     echo "======= Build and analyze $GITHUB_REF_NAME ======="
-    if [[ "${RUN_SHADOW_SCANS}" != "true" ]]; then
+    if should_deploy; then
       maven_command_args+=("-Prelease,sign")
     fi
   elif is_pull_request; then
     echo "======= Build and analyze pull request $PULL_REQUEST ($GITHUB_HEAD_REF) ======="
   elif is_dogfood_branch; then
     echo "======= Build dogfood branch $GITHUB_REF_NAME ======="
-    if [[ "${RUN_SHADOW_SCANS}" != "true" ]]; then
+    if should_deploy; then
       maven_command_args+=("-Prelease")
     fi
   elif is_long_lived_feature_branch; then

--- a/spec/build-maven_spec.sh
+++ b/spec/build-maven_spec.sh
@@ -376,9 +376,19 @@ Describe 'build_maven()'
       The line 6 should include "Build and analyze def_main"
       The line 7 should start with "Maven command: mvn install"
       The line 8 should start with "mvn install"
-      The line 8 should include "-Pcoverage -Prelease,sign"
+      The line 8 should include "-Pcoverage"
       The line 9 should equal "::endgroup::"
       The line 10 should start with "orchestrate_sonar_platforms"
+    End
+
+    It 'excludes release and sign profiles when DEPLOY is false'
+      export DEPLOY="false"
+
+      When call build_maven
+      The status should be success
+      The output should include "Maven command: mvn install -Pcoverage"
+      The output should not include "release"
+      The output should not include "sign"
     End
   End
 
@@ -512,8 +522,17 @@ Describe 'build_maven()'
       The line 5 should include "Build dogfood branch dogfood-on-something"
       The line 6 should start with "Maven command: mvn install"
       The line 7 should start with "mvn install"
-      The line 7 should include "-Prelease"
       The line 8 should equal "::endgroup::"
+    End
+
+    It 'excludes release and sign profiles when DEPLOY is false'
+      export DEPLOY="false"
+
+      When call build_maven
+      The status should be success
+      The output should include "Maven command: mvn install"
+      The output should not include "release"
+      The output should not include "sign"
     End
   End
 


### PR DESCRIPTION
## Context

`sonar-security` uses PGP signing (`-Psign`) plus [gh-action_azure-artifact-signing](https://github.com/SonarSource/gh-action_azure-artifact-signing) setup for `jsign-maven-plugin`. The Unit Tests job uses `deploy: false` but previously still received `-Prelease,sign`, causing unnecessary signing and jsign failures without Azure env vars.

## Summary

- Gate `-Prelease,sign` (default/maintenance) and `-Prelease` (dogfood) on `should_deploy()` in `build-maven/build.sh`
- When `deploy: false`, Maven runs `install` with `-Pcoverage` only — same behaviour as shadow scans (no signing)
- Fixes `sonar-security` **Unit Tests and Sonar Analysis** failing after BUILD-11035 Azure signing migration ([failed run](https://github.com/SonarSource/sonar-security/actions/runs/26089539704))

## Test plan

- [x] `shellspec spec/build-maven_spec.sh` (33 examples)
- [ ] After release: confirm `sonar-security` Unit Tests job on `master` passes with existing `deploy: false`

## Links

- Jira: https://sonarsource.atlassian.net/browse/PREQ-5981
- Slack: https://sonarsource.slack.com/archives/C0455GD6K8Q/p1779185354979139