### PR TITLE
BUILD-10781 Bump gh-action_cache to v1.6.0 (Node 24 runtime)

### DIFF
--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -23,4 +23,4 @@ jobs:
     environment: sca-checking
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: SonarSource/ci-github-actions/check-sca@master
+      - uses: SonarSource/ci-github-actions/check-sca@0b6af4d68192fa1c371e9327b5f0513949b39119 # master

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run IRIS Analysis
-        uses: SonarSource/unified-dogfooding-actions/run-iris@v1
+        uses: SonarSource/unified-dogfooding-actions/run-iris@54cee68ff08f10645c757675c59d232063e0b947 # 1.0.0
         with:
           primary_project_key: SonarSource_ci-github-actions
           primary_platform: SQC-EU

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -111,7 +111,7 @@ runs:
       with:
         host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
     - name: Cache local Poetry cache
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ github.workspace }}/${{ inputs.poetry-cache-dir }}

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -122,7 +122,7 @@ runs:
         working_directory: ${{ inputs.working-directory }}
 
     - name: Cache Yarn dependencies
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
       if: ${{ inputs.cache-yarn == 'true' && inputs.disable-caching != 'true' }}
       with:
         path: |

--- a/cache/action.yml
+++ b/cache/action.yml
@@ -36,7 +36,7 @@ runs:
         echo "::warning:: This action is deprecated and will be removed in future releases." \
           "Please migrate to using the SonarSource/gh-action_cache action directly." >&2
 
-    - uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+    - uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
       id: cache
       with:
         path: ${{ inputs.path }}

--- a/code-signing/action.yml
+++ b/code-signing/action.yml
@@ -24,7 +24,7 @@ runs:
         echo "JSIGN_CACHE_PATH=/tmp/jsign-cache" >> "$GITHUB_ENV"
 
     - name: Cache code signing tools
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
       id: tools-cache
       with:
         path: |

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -169,7 +169,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Gradle Cache
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
       if: steps.config-gradle-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -180,7 +180,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache local Maven repository
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
       if: steps.config-maven-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -125,7 +125,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache NPM dependencies
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
       if: steps.config-npm-completed.outputs.skip != 'true' && inputs.disable-caching != 'true' && inputs.cache-npm == 'true'
       with:
         path: ~/.npm

--- a/config-pip/action.yml
+++ b/config-pip/action.yml
@@ -100,7 +100,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache pip dependencies
-      uses: SonarSource/gh-action_cache@bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0
+      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}


### PR DESCRIPTION
## Why

GitHub deprecates Node 20 on Actions runners starting **2026-06-02** (full removal by Fall 2026). `gh-action_cache` v1.6.0 ([SonarSource/gh-action_cache#75](https://github.com/SonarSource/gh-action_cache/pull/75)) migrates the four JS sub-actions to `using: node24`. The 8 composites in this repo pin `gh-action_cache` by SHA, so they need an explicit bump to pick up the Node 24 runtime — otherwise every consumer of `ci-github-actions/*` (effectively the org's CI fleet) keeps executing the Node 20 sub-actions until the bump lands.

Linked ticket: [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781).

## What changed

### 8 composites bumped to `gh-action_cache@a7d13cd # v1.6.0`

- `build-poetry/action.yml`
- `build-yarn/action.yml`
- `cache/action.yml` (the deprecated wrapper)
- `code-signing/action.yml`
- `config-gradle/action.yml`
- `config-maven/action.yml`
- `config-npm/action.yml`
- `config-pip/action.yml`

SHA: `bdecdb711dbf5939d90c58d0fcadbfd0749301fa # v1.5.0` → `a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0`.

### Carried over from Renovate PR #271 (which this supersedes)

- `.github/workflows/check-sca.yml` — pin `SonarSource/ci-github-actions/check-sca` to the current master SHA (`0b6af4d`) instead of `@master`.
- `.github/workflows/unified-dogfooding.yml` — pin `SonarSource/unified-dogfooding-actions/run-iris` to the `1.0.0` release SHA (`54cee68`) instead of `@v1`.

These are byte-for-byte identical to PR #271 — preserved so we can close that PR without losing review work.

## Supersedes

Closes #271. Renovate had only bumped `gh-action_cache` to v1.5.1 — pre-Node-24. Rolling everything into one PR lets the regression suite exercise the full Node 24 migration in one go.

## Verification

- `pre-commit` clean on all touched files (`yamllint`, `actionlint`, validate workflows).
- All 8 SHA pins resolve to the same v1.6.0 commit — verified via `grep`.
- CI on this PR runs the composites against the Node 24 sub-actions; that's the real signal.

## Downstream

Once merged, the Node 20 → Node 24 cascade reaches every repo that consumes `ci-github-actions/*`. Remaining BUILD-10781 follow-ups (separate tickets): `vault-action-wrapper`, `jfrog-setup-wrapper`, `gh-action_slack-notify`, `gh-action_jira-create`, `unified-dogfooding-actions/run-iris`.


[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ