### PR TITLE
TEMP BUILD-11444 Pin gh-action_cache to PR #81 branch for e2e testing

### DIFF
--- a/build-poetry/action.yml
+++ b/build-poetry/action.yml
@@ -108,7 +108,7 @@ runs:
       with:
         host-actions-root: ${{ steps.set-path.outputs.host_actions_root }}
     - name: Cache local Poetry cache
-      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11444-github-env-gate # TEMP: test PR #81 - restore decision-file gate
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ github.workspace }}/${{ inputs.poetry-cache-dir }}

--- a/build-yarn/action.yml
+++ b/build-yarn/action.yml
@@ -119,7 +119,7 @@ runs:
         working_directory: ${{ inputs.working-directory }}
 
     - name: Cache Yarn dependencies
-      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11444-github-env-gate # TEMP: test PR #81 - restore decision-file gate
       if: ${{ inputs.cache-yarn == 'true' && inputs.disable-caching != 'true' }}
       with:
         path: |

--- a/cache/action.yml
+++ b/cache/action.yml
@@ -36,7 +36,7 @@ runs:
         echo "::warning:: This action is deprecated and will be removed in future releases." \
           "Please migrate to using the SonarSource/gh-action_cache action directly." >&2
 
-    - uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
+    - uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11444-github-env-gate # TEMP: test PR #81 - restore decision-file gate
       id: cache
       with:
         path: ${{ inputs.path }}

--- a/code-signing/action.yml
+++ b/code-signing/action.yml
@@ -24,7 +24,7 @@ runs:
         echo "JSIGN_CACHE_PATH=/tmp/jsign-cache" >> "$GITHUB_ENV"
 
     - name: Cache code signing tools
-      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11444-github-env-gate # TEMP: test PR #81 - restore decision-file gate
       id: tools-cache
       with:
         path: |

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -199,7 +199,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Gradle Cache
-      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11444-github-env-gate # TEMP: test PR #81 - restore decision-file gate
       if: steps.config-gradle-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -184,7 +184,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache local Maven repository
-      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11444-github-env-gate # TEMP: test PR #81 - restore decision-file gate
       if: steps.config-maven-completed.outputs.skip != 'true' && inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}

--- a/config-npm/action.yml
+++ b/config-npm/action.yml
@@ -122,7 +122,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache NPM dependencies
-      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11444-github-env-gate # TEMP: test PR #81 - restore decision-file gate
       if: steps.config-npm-completed.outputs.skip != 'true' && inputs.disable-caching != 'true' && inputs.cache-npm == 'true'
       with:
         path: ~/.npm

--- a/config-pip/action.yml
+++ b/config-pip/action.yml
@@ -96,7 +96,7 @@ runs:
       run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
 
     - name: Cache pip dependencies
-      uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
+      uses: SonarSource/gh-action_cache@feat/jcarsique/BUILD-11444-github-env-gate # TEMP: test PR #81 - restore decision-file gate
       if: inputs.disable-caching == 'false'
       with:
         path: ${{ inputs.cache-paths }}


### PR DESCRIPTION
## Summary

**TEMP — DO NOT MERGE.** This PR pins `gh-action_cache` to the [PR #81](https://github.com/SonarSource/gh-action_cache/pull/81) branch (`feat/jcarsique/BUILD-11444-github-env-gate`) across all ci-github-actions action files to exercise the restored decision-file gate during e2e validation of the BUILD-11444 revert.

This PR will be **closed without merging** after e2e validation passes.

## Context

The BUILD-11444 revert restores the decision-file approach (`/tmp/ci-metrics/enabled`) for CI metrics gating. The full revert spans 4 repos. This temp PR exists purely to dogfood gh-action_cache PR #81 via sonar-dummy, which calls ci-github-actions actions that internally call gh-action_cache.

## Related PRs

- [gh-action_cache PR #81](https://github.com/SonarSource/gh-action_cache/pull/81) — gate restore (MUST merge first)
- [github-runners-infra PR #421](https://github.com/SonarSource/github-runners-infra/pull/421) — K8s job-started.sh
- [ci-ami-images PR #389](https://github.com/SonarSource/ci-ami-images/pull/389) — WarpBuild job-started.sh
- [sonar-dummy PR #618](https://github.com/SonarSource/sonar-dummy/pull/618) — e2e test harness