### PR TITLE
BUILD-11461: Add integration test workflow for update-release-channel

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,3 +3,4 @@ self-hosted-runner:
   labels:
     - warp-custom-ubuntu-24-04
     - github-windows-latest-s
+    - sonar-xs

--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -27,11 +27,16 @@ jobs:
       - name: Assert key output
         run: |
           [[ "${{ steps.urc.outputs.key }}" == "Distribution/test-fixture/stable.json" ]]
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.5.9
+          tool_versions: |
+            pipx 1.12.0
+            pipx:check-jsonschema 0.37.2
       - name: Validate body against schema/v1.json
         env:
           BODY: ${{ steps.urc.outputs.body }}
         run: |
-          pip install --quiet check-jsonschema==0.37.2
           printf '%s' "$BODY" > /tmp/body.json
           check-jsonschema --schemafile update-release-channel/schema/v1.json /tmp/body.json
 

--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -95,18 +95,3 @@ jobs:
       - name: Assert custom prefix used in key
         run: |
           [[ "${{ steps.urc.outputs.key }}" == "NotDistribution/test-fixture/stable.json" ]]
-
-  test-urc:
-    if: always()
-    needs:
-      - test-urc-happy-path
-      - test-urc-invalid-product
-      - test-urc-invalid-channel
-      - test-urc-custom-prefix
-    runs-on: sonar-xs
-    permissions:
-      contents: read
-    steps:
-      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
-        with:
-          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -1,0 +1,113 @@
+---
+name: Test update-release-channel
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - master
+      - branch-*
+  workflow_dispatch:
+
+jobs:
+  test-urc-happy-path:
+    runs-on: warp-custom-ubuntu-24-04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Update release channel (dry-run, happy path)
+        id: urc
+        uses: ./update-release-channel
+        with:
+          version: '0.0.0-test'
+          channel: 'stable'
+          product: 'test-fixture'
+          dryRun: 'true'
+      - name: Assert key output
+        run: |
+          [[ "${{ steps.urc.outputs.key }}" == "Distribution/test-fixture/stable.json" ]]
+      - name: Validate body against schema/v1.json
+        env:
+          BODY: ${{ steps.urc.outputs.body }}
+        run: |
+          pip install --quiet check-jsonschema==0.37.2
+          printf '%s' "$BODY" > /tmp/body.json
+          check-jsonschema --schemafile update-release-channel/schema/v1.json /tmp/body.json
+
+  test-urc-invalid-product:
+    runs-on: warp-custom-ubuntu-24-04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Update release channel (invalid product)
+        id: urc
+        continue-on-error: true
+        uses: ./update-release-channel
+        with:
+          version: '0.0.0-test'
+          channel: 'stable'
+          product: '../escape'
+          dryRun: 'true'
+      - name: Assert action failed
+        run: |
+          [[ "${{ steps.urc.outcome }}" == "failure" ]]
+
+  test-urc-invalid-channel:
+    runs-on: warp-custom-ubuntu-24-04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Update release channel (invalid channel)
+        id: urc
+        continue-on-error: true
+        uses: ./update-release-channel
+        with:
+          version: '0.0.0-test'
+          channel: 'foo'
+          dryRun: 'true'
+      - name: Assert action failed
+        run: |
+          [[ "${{ steps.urc.outcome }}" == "failure" ]]
+
+  test-urc-custom-prefix:
+    runs-on: warp-custom-ubuntu-24-04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Update release channel (custom prefix, warns but succeeds)
+        id: urc
+        uses: ./update-release-channel
+        with:
+          version: '0.0.0-test'
+          channel: 'stable'
+          product: 'test-fixture'
+          prefix: 'NotDistribution'
+          dryRun: 'true'
+      - name: Assert custom prefix used in key
+        run: |
+          [[ "${{ steps.urc.outputs.key }}" == "NotDistribution/test-fixture/stable.json" ]]
+
+  test-urc:
+    if: always()
+    needs:
+      - test-urc-happy-path
+      - test-urc-invalid-product
+      - test-urc-invalid-channel
+      - test-urc-custom-prefix
+    runs-on: warp-custom-ubuntu-24-04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./config-npm
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.5.9
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -20,10 +20,10 @@ jobs:
         id: urc
         uses: ./update-release-channel
         with:
-          version: '0.0.0-test'
-          channel: 'stable'
-          product: 'test-fixture'
-          dryRun: 'true'
+          version: 0.0.0-test
+          channel: stable
+          product: test-fixture
+          dryRun: true
       - name: Assert key output
         run: |
           [[ "${{ steps.urc.outputs.key }}" == "Distribution/test-fixture/stable.json" ]]
@@ -48,10 +48,10 @@ jobs:
         continue-on-error: true
         uses: ./update-release-channel
         with:
-          version: '0.0.0-test'
-          channel: 'stable'
-          product: '../escape'
-          dryRun: 'true'
+          version: 0.0.0-test
+          channel: stable
+          product: ../escape
+          dryRun: true
       - name: Assert action failed
         run: |
           [[ "${{ steps.urc.outcome }}" == "failure" ]]
@@ -67,10 +67,10 @@ jobs:
         continue-on-error: true
         uses: ./update-release-channel
         with:
-          version: '0.0.0-test'
-          channel: 'foo'
-          product: 'test-fixture'
-          dryRun: 'true'
+          version: 0.0.0-test
+          channel: foo
+          product: test-fixture
+          dryRun: true
       - name: Assert action failed
         run: |
           [[ "${{ steps.urc.outcome }}" == "failure" ]]
@@ -85,11 +85,11 @@ jobs:
         id: urc
         uses: ./update-release-channel
         with:
-          version: '0.0.0-test'
-          channel: 'stable'
-          product: 'test-fixture'
-          prefix: 'NotDistribution'
-          dryRun: 'true'
+          version: 0.0.0-test
+          channel: stable
+          product: test-fixture
+          prefix: NotDistribution
+          dryRun: true
       - name: Assert custom prefix used in key
         run: |
           [[ "${{ steps.urc.outputs.key }}" == "NotDistribution/test-fixture/stable.json" ]]

--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-urc-happy-path:
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     permissions:
       contents: read
     steps:
@@ -36,7 +36,7 @@ jobs:
           check-jsonschema --schemafile update-release-channel/schema/v1.json /tmp/body.json
 
   test-urc-invalid-product:
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     permissions:
       contents: read
     steps:
@@ -55,7 +55,7 @@ jobs:
           [[ "${{ steps.urc.outcome }}" == "failure" ]]
 
   test-urc-invalid-channel:
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     permissions:
       contents: read
     steps:
@@ -73,7 +73,7 @@ jobs:
           [[ "${{ steps.urc.outcome }}" == "failure" ]]
 
   test-urc-custom-prefix:
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     permissions:
       contents: read
     steps:
@@ -98,7 +98,7 @@ jobs:
       - test-urc-invalid-product
       - test-urc-invalid-channel
       - test-urc-custom-prefix
-    runs-on: warp-custom-ubuntu-24-04
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -30,9 +30,6 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.9
-          tool_versions: |
-            pipx 1.12.0
-            pipx:check-jsonschema 0.37.2
       - name: Validate body against schema/v1.json
         env:
           BODY: ${{ steps.urc.outputs.body }}
@@ -72,6 +69,7 @@ jobs:
         with:
           version: '0.0.0-test'
           channel: 'foo'
+          product: 'test-fixture'
           dryRun: 'true'
       - name: Assert action failed
         run: |

--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -107,7 +107,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -105,14 +105,9 @@ jobs:
       - test-urc-custom-prefix
     runs-on: sonar-xs
     permissions:
-      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./config-npm
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          version: 2026.5.9
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,8 @@ jfrog-cli = "2.96.0"
 node = "24.15.0"
 python = "3.14"
 "npm:markdownlint-cli" = "0.39.0"
+pipx = "1.12.0"
+"pipx:check-jsonschema" = "0.37.2"
 
 [env]
 JFROG_CLI_ENV_EXCLUDE = "*password*;*secret*;*key*;*token*;*auth*;*credential*"

--- a/spec/update-release-channel_spec.sh
+++ b/spec/update-release-channel_spec.sh
@@ -34,6 +34,7 @@ Describe 'update-release-channel/update-release-channel.sh'
       The contents of file "$GITHUB_OUTPUT" should include "bucket=downloads-cdn-eu-central-1-prod"
       The contents of file "$GITHUB_OUTPUT" should include "key=Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.json"
+      The contents of file "$GITHUB_OUTPUT" should include "body={"
       The contents of file "$GITHUB_STEP_SUMMARY" should include "update-release-channel"
       The contents of file "$GITHUB_STEP_SUMMARY" should include "Distribution/sonarqube-cli/latest.json"
     End
@@ -114,6 +115,7 @@ Describe 'update-release-channel/update-release-channel.sh'
       The status should be success
       The output should include "Wrote https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.json"
+      The contents of file "$GITHUB_OUTPUT" should include "body={"
     End
   End
 End

--- a/update-release-channel/action.yml
+++ b/update-release-channel/action.yml
@@ -31,6 +31,11 @@ outputs:
   url:
     description: Public URL of the channel pointer (e.g. `https://binaries.sonarsource.com/Distribution/<product>/<channel>.json`).
     value: ${{ steps.update.outputs.url }}
+  body:
+    description: |
+      The JSON body written (or that would be written) to S3. Always set.
+      Useful for schema validation and debugging in dry-run mode.
+    value: ${{ steps.update.outputs.body }}
 
 runs:
   using: composite

--- a/update-release-channel/update-release-channel.sh
+++ b/update-release-channel/update-release-channel.sh
@@ -53,6 +53,7 @@ fi
   echo "bucket=$BUCKET"
   echo "key=$KEY"
   echo "url=$URL"
+  echo "body=$BODY"
 } >> "${GITHUB_OUTPUT:?}"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then


### PR DESCRIPTION
## BUILD-11461

Adds end-to-end CI coverage for the `update-release-channel` action and exposes the JSON body as a new action output.

### Changes

**`.github/workflows/test-update-release-channel.yml`** (new)

Four integration test jobs that invoke the action with `dryRun: true`, plus a `test-urc` alls-green gate as the required check:

| Job | Inputs | Assertion |
|-----|--------|-----------|
| `test-urc-happy-path` | `channel: stable`, `product: test-fixture` | `key` output == `Distribution/test-fixture/stable.json`; body validates against `schema/v1.json` via `check-jsonschema` |
| `test-urc-invalid-product` | `product: ../escape` | `outcome == failure` |
| `test-urc-invalid-channel` | `channel: foo` | `outcome == failure` |
| `test-urc-custom-prefix` | `prefix: NotDistribution` | exit 0; `key` uses the custom prefix |

**`update-release-channel/action.yml`**

Adds a `body` output (always set, sourced from `steps.update.outputs.body`) so consumers and tests can read the JSON payload without re-running the script.

**`update-release-channel/update-release-channel.sh`**

Writes `body=$BODY` to `GITHUB_OUTPUT` alongside the existing `bucket`, `key`, and `url` outputs.

**`spec/update-release-channel_spec.sh`**

Extends the existing dry-run and non-dry-run ShellSpec tests to assert `body={` is present in `GITHUB_OUTPUT`.

### Notes

- The `body` output is exposed on both dry-run and live paths — no secrets, just the version + timestamp JSON.
- The `test-urc-invalid-*` jobs use `continue-on-error: true` on the action step and assert `outcome == failure` in the next step, so a regression (action unexpectedly succeeding) fails the job.
- After this workflow is green on master, the `v1` tag and `v1` major-version branch will be cut as the final step of BUILD-11461.

----
## Summary by Gitar

- **CI Configuration:**
  - Migrated `check-jsonschema` installation to `mise.toml` to streamline environment setup.
  - Removed redundant `pipx` tool versioning from `.github/workflows/test-update-release-channel.yml`.
- **Test Improvements:**
  - Added an explicit `product: 'test-fixture'` input to the `test-urc-invalid-channel` integration test for consistency.

<sub>This will update automatically on new commits.</sub>