### PR TITLE
PREQ-6373: Fix regression with build-number cache path

### DIFF
--- a/.github/workflows/test-build-number.yml
+++ b/.github/workflows/test-build-number.yml
@@ -27,6 +27,11 @@ jobs:
         run: |
           echo "BUILD_NUMBER: ${BUILD_NUMBER}"
           [[ "${BUILD_NUMBER}" =~ ^[0-9]+$ ]]
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "::error title=test-build-number-generation::Workspace polluted after get-build-number:"
+            git status --porcelain
+            exit 1
+          fi
 
       - uses: ./get-build-number
         id: get_build_number_second_call
@@ -59,6 +64,7 @@ jobs:
             echo -e "::error title=test-build-number-reuse::Build number '${BUILD_NUMBER}' does not match the previous job build number" \
               "'${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run.\n" \
               "Prefer using the output from SonarSource/ci-github-actions/get-build-number instead of calling it from distinct jobs."
+            # exit 1 # flaky test
           fi
 
   test-build-number-reuse-from-cache-windows:
@@ -80,6 +86,7 @@ jobs:
             echo -e "::error title=test-build-number-reuse-from-cache-windows::Build number '${BUILD_NUMBER}' does not match the previous" \
               "job build number '${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run.\n" \
               "Prefer using the output from SonarSource/ci-github-actions/get-build-number instead of calling it from distinct jobs."
+            # exit 1 # flaky test
           fi
 
   test-build-number-reuse-from-env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /.idea/
 /coverage/
 /.scannerwork/
-/build_number.txt
 /.shellspec-quick.log
 package.json
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ and set it as an environment variable named `BUILD_NUMBER`, and as a GitHub Acti
 
 The build number is unique per workflow run ID. It is not incremented on workflow reruns.
 
+During execution the action temporarily writes `.build_number.txt` at the repository root (for
+`actions/cache`); the file is removed before the action completes. Do not track a file named
+`.build_number.txt` in your repository.
+
 ### Requirements
 
 #### Required GitHub Permissions

--- a/get-build-number/action.yml
+++ b/get-build-number/action.yml
@@ -29,7 +29,7 @@ runs:
         fi
         echo "ACTION_PATH_GET_BUILD_NUMBER=$ACTION_PATH_GET_BUILD_NUMBER"
         echo "ACTION_PATH_GET_BUILD_NUMBER=$ACTION_PATH_GET_BUILD_NUMBER" >> "$GITHUB_ENV"
-        echo "BUILD_NUMBER_FILE=${RUNNER_TEMP}/build_number.txt" >> "$GITHUB_ENV"
+        echo "BUILD_NUMBER_FILE=.build_number.txt" >> "$GITHUB_ENV"
         echo "::endgroup::"
 
     # Reuse build number from environment if provided (e.g. from a parent workflow)
@@ -82,3 +82,8 @@ runs:
         path: ${{ env.BUILD_NUMBER_FILE }}
         key: build-number-${{ github.run_id }}
         enableCrossOsArchive: true
+
+    - name: Remove build number file from workspace
+      if: always()
+      shell: bash
+      run: rm -f "$BUILD_NUMBER_FILE"

--- a/get-build-number/get_build_number.sh
+++ b/get-build-number/get_build_number.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Get the build number for a GitHub repository and save the incremented value to build_number.txt
+# Get the build number for a GitHub repository and save the incremented value to .build_number.txt
 
 set -euo pipefail
 
 : "${GITHUB_REPOSITORY:?}"
 GH_API_VERSION_HEADER="X-GitHub-Api-Version: 2022-11-28"
-CACHE_FILE="${BUILD_NUMBER_FILE:-${RUNNER_TEMP}/build_number.txt}"
+BUILD_NUMBER_FILE="${BUILD_NUMBER_FILE:-.build_number.txt}"
 
 echo "Fetching build number from repository properties..."
 PROPERTIES_API_URL="repos/${GITHUB_REPOSITORY}/properties/values"
@@ -21,4 +21,4 @@ gh api --method PATCH -H "$GH_API_VERSION_HEADER" "$PROPERTIES_API_URL" \
   -f "properties[][property_name]=build_number" \
   -f "properties[][value]=${BUILD_NUMBER}"
 echo "Incremented 'build_number' repository property to ${BUILD_NUMBER}"
-echo "${BUILD_NUMBER}" > "$CACHE_FILE"
+echo "${BUILD_NUMBER}" > "$BUILD_NUMBER_FILE"

--- a/spec/get_build_number_spec.sh
+++ b/spec/get_build_number_spec.sh
@@ -2,9 +2,8 @@
 eval "$(shellspec - -c) exit 1"
 
 export GITHUB_REPOSITORY="my org/my-repo"
-export RUNNER_TEMP="${SHELLSPEC_TMPBASE:-/tmp}"
-export BUILD_NUMBER_FILE="${RUNNER_TEMP}/build_number.txt"
-CACHE_FILE="${BUILD_NUMBER_FILE}"
+TEMP_DIR="${SHELLSPEC_TMPBASE:-/tmp}"
+export BUILD_NUMBER_FILE="${TEMP_DIR}/build_number.txt"
 
 Mock gh
     echo "gh $*"
@@ -28,8 +27,8 @@ Describe 'get_build_number.sh'
     The line 1 should include "Fetching build number"
     The line 2 should equal "Current build number from repo: 42"
     The line 3 should include "43"
-    The path "$CACHE_FILE" should be file
-    The contents of file "$CACHE_FILE" should equal "43"
+    The path "$BUILD_NUMBER_FILE" should be file
+    The contents of file "$BUILD_NUMBER_FILE" should equal "43"
 #    The variable BUILD_NUMBER should equal "43"
   End
 

--- a/spec/update-release-channel_spec.sh
+++ b/spec/update-release-channel_spec.sh
@@ -43,7 +43,7 @@ Describe 'update-release-channel/update-release-channel.sh'
     It 'produces a JSON body that validates against schema/v1.json'
       stdout_file=$(mktemp)
       bash update-release-channel/update-release-channel.sh > "$stdout_file"
-      body_file=$(mktemp --suffix=.json)
+      body_file=$(mktemp)
       extract_body "$stdout_file" > "$body_file"
       When call check-jsonschema --schemafile update-release-channel/schema/v1.json "$body_file"
       The status should be success


### PR DESCRIPTION
## Summary

Fixes the regression introduced in [#287](https://github.com/SonarSource/ci-github-actions/pull/287) (BUILD-11553), where moving the build-number cache file to `${RUNNER_TEMP}/build_number.txt` broke cache restore across jobs on different runner types and OSes.

- Store the build-number cache at `.build_number.txt` (workspace-relative) instead of `${RUNNER_TEMP}/build_number.txt`, which differs between GitHub-hosted and ARC runners and breaks `actions/cache` restore across jobs
- `actions/cache` rejects `..` in paths, so parent-directory locations cannot be cached; a workspace-relative file with `enableCrossOsArchive: true` works across Linux and Windows runners
- After exporting `BUILD_NUMBER` to `GITHUB_ENV` / outputs and saving the cache, remove the file from the workspace so calling workflows are not polluted (preserving the intent of #287)
- Use `.build_number.txt` rather than `build_number.txt` to avoid colliding with a tracked file in consuming repositories; document the reserved filename in the README
- Simplify `get_build_number.sh` by using `BUILD_NUMBER_FILE` directly instead of a separate `CACHE_FILE` alias
- Add a workspace cleanliness check to `test-build-number-generation` (`git status --porcelain` must be empty after `get-build-number`); drop `/build_number.txt` from `.gitignore` so a leftover cache file is visible to git status

## Note

- We can not make `test-build-number-reuse-from-cache` jobs fail the workflow when the build number does not match, due to the flakyness of GitHub hosted cache

## Test plan

- [x] `shellspec spec/get_build_number_spec.sh` passes locally
- [ ] CI `Test Build Number` workflow passes on the PR (cross-runner and cross-OS cache reuse, workspace not polluted)
- [ ] Verify cache restore works across jobs on different ARC runners in `sonar-dotnet-a3s`