### PR TITLE
BUILD-11573 Fix config-npm path resolution in container jobs

### DIFF
--- a/.github/workflows/test-config-npm-container.yml
+++ b/.github/workflows/test-config-npm-container.yml
@@ -1,0 +1,41 @@
+---
+name: Test Config NPM in Container
+on:
+  pull_request:
+    paths:
+      - config-npm/**
+      - get-build-number/**
+      - shared/**
+      - .github/workflows/test-config-npm-container.yml
+  merge_group:
+  push:
+    branches:
+      - master
+      - branch-*
+    paths:
+      - config-npm/**
+      - get-build-number/**
+      - shared/**
+      - .github/workflows/test-config-npm-container.yml
+  workflow_dispatch:
+
+jobs:
+  test-config-npm-container:
+    runs-on: warp-custom-ubuntu-24-04
+    container: node:24-bookworm
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./config-npm
+        with:
+          # gh-action_cache prepare-keys.sh needs jq after config-npm restores mise files.
+          disable-caching: "true"
+      - name: Verify config-npm completed in container
+        shell: bash
+        run: |
+          test -f "${ACTION_PATH_CONFIG_NPM}/mise.local.toml"
+          test -f "${ACTION_PATH_CONFIG_NPM}/npm_config.sh"
+          [[ "${ACTION_PATH_CONFIG_NPM}" == "${GITHUB_ACTION_PATH}" ]]
+          [[ "${BUILD_NUMBER}" =~ ^[0-9]+$ ]]

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: URL for Repox
     default: https://repox.jfrog.io
   host-actions-root:
-    description: Path to the actions folder on the host (used when called from another local action)
+    description: Path to the actions folder on the host (used when called from another local action via a workspace symlink). Ignored when it points at the container mount (/__w).
     default: ''
 
 outputs:
@@ -54,12 +54,14 @@ runs:
         echo "::group::Fix for using local actions"
         echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
         echo "github.action_path=${{ github.action_path }}"
-        ACTION_PATH_CONFIG_NPM="${{ github.action_path }}"
+        ACTION_PATH_CONFIG_NPM="$GITHUB_ACTION_PATH"
         host_actions_root="${{ inputs.host-actions-root }}"
         if [[ -z "$host_actions_root" ]]; then
-          host_actions_root="$(dirname "$ACTION_PATH_CONFIG_NPM")"
-        else
-          ACTION_PATH_CONFIG_NPM="$host_actions_root/config-npm"
+          host_actions_root="$(dirname "${{ github.action_path }}")"
+        elif [[ "$host_actions_root" == /__w/* ]]; then
+          echo "::warning::host-actions-root points at the container mount ($host_actions_root);" \
+            "using host path for local action symlinks." >&2
+          host_actions_root="$(dirname "${{ github.action_path }}")"
         fi
         echo "ACTION_PATH_CONFIG_NPM=$ACTION_PATH_CONFIG_NPM"
         echo "ACTION_PATH_CONFIG_NPM=$ACTION_PATH_CONFIG_NPM" >> "$GITHUB_ENV"

--- a/get-build-number/action.yml
+++ b/get-build-number/action.yml
@@ -20,13 +20,8 @@ runs:
         echo "::group::Fix for using local actions"
         echo "GITHUB_ACTION_PATH=$GITHUB_ACTION_PATH"
         echo "github.action_path=${{ github.action_path }}"
-        ACTION_PATH_GET_BUILD_NUMBER="${{ github.action_path }}"
-        host_actions_root="${{ inputs.host-actions-root }}"
-        if [[ -z "$host_actions_root" ]]; then
-          host_actions_root="$(dirname "$ACTION_PATH_GET_BUILD_NUMBER")"
-        else
-          ACTION_PATH_GET_BUILD_NUMBER="$host_actions_root/get-build-number"
-        fi
+        # Scripts run inside the job environment (container or host).
+        ACTION_PATH_GET_BUILD_NUMBER="$GITHUB_ACTION_PATH"
         echo "ACTION_PATH_GET_BUILD_NUMBER=$ACTION_PATH_GET_BUILD_NUMBER"
         echo "ACTION_PATH_GET_BUILD_NUMBER=$ACTION_PATH_GET_BUILD_NUMBER" >> "$GITHUB_ENV"
         echo "BUILD_NUMBER_FILE=${RUNNER_TEMP}/build_number.txt" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

- Use `GITHUB_ACTION_PATH` for script/file access in `config-npm` and `get-build-number`, so composite steps work inside container jobs where `github.action_path` points at the host mount
- Keep host-side paths for `.actions/*` symlinks so nested local actions (e.g. `get-build-number`) resolve correctly on the runner
- Ignore `host-actions-root` when it points at the container mount (`/__w/*`)
- Add `test-config-npm-container.yml` integration test running `./config-npm` in a `node:24-bookworm` container without `host-actions-root`

Fixes the gitar Playwright regression workflow failure when calling `SonarSource/ci-github-actions/config-npm@v1` inside a container.

## Issue reproduction

- Created `Test Config NPM in Container` workflow and run it without the fix in place: https://github.com/SonarSource/ci-github-actions/actions/runs/27403180242/job/80985817988?pr=294

## Test plan

- [ ] `Test Config NPM in Container` workflow passes on this PR
- [ ] Existing `Test Build Number` and `Test Shell Scripts` workflows still pass
- [ ] After release, gitar can run `config-npm` in the Playwright container without `host-actions-root` or a separate install-deps job