### PR TITLE
BUILD-11470 Use snake_case keys in cache JSON metrics

### DIFF
--- a/ci-metrics/job-completed.sh
+++ b/ci-metrics/job-completed.sh
@@ -404,12 +404,12 @@ if [[ "$cache_json" != "[]" ]] && command -v jq >/dev/null 2>&1; then
         | .[]
         | [
             (.key // ""),
-            (if ."cache-hit" == true then "true" else "false" end),
-            (."restore-key-hit" // ""),
+            (if .cache_hit == true then "true" else "false" end),
+            (.restore_key_hit // ""),
             (.backend // "unknown"),
-            (if (."size-bytes-restored"|type) == "number" then (."size-bytes-restored"|tostring) else "" end),
+            (if (.size_bytes_restored|type) == "number" then (.size_bytes_restored|tostring) else "" end),
             (if .saved == true then "true" elif .saved == false then "false" else "" end),
-            (if (."size-bytes-at-end"|type) == "number" then (."size-bytes-at-end"|tostring) else "" end)
+            (if (.size_bytes_at_end|type) == "number" then (.size_bytes_at_end|tostring) else "" end)
           ]
         | join("\u001f")
     ' 2>/dev/null) || cache_rows=""


### PR DESCRIPTION
## Summary

- Renames kebab-case jq field references in `ci-metrics/job-completed.sh` to snake_case to match the updated `CacheMetricsRecord` schema from `gh-action_cache` ([BUILD-11470](https://sonarsource.atlassian.net/browse/BUILD-11470))
- Fields renamed: `cache-hit` → `cache_hit`, `restore-key-hit` → `restore_key_hit`, `size-bytes-restored` → `size_bytes_restored`, `size-bytes-at-end` → `size_bytes_at_end`

The file is aligned with the source in https://github.com/SonarSource/github-runners-infra/pull/417
https://github.com/SonarSource/github-runners-infra/blob/8d793a9623327bac9b363dd0d5d8e47d8e17230d/infra/applications/github-runners/hooks/job-completed.sh

## Related PRs

Part of BUILD-11470 — three-repo change:
- `gh-action_cache` — interface + source (pending)
- `github-runners-infra` — hook + fixtures (pending)
- This PR — copy of the hook in `ci-metrics/`

## Test plan

- [ ] Pre-commit hooks passed (ShellCheck)
- [ ] Verify cache section renders correctly in `$GITHUB_STEP_SUMMARY` on a real run

[BUILD-11470]: https://sonarsource.atlassian.net/browse/BUILD-11470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ