### PR TITLE
BUILD-11460: Disable caching on release channel pointer in S3

### DIFF
--- a/spec/update-release-channel_spec.sh
+++ b/spec/update-release-channel_spec.sh
@@ -29,7 +29,7 @@ Describe 'update-release-channel/update-release-channel.sh'
       When run script update-release-channel/update-release-channel.sh
       The status should be success
       The output should include "Dry-run: aws s3api put-object"
-      The output should include "--cache-control max-age=60"
+      The output should include "--cache-control 'no-cache, no-store, max-age=0'"
       The output should include "--content-type application/json"
       The contents of file "$GITHUB_OUTPUT" should include "bucket=downloads-cdn-eu-central-1-prod"
       The contents of file "$GITHUB_OUTPUT" should include "key=Distribution/sonarqube-cli/latest.json"

--- a/update-release-channel/update-release-channel.sh
+++ b/update-release-channel/update-release-channel.sh
@@ -36,7 +36,7 @@ UPDATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 BODY="$(jq -cn --arg v "$VERSION" --arg t "$UPDATED_AT" '{schemaVersion:1, version:$v, updatedAt:$t}')"
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  echo "Dry-run: aws s3api put-object --bucket $BUCKET --key $KEY --cache-control max-age=60 --content-type application/json --body <generated-json-file>"
+  echo "Dry-run: aws s3api put-object --bucket $BUCKET --key $KEY --cache-control 'no-cache, no-store, max-age=0' --content-type application/json --body <generated-json-file>"
   echo "Dry-run body: $BODY"
 else
   BODY_FILE="$(mktemp)"
@@ -45,7 +45,7 @@ else
 
   aws s3api put-object \
     --bucket "$BUCKET" --key "$KEY" --body "$BODY_FILE" \
-    --cache-control "max-age=60" --content-type "application/json" > /dev/null
+    --cache-control "no-cache, no-store, max-age=0" --content-type "application/json" > /dev/null
   echo "Wrote $URL"
 fi
 


### PR DESCRIPTION
BUILD-11460

Disables HTTP caching on the release-channel pointer object written to S3 (served at `https://binaries.sonarsource.com/<prefix>/<product>/<channel>.json`).

**Why:** the pointer JSON is what consumers poll to discover the latest published version. The previous `Cache-Control: max-age=60` meant a freshly promoted version could stay invisible for up to a minute behind the CDN/browser cache.

**Change:** `--cache-control` on the `aws s3api put-object` call goes from `max-age=60` → `no-cache, no-store, max-age=0` (covers browsers, proxies, and the CloudFront CDN). Dry-run echo and the ShellSpec assertion updated to match.

**Behavioral change:** newly written pointers are served with no caching. Objects written before this change keep their `max-age=60` header until the action next overwrites them.

**Tests:** `shellspec spec/update-release-channel_spec.sh --shell bash` → 8 examples, 0 failures; `shellcheck` clean.
