### PR TITLE
BUILD-10781 Bump vault-action-wrapper to 3.5.0

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -18,7 +18,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           secrets: |
             development/kv/data/jira user | JIRA_USER;

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -17,7 +17,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -17,7 +17,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -20,7 +20,7 @@ jobs:
           || github.event.review.state == 'approved')
     steps:
       - id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           secrets: |
             development/github/token/{REPO_OWNER_NAME_DASH}-jira token | GITHUB_TOKEN;

--- a/.github/workflows/test-shell-scripts.yml
+++ b/.github/workflows/test-shell-scripts.yml
@@ -36,7 +36,7 @@ jobs:
           ./run_shell_tests.sh
       - name: Vault
         id: secrets
-        uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+        uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
         with:
           secrets: |
             development/kv/data/sonarcloud url | SONAR_URL;

--- a/build-gradle/action.yml
+++ b/build-gradle/action.yml
@@ -129,7 +129,7 @@ runs:
       run: |
         echo "ARTIFACTORY_DEPLOYER_ROLE=${ARTIFACTORY_DEPLOYER_ROLE}" >> "$GITHUB_ENV"
 
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       id: secrets
       with:
         # yamllint disable rule:line-length

--- a/build-maven/action.yml
+++ b/build-maven/action.yml
@@ -151,7 +151,7 @@ runs:
         echo "SONARSOURCE_REPOSITORY_URL=${ARTIFACTORY_URL}/sonarsource" >> "$GITHUB_ENV"
       # yamllint enable rule:line-length
 
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       id: secrets
       with:
         # yamllint disable rule:line-length

--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -135,7 +135,7 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         disable-caching: ${{ inputs.cache-npm != 'true' && 'true' || inputs.disable-caching }}
 
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       id: secrets
       # yamllint disable rule:line-length
       with:

--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -120,7 +120,7 @@ runs:
     - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       with:
         version: 2026.5.9
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       id: secrets
       # yamllint disable rule:line-length
       with:

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -130,7 +130,7 @@ runs:
         key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
         restore-keys: yarn-${{ runner.os }}-
 
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       id: secrets
       # yamllint disable rule:line-length
       with:

--- a/check-sca/action.yml
+++ b/check-sca/action.yml
@@ -43,7 +43,7 @@ runs:
         ACTION_PATH_CHECK_SCA="${{ github.action_path }}"
         echo "ACTION_PATH_CHECK_SCA=$ACTION_PATH_CHECK_SCA" >> "$GITHUB_ENV"
 
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       id: secrets
       continue-on-error: true
       with:

--- a/code-signing/action.yml
+++ b/code-signing/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Get DigiCert secrets from Vault
       id: secrets
-      uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+      uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       with:
         secrets: |
           development/kv/data/sign/digicert apikey | SM_API_KEY;

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -91,7 +91,7 @@ runs:
           (github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader') }}
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       if: steps.config-gradle-completed.outputs.skip != 'true'
       id: secrets
       with:

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -92,7 +92,7 @@ runs:
           (github.event.repository.visibility == 'public' && 'public-reader' || 'private-reader') }}
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       if: steps.config-maven-completed.outputs.skip != 'true'
       id: secrets
       with:

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -92,7 +92,7 @@ runs:
       with:
         version: 2026.3.7
 
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       if: steps.config-npm-completed.outputs.skip != 'true'
       id: secrets
       with:

--- a/config-pip/action.yml
+++ b/config-pip/action.yml
@@ -73,7 +73,7 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
 
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       id: secrets
       with:
         secrets: |

--- a/get-build-number/action.yml
+++ b/get-build-number/action.yml
@@ -52,7 +52,7 @@ runs:
         enableCrossOsArchive: true
 
     # Otherwise, increment the build number
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       id: secrets
       if: steps.from-env.outputs.skip != 'true' && steps.current-build-number.outputs.cache-hit != 'true'
       with:

--- a/promote/action.yml
+++ b/promote/action.yml
@@ -51,7 +51,7 @@ runs:
     - uses: ./.actions/get-build-number
       with:
         host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
-    - uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+    - uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       id: secrets
       with:
         secrets: |

--- a/update-release-channel/action.yml
+++ b/update-release-channel/action.yml
@@ -58,7 +58,7 @@ runs:
     - name: Fetch AWS credentials from Vault
       id: secrets
       if: inputs.dryRun != 'true'
-      uses: SonarSource/vault-action-wrapper@c154b4a417b51cb98dd71137f49bf20e77c56820 # 3.4.0
+      uses: SonarSource/vault-action-wrapper@0a3114fe1230b784c35b53b099f9ab1f1e538cc7 # 3.5.0
       with:
         secrets: |
           development/aws/sts/downloads access_key | AWS_ACCESS_KEY_ID;


### PR DESCRIPTION
## Why

`SonarSource/vault-action-wrapper` 3.5.0 ([release](https://github.com/SonarSource/vault-action-wrapper/releases/tag/3.5.0)) ships `actions/github-script@v9` and `hashicorp/vault-action@v4` — both Node 24 runtime. Bumping the pin here so every composite that needs Vault secrets (and every internal workflow that uses the wrapper directly) inherits Node 24.

Linked ticket: [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781).

## What changed

`SonarSource/vault-action-wrapper@c154b4a4 # 3.4.0` → `SonarSource/vault-action-wrapper@0a3114fe # 3.5.0` across 19 files:

**14 composite actions:**
`build-gradle`, `build-maven`, `build-npm`, `build-poetry`, `build-yarn`, `check-sca`, `code-signing`, `config-gradle`, `config-maven`, `config-npm`, `config-pip`, `get-build-number`, `promote`, `update-release-channel`.

**5 internal workflows:**
`PullRequestClosed.yml`, `PullRequestCreated.yml`, `RequestReview.yml`, `SubmitReview.yml`, `test-shell-scripts.yml`.

## Verification

`pre-commit` clean (yamllint, actionlint, Validate GitHub Workflows).

CI on this PR exercises every composite that fetches secrets; green is the merge signal.


[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ