### PR TITLE
PREQ-6264: Add Gradle wrapper download retries in config-gradle

### DIFF
--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -155,6 +155,7 @@ runs:
           if grep -q "^${key}=" "$WRAPPER_PROPS"; then
             sed -i.bak "s/^${key}=.*/${key}=${value}/" "$WRAPPER_PROPS"
           else
+            [[ -s "$WRAPPER_PROPS" && -n "$(tail -c1 "$WRAPPER_PROPS")" ]] && echo >> "$WRAPPER_PROPS"
             echo "${key}=${value}" >> "$WRAPPER_PROPS"
           fi
         }

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -139,6 +139,31 @@ runs:
           echo "DEVELOCITY_ACCESS_KEY=${{ steps.develocity-hostname.outputs.hostname }}=$DEVELOCITY_TOKEN" >> "$GITHUB_ENV"
         fi
 
+    - name: Configure Gradle wrapper download resilience
+      if: steps.config-gradle-completed.outputs.skip != 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        WRAPPER_PROPS="gradle/wrapper/gradle-wrapper.properties"
+        if [[ ! -f "$WRAPPER_PROPS" ]]; then
+          echo "No ${WRAPPER_PROPS} found, skipping wrapper resilience config"
+          exit 0
+        fi
+
+        update_prop() {
+          local key="$1" value="$2"
+          if grep -q "^${key}=" "$WRAPPER_PROPS"; then
+            sed -i.bak "s/^${key}=.*/${key}=${value}/" "$WRAPPER_PROPS"
+          else
+            echo "${key}=${value}" >> "$WRAPPER_PROPS"
+          fi
+        }
+
+        update_prop networkTimeout 60000
+        update_prop retries 3
+        update_prop retryBackOffMs 1000
+        rm -f "${WRAPPER_PROPS}.bak"
+
     - name: Configure Gradle
       if: steps.config-gradle-completed.outputs.skip != 'true'
       uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0


### PR DESCRIPTION
## Summary

- Add a **Configure Gradle wrapper download resilience** step to `config-gradle` that sets `networkTimeout=60000`, `retries=3`, and `retryBackOffMs=1000` in `gradle/wrapper/gradle-wrapper.properties` at CI runtime
- Mitigates flaky Gradle distribution downloads (e.g. `services.gradle.org` timeouts on `sonar-scanner-engine`) without requiring per-repo wrapper property changes

Jira: https://sonarsource.atlassian.net/browse/PREQ-6264

Related: Julien Henry reported Gradle download timeout in https://github.com/SonarSource/sonar-scanner-engine/actions/runs/27123611072/job/80050116778 — wrapper had `retries=0` and `networkTimeout=10000`.

## Test plan

- [ ] CI passes on this PR
- [ ] After release on `@v1`, verify `sonar-scanner-engine` Gradle build no longer flakes on distribution download