### PR TITLE
BUILD-11458 Add release channel pointer JSON schema

### DIFF
--- a/update-release-channel/schema/README.md
+++ b/update-release-channel/schema/README.md
@@ -1,0 +1,23 @@
+# Release channel pointer schema
+
+JSON Schema for the per-channel pointer file written by the `update-release-channel` GitHub Action to
+`s3://downloads-cdn-eu-central-1-prod/<prefix>/<product>/<channel>.json`.
+
+## Versioning
+
+The schema version lives in the **filename** (`v1.json`, `v2.json`, ...) and in lockstep in the `schemaVersion` field
+inside the JSON document.
+
+A new file (e.g. `v2.json`) is introduced **only** when existing fields are removed, renamed, or changed in a
+non-backwards-compatible way. Additive changes (new optional fields) ship as updates to `v1.json` — consumers MUST
+ignore unknown fields.
+
+## v1 fields
+
+| Field           | Type    | Required | Description                                                              |
+| --------------- | ------- | -------- | ------------------------------------------------------------------------ |
+| `schemaVersion` | integer | yes      | Const `1`.                                                               |
+| `version`       | string  | yes      | Currently published version on this channel (e.g. `0.9.0.977`).          |
+| `updatedAt`     | string  | yes      | ISO-8601 UTC timestamp at which the channel was promoted to `version`.   |
+
+`additionalProperties: true` — unknown fields are accepted and MUST be ignored by older consumers.

--- a/update-release-channel/schema/v1.json
+++ b/update-release-channel/schema/v1.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/SonarSource/ci-github-actions/master/update-release-channel/schema/v1.json",
+  "title": "Release Channel Pointer (v1)",
+  "description": "Per-channel release pointer JSON. Consumers MUST ignore unknown fields.",
+  "type": "object",
+  "required": ["schemaVersion", "version", "updatedAt"],
+  "additionalProperties": true,
+  "properties": {
+    "schemaVersion": {
+      "description": "Schema version. Bumped only on non-backwards-compatible changes; additive evolution stays at 1.",
+      "type": "integer",
+      "const": 1
+    },
+    "version": {
+      "description": "Currently published version on this channel (e.g. \"0.9.0.977\", \"2026.1.0\").",
+      "type": "string",
+      "minLength": 1
+    },
+    "updatedAt": {
+      "description": "ISO-8601 / RFC 3339 UTC timestamp at which this channel was promoted to point at `version`.",
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$"
+    }
+  }
+}


### PR DESCRIPTION
BUILD-11458 — first task of epic [BUILD-11447](https://sonarsource.atlassian.net/browse/BUILD-11447) (update-release-channel action for binary release channel pointers).

## What

Adds the JSON Schema (draft-07) for the per-channel pointer JSON that the upcoming `update-release-channel` action will write to `s3://downloads-cdn-eu-central-1-prod/<prefix>/<product>/<channel>.json`.

- `update-release-channel/schema/v1.json` — schema definition
- `update-release-channel/schema/README.md` — versioning policy and field reference

## Schema shape

| Field | Type | Required |
| --- | --- | --- |
| `schemaVersion` | integer (const `1`) | yes |
| `version` | string | yes |
| `updatedAt` | ISO-8601 / RFC 3339 UTC string | yes |

`additionalProperties: true` — consumers MUST ignore unknown fields. This lets us add optional fields later (e.g. per-platform artifact URLs, signature metadata) without bumping the schema version. A new file (`v2.json`) is only introduced for non-backwards-compatible changes; the in-document `schemaVersion` stays in lockstep with the filename.

## Path convention

Action directory lives at the repo root (`update-release-channel/`) to match the existing convention in this repo (`promote/`, `cache/`, `build-gradle/`, ...). The spec mentioned `.github/actions/update-release-channel/` but `CONTRIBUTE.md` documents top-level placement.

## Validation

No sample fixtures are checked in. Validation against real action outputs lands with:
- Writer unit tests — [BUILD-11460](https://sonarsource.atlassian.net/browse/BUILD-11460)
- Integration test workflow — [BUILD-11461](https://sonarsource.atlassian.net/browse/BUILD-11461)

Both will pipe the dry-run JSON body through `check-jsonschema` against `v1.json`.

## Not in scope

Action code, workflows, README for the action, and pilot wiring — those land in the follow-up tickets (BUILD-11459 through BUILD-11464). Draft until those are at least in flight.

[BUILD-11447]: https://sonarsource.atlassian.net/browse/BUILD-11447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11460]: https://sonarsource.atlassian.net/browse/BUILD-11460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ