### PR TITLE
BUILD-11521: Remove repox-artifactory-url from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ steps:
 | `artifactory-reader-role` | Suffix for the Artifactory reader role in Vault                             | `private-reader` for private repos, `public-reader` for public repos                                                    |
 | `common-mvn-flags`        | Maven flags for all subsequent mvn calls                                    | `--batch-mode --no-transfer-progress --errors --fail-at-end --show-version -Dmaven.test.redirectTestOutputToFile=false` |
 | `repox-url`               | URL for Repox                                                               | `https://repox.jfrog.io`                                                                                                |
-| `repox-artifactory-url`   | URL for Repox Artifactory API (overrides repox-url/artifactory if provided) | (optional)                                                                                                              |
 | `use-develocity`          | Whether to use Develocity for build tracking                                | `false`                                                                                                                 |
 | `develocity-url`          | URL for Develocity                                                          | `https://develocity.sonar.build/`                                                                                       |
 | `cache-paths`             | Custom cache paths (multiline).                                             | (optional)                                                                                                              |
@@ -312,7 +311,6 @@ See also [`config-maven`](#config-maven) input environment variables.
 | `maven-args`                | Additional arguments to pass to Maven                                                                                        | (optional)                                                                                  |
 | `scanner-java-opts`         | Additional Java options for the Sonar scanner (`SONAR_SCANNER_JAVA_OPTS`)                                                    | `-Xmx512m`                                                                                  |
 | `repox-url`                 | URL for Repox                                                                                                                | `https://repox.jfrog.io`                                                                    |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                  | (optional)                                                                                  |
 | `use-develocity`            | Whether to use Develocity for build tracking                                                                                 | `false`                                                                                     |
 | `develocity-url`            | URL for Develocity                                                                                                           | `https://develocity.sonar.build/`                                                           |
 | `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans                           | `next`                                                                                      |
@@ -436,7 +434,6 @@ jobs:
 | `poetry-virtualenvs-path`   | Path to the Poetry virtual environments, relative to GitHub workspace                                                                                                                         | `.cache/pypoetry/virtualenvs`                                                                         |
 | `poetry-cache-dir`          | Path to the Poetry cache directory, relative to GitHub workspace                                                                                                                              | `.cache/pypoetry`                                                                                     |
 | `repox-url`                 | URL for Repox                                                                                                                                                                                 | `https://repox.jfrog.io`                                                                              |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                                                                                   | (optional)                                                                                            |
 | `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', sqc-us, or 'none'. Use 'none' to skip sonar scans                                                                                              | `next`                                                                                                |
 | `run-shadow-scans`          | If true, run sonar scanner on all 3 platforms using the provided URL and token. If false, run on the platform provided by sonar-platform. When enabled, the sonar-platform setting is ignored | `false`                                                                                               |
 | `working-directory`         | Relative path under github.workspace to execute the build in                                                                                                                                  | `.`                                                                                                   |
@@ -549,7 +546,6 @@ If provided, `SONARSOURCE_REPOSITORY` is used at runtime by the Gradle init scri
 | `use-develocity`          | Whether to use Develocity for build tracking                                | `false`                                                              |
 | `develocity-url`          | URL for Develocity                                                          | `https://develocity.sonar.build/`                                    |
 | `repox-url`               | URL for Repox                                                               | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`   | URL for Repox Artifactory API (overrides repox-url/artifactory if provided) | (optional)                                                           |
 | `cache-paths`             | Custom cache paths (multiline).                                             | `~/.gradle/caches`<br>`~/.gradle/wrapper`                            |
 | `disable-caching`         | Whether to disable Gradle caching entirely                                  | `false`                                                              |
 
@@ -673,7 +669,6 @@ See also [`config-gradle`](#config-gradle) input environment variables.
 | `gradle-args`               | Additional arguments to pass to Gradle                                                                                       | (optional)                                                                                  |
 | `develocity-url`            | URL for Develocity                                                                                                           | `https://develocity.sonar.build/`                                                           |
 | `repox-url`                 | URL for Repox                                                                                                                | `https://repox.jfrog.io`                                                                    |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                  | (optional)                                                                                  |
 | `sonar-platform`            | SonarQube variant - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans                                    | `next`                                                                                      |
 | `working-directory`         | Relative path under github.workspace to execute the build in                                                                 | `.`                                                                                         |
 | `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding)                                               | `false`                                                                                     |
@@ -873,7 +868,6 @@ See also [`get-build-number`](#get-build-number) input environment variables.
 | `disable-caching`         | Whether to disable NPM caching entirely                                     | `false`                                                              |
 | `cache-npm`               | Deprecated. Use `disable-caching: 'true'` instead                           | `true`                                                               |
 | `repox-url`               | URL for Repox                                                               | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`   | URL for Repox Artifactory API (overrides repox-url/artifactory if provided) | (optional)                                                           |
 
 ### Outputs
 
@@ -967,7 +961,6 @@ See also [`config-npm`](#config-npm) input environment variables.
 | `disable-caching`           | Whether to disable NPM caching entirely                                                                                      | `false`                                                                                      |
 | `cache-npm`                 | Deprecated. Use `disable-caching: 'true'` instead                                                                            | `true`                                                                                       |
 | `repox-url`                 | URL for Repox                                                                                                                | `https://repox.jfrog.io`                                                                     |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                  | (optional)                                                                                   |
 | `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', or 'sqc-us'                                                                   | `next`                                                                                       |
 | `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding)                                               | `false`                                                                                      |
 | `build-name`                | Name of the JFrog build to publish.                                                                                          | `<Repository name>`                                                                          |
@@ -1077,7 +1070,6 @@ jobs:
 | `disable-caching`           | Whether to disable Yarn caching entirely                                                                                     | `false`                                                                                     |
 | `cache-yarn`                | Deprecated. Use `disable-caching: 'true'` instead                                                                            | `true`                                                                                      |
 | `repox-url`                 | URL for Repox                                                                                                                | `https://repox.jfrog.io`                                                                    |
-| `repox-artifactory-url`     | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                                  | (optional)                                                                                  |
 | `sonar-platform`            | SonarQube primary platform - 'next', 'sqc-eu', 'sqc-us', or 'none'. Use 'none' to skip sonar scans                           | `next`                                                                                      |
 | `run-shadow-scans`          | Enable analysis across all 3 SonarQube platforms (unified platform dogfooding)                                               | `false`                                                                                     |
 | `provenance`                | Whether to generate provenance attestation for built artifacts                                                               | `false`                                                                                     |
@@ -1155,7 +1147,6 @@ steps:
 | `working-directory`       | Relative path under github.workspace to execute the build in                | `.`                                                                  |
 | `artifactory-reader-role` | Suffix for the Artifactory reader role in Vault                             | `private-reader` for private repos, `public-reader` for public repos |
 | `repox-url`               | URL for Repox                                                               | `https://repox.jfrog.io`                                             |
-| `repox-artifactory-url`   | URL for Repox Artifactory API (overrides repox-url/artifactory if provided) | (optional)                                                           |
 | `cache-paths`             | Cache paths to use (multiline)                                              | `~/.cache/pip`                                                       |
 | `disable-caching`         | Whether to disable pip caching entirely                                     | `false`                                                              |
 
@@ -1260,7 +1251,6 @@ promote:
 | Input                     | Description                                                                                                               | Default                  |
 |---------------------------|---------------------------------------------------------------------------------------------------------------------------|--------------------------|
 | `repox-url`               | URL for Repox                                                                                                             | `https://repox.jfrog.io` |
-| `repox-artifactory-url`   | URL for Repox Artifactory API (overrides repox-url/artifactory if provided)                                               | (optional)               |
 | `promote-pull-request`    | Whether to promote pull request artifacts. Requires `deploy-pull-request` input to be set to `true` in the build action   | `false`                  |
 | `multi-repo`              | If true, promotes to public and private repositories. For projects with both public and private artifacts                 | (optional)               |
 | `artifactory-deploy-repo` | Repository to deploy to. If not set, it will be retrieved from the build info                                             | (optional)               |


### PR DESCRIPTION
## Summary by Gitar

- **Documentation:**
  - Removed `repox-artifactory-url` configuration instructions from `README.md`.

<sub>This will update automatically on new commits.</sub>