### PR TITLE
BUILD-11553: Avoid workspace pollution in CI actions

### DIFF
--- a/build-npm/action.yml
+++ b/build-npm/action.yml
@@ -238,3 +238,10 @@ runs:
           echo "🐸 [Browse build \`${build_name}:${BUILD_NUMBER}\` in Artifactory](${ARTIFACTORY_BROWSE_URL})" >> $GITHUB_STEP_SUMMARY
           "$ACTION_PATH_BUILD_NPM/../shared/generate-jfrog-summary.sh" repox
         fi
+
+    - name: Clean up local action symlinks
+      if: always()
+      shell: bash
+      run: |
+        rm -f .actions/get-build-number .actions/config-npm .actions/shared
+        rmdir .actions 2>/dev/null || true

--- a/build-npm/build.sh
+++ b/build-npm/build.sh
@@ -102,7 +102,7 @@ jfrog_npm_publish() {
   jf config remove repox > /dev/null 2>&1 || true # Ignore inexistent configuration
   jf config add repox --url "${ARTIFACTORY_URL%/artifactory*}" --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_DEPLOY_ACCESS_TOKEN"
   jf config use repox
-  jf npm-config --repo-resolve "npm" --repo-deploy "$ARTIFACTORY_DEPLOY_REPO"
+  jf npm-config --global --repo-resolve "npm" --repo-deploy "$ARTIFACTORY_DEPLOY_REPO"
 
   export PROJECT="${GITHUB_REPOSITORY#*/}"
   echo "PROJECT: ${PROJECT}"

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -221,3 +221,10 @@ runs:
           echo "🐸 [Browse build \`${build_name}:${BUILD_NUMBER}\` in Artifactory](${ARTIFACTORY_BROWSE_URL})" >> $GITHUB_STEP_SUMMARY
           "$ACTION_PATH_BUILD_YARN/../shared/generate-jfrog-summary.sh" repox
         fi
+
+    - name: Clean up local action symlinks
+      if: always()
+      shell: bash
+      run: |
+        rm -f .actions/get-build-number .actions/shared
+        rmdir .actions 2>/dev/null || true

--- a/build-yarn/build.sh
+++ b/build-yarn/build.sh
@@ -106,7 +106,7 @@ EOF
   jf config remove repox > /dev/null 2>&1 || true # Ignore inexistent configuration
   jf config add repox --url "${ARTIFACTORY_URL%/artifactory*}" --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_ACCESS_TOKEN"
   jf config use repox
-  jf npm-config --repo-resolve "npm"
+  jf npm-config --global --repo-resolve "npm"
 }
 
 set_project_version() {
@@ -175,7 +175,7 @@ jfrog_yarn_publish() {
   jf config remove repox > /dev/null 2>&1 || true # Ignore inexistent configuration
   jf config add repox --url "${ARTIFACTORY_URL%/artifactory*}" --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_DEPLOY_ACCESS_TOKEN"
   jf config use repox
-  jf npm-config --repo-resolve "npm" --repo-deploy "$ARTIFACTORY_DEPLOY_REPO"
+  jf npm-config --global --repo-resolve "npm" --repo-deploy "$ARTIFACTORY_DEPLOY_REPO"
 
   # Create a local tarball and preserve it for attestation
   echo "Creating local tarball for attestation..."

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -161,3 +161,10 @@ runs:
       if: steps.config-npm-completed.outputs.skip != 'true'
       shell: bash
       run: echo "CONFIG_NPM_COMPLETED=$GITHUB_ACTION" >> "$GITHUB_ENV"
+
+    - name: Clean up local action symlinks
+      if: always() && steps.config-npm-completed.outputs.skip != 'true'
+      shell: bash
+      run: |
+        rm -f .actions/get-build-number .actions/shared
+        rmdir .actions 2>/dev/null || true

--- a/config-npm/npm_config.sh
+++ b/config-npm/npm_config.sh
@@ -21,7 +21,7 @@ EOF
   jf config remove repox > /dev/null 2>&1 || true # Ignore inexistent configuration
   jf config add repox --url "${ARTIFACTORY_URL%/artifactory*}" --artifactory-url "$ARTIFACTORY_URL" --access-token "$ARTIFACTORY_ACCESS_TOKEN"
   jf config use repox
-  jf npm-config --repo-resolve "npm"
+  jf npm-config --global --repo-resolve "npm"
   return 0
 }
 

--- a/get-build-number/action.yml
+++ b/get-build-number/action.yml
@@ -29,6 +29,7 @@ runs:
         fi
         echo "ACTION_PATH_GET_BUILD_NUMBER=$ACTION_PATH_GET_BUILD_NUMBER"
         echo "ACTION_PATH_GET_BUILD_NUMBER=$ACTION_PATH_GET_BUILD_NUMBER" >> "$GITHUB_ENV"
+        echo "BUILD_NUMBER_FILE=${RUNNER_TEMP}/build_number.txt" >> "$GITHUB_ENV"
         echo "::endgroup::"
 
     # Reuse build number from environment if provided (e.g. from a parent workflow)
@@ -38,7 +39,7 @@ runs:
       shell: bash
       run: |
         echo "BUILD_NUMBER ${BUILD_NUMBER} provided from environment, skipping both increment and save to cache."
-        echo "${BUILD_NUMBER}" > build_number.txt
+        echo "${BUILD_NUMBER}" > "$BUILD_NUMBER_FILE"
         echo "skip=true" >> $GITHUB_OUTPUT
 
     # Reuse current build number in case of rerun
@@ -47,7 +48,7 @@ runs:
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: current-build-number
       with:
-        path: build_number.txt
+        path: ${{ env.BUILD_NUMBER_FILE }}
         key: build-number-${{ github.run_id }}
         enableCrossOsArchive: true
 
@@ -69,7 +70,7 @@ runs:
       id: export
       shell: bash
       run: |
-        BUILD_NUMBER=$(cat build_number.txt)
+        BUILD_NUMBER=$(cat "$BUILD_NUMBER_FILE")
         echo "BUILD_NUMBER: ${BUILD_NUMBER}"
         echo "BUILD_NUMBER=${BUILD_NUMBER}" >> "$GITHUB_ENV"
         echo "BUILD_NUMBER=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
@@ -78,6 +79,6 @@ runs:
       uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       if: steps.from-env.outputs.skip != 'true' && steps.current-build-number.outputs.cache-hit != 'true'
       with:
-        path: build_number.txt
+        path: ${{ env.BUILD_NUMBER_FILE }}
         key: build-number-${{ github.run_id }}
         enableCrossOsArchive: true

--- a/get-build-number/get_build_number.sh
+++ b/get-build-number/get_build_number.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 : "${GITHUB_REPOSITORY:?}"
 GH_API_VERSION_HEADER="X-GitHub-Api-Version: 2022-11-28"
-CACHE_FILE="build_number.txt"
+CACHE_FILE="${BUILD_NUMBER_FILE:-${RUNNER_TEMP}/build_number.txt}"
 
 echo "Fetching build number from repository properties..."
 PROPERTIES_API_URL="repos/${GITHUB_REPOSITORY}/properties/values"

--- a/spec/config-npm_spec.sh
+++ b/spec/config-npm_spec.sh
@@ -100,7 +100,7 @@ Describe 'set_build_env()'
     The line 1 should include "Configuring JFrog and NPM repositories"
     The line 2 should equal "jf config add repox --url https://repox.jfrog.io --artifactory-url https://repox.jfrog.io/artifactory --access-token reader-token"
     The line 3 should equal "jf config use repox"
-    The line 4 should equal "jf npm-config --repo-resolve npm"
+    The line 4 should equal "jf npm-config --global --repo-resolve npm"
   End
 End
 

--- a/spec/get_build_number_spec.sh
+++ b/spec/get_build_number_spec.sh
@@ -2,7 +2,9 @@
 eval "$(shellspec - -c) exit 1"
 
 export GITHUB_REPOSITORY="my org/my-repo"
-CACHE_FILE="build_number.txt"
+export RUNNER_TEMP="${SHELLSPEC_TMPBASE:-/tmp}"
+export BUILD_NUMBER_FILE="${RUNNER_TEMP}/build_number.txt"
+CACHE_FILE="${BUILD_NUMBER_FILE}"
 
 Mock gh
     echo "gh $*"


### PR DESCRIPTION
## Summary

Keep the GitHub workspace checkout clean by moving ephemeral CI state out of the repository tree. This prevents downstream steps (e.g. Docker image tagging in gitar) from behaving differently when the working tree is polluted with untracked files or directories.

- **get-build-number**: write `build_number.txt` to `${RUNNER_TEMP}` instead of the workspace; update cache paths and shell specs accordingly
- **config-npm / build-npm / build-yarn**: use `jf npm-config --global` so `.jfrog/projects/` is created under the runner home, not the workspace
- **config-npm / build-npm / build-yarn**: remove transient `.actions/` symlinks after local composite action references are consumed (only symlinks created by the action; `rmdir` if empty)

## Why

Blocks [gitar/actions/runs/27045793684](https://github.com/gitarcode/gitar/actions/runs/27045793684): image tagging logic behaves differently when the workspace is clean vs polluted.

## Test plan

- [x] ShellSpec: `config-npm`, `build-npm`, `build-yarn`, `get-build-number`
- [x] Verify npm/yarn install and publish still resolve/deploy correctly in dummy-repo CI: https://github.com/SonarSource/sonar-dummy-js/actions/runs/27240536197/job/80443233244
- [x] Confirm gitar build is unblocked with a clean workspace after consuming updated actions