### PR TITLE
BUILD-11460: Write S3 body via tempfile instead of /dev/stdin

### DIFF
--- a/.github/workflows/test-shell-scripts.yml
+++ b/.github/workflows/test-shell-scripts.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./config-npm
-      - uses: step-security/mise-action@c7396e2a2a4ad1ea43abee3317d964292da354ae # v4.0.1
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.9
           tool_versions: |

--- a/spec/update-release-channel_spec.sh
+++ b/spec/update-release-channel_spec.sh
@@ -94,16 +94,16 @@ Describe 'update-release-channel/update-release-channel.sh'
   Describe 'non-dry-run path'
     Mock aws
       body_file=""
-      while [ "$#" -gt 0 ]; do
-        if [ "$1" = "--body" ]; then
+      while [[ "$#" -gt 0 ]]; do
+        if [[ "$1" == "--body" ]]; then
           body_file="$2"
           break
         fi
         shift
       done
-      [ -n "$body_file" ] || exit 1
-      [ "$body_file" != "/dev/stdin" ] || exit 1
-      [ -f "$body_file" ] || exit 1
+      [[ -n "$body_file" ]] || exit 1
+      [[ "$body_file" != "/dev/stdin" ]] || exit 1
+      [[ -f "$body_file" ]] || exit 1
       grep -q '"version":"0.9.0.977"' "$body_file" || exit 1
       echo '{"ServerSideEncryption":"AES256"}'
     End

--- a/spec/update-release-channel_spec.sh
+++ b/spec/update-release-channel_spec.sh
@@ -15,9 +15,9 @@ setup() {
 }
 
 extract_body() {
-  # The dry-run line ends with `--body - <<< '<json>'`.
+  # The dry-run body line includes the generated JSON payload.
   local stdout_file="$1"
-  grep -o "<<< '[^']*'" "$stdout_file" | sed -e "s/<<< '//" -e "s/'$//"
+  sed -n 's/^Dry-run body: //p' "$stdout_file"
   return 0
 }
 
@@ -93,7 +93,18 @@ Describe 'update-release-channel/update-release-channel.sh'
 
   Describe 'non-dry-run path'
     Mock aws
-      cat > /dev/null
+      body_file=""
+      while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--body" ]; then
+          body_file="$2"
+          break
+        fi
+        shift
+      done
+      [ -n "$body_file" ] || exit 1
+      [ "$body_file" != "/dev/stdin" ] || exit 1
+      [ -f "$body_file" ] || exit 1
+      grep -q '"version":"0.9.0.977"' "$body_file" || exit 1
       echo '{"ServerSideEncryption":"AES256"}'
     End
 

--- a/update-release-channel/action.yml
+++ b/update-release-channel/action.yml
@@ -43,7 +43,7 @@ runs:
 
     - name: Install AWS CLI
       if: inputs.dryRun != 'true'
-      uses: step-security/mise-action@c7396e2a2a4ad1ea43abee3317d964292da354ae # v4.0.1
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
         version: 2026.5.9
         mise_toml: |

--- a/update-release-channel/update-release-channel.sh
+++ b/update-release-channel/update-release-channel.sh
@@ -36,10 +36,15 @@ UPDATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 BODY="$(jq -cn --arg v "$VERSION" --arg t "$UPDATED_AT" '{schemaVersion:1, version:$v, updatedAt:$t}')"
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  echo "Dry-run: aws s3api put-object --bucket $BUCKET --key $KEY --cache-control max-age=60 --content-type application/json --body - <<< '$BODY'"
+  echo "Dry-run: aws s3api put-object --bucket $BUCKET --key $KEY --cache-control max-age=60 --content-type application/json --body <generated-json-file>"
+  echo "Dry-run body: $BODY"
 else
-  printf '%s' "$BODY" | aws s3api put-object \
-    --bucket "$BUCKET" --key "$KEY" --body /dev/stdin \
+  BODY_FILE="$(mktemp)"
+  trap 'rm -f "$BODY_FILE"' EXIT
+  printf '%s' "$BODY" > "$BODY_FILE"
+
+  aws s3api put-object \
+    --bucket "$BUCKET" --key "$KEY" --body "$BODY_FILE" \
     --cache-control "max-age=60" --content-type "application/json" > /dev/null
   echo "Wrote $URL"
 fi


### PR DESCRIPTION
BUILD-11460 follow-up to PR #274.

## Why

The first real consumer of `update-release-channel@master` failed
because AWS CLI v2.34.55 (pinned via mise in `action.yml`) rejects
`--body /dev/stdin`:

```
aws: [ERROR]: An error occurred (ParamValidation):
Error parsing parameter '--body': Blob values must be a path to a file.
```

The CLI's blob validator wants a regular file path, not a character
device. Failing run for reference:
https://github.com/SonarSource/sonar-dummy-gradle-oss/actions/runs/26578122174

The original spec in BUILD-11460 prescribed `--body /dev/stdin`, but
that contract turns out not to hold against the pinned CLI. This PR
intentionally deviates on that one point.

## What changed

- `update-release-channel/update-release-channel.sh`
  - Write the JSON body to a `mktemp`-backed tempfile and pass that
    path to `--body`. Clean up via `trap` on exit.
  - Emit the body on a dedicated `Dry-run body:` line in dry-run mode
    so consumers (and the spec helper) can read it without grepping
    for a heredoc that no longer exists.
- `spec/update-release-channel_spec.sh`
  - Harden the `aws` mock for the non-dry-run case so this regression
    can't recur silently: assert `--body` is present, is not
    `/dev/stdin`, points to an existing file, and that file contains
    the expected version string.
  - Update `extract_body` for the new dry-run output.

## Verification

- `mise exec -- shellspec spec/update-release-channel_spec.sh --shell bash` → 8/8 pass
- `mise exec -- shellcheck update-release-channel/update-release-channel.sh spec/update-release-channel_spec.sh` → clean

----
## Summary by Gitar

- **Tooling updates:**
  - Aligned `mise-action` with repository conventions by switching from `step-security/mise-action` to `jdx/mise-action` in `action.yml` and `test-shell-scripts.yml`.

<sub>This will update automatically on new commits.</sub>