### PR TITLE
BUILD-11310 Sentinel-wrap job-metrics stdout for log recovery

### DIFF
--- a/ci-metrics/job-completed.sh
+++ b/ci-metrics/job-completed.sh
@@ -341,9 +341,10 @@ if (( ${#readable_cache_files[@]} > 0 )) && command -v jq >/dev/null 2>&1; then
     fi
 fi
 
-# Persist + stdout-log.
+# Persist + stdout-log. The stdout copy is wrapped in sentinels so report-ci-insights
+# (BUILD-11310) can recover the metrics JSON from the job log via the Actions API.
 printf '%s\n' "$job_metrics_json" > "${CI_METRICS_DIR}/job-metrics.json" 2>/dev/null || true
-printf '%s\n' "$job_metrics_json"
+printf '===CI_METRICS_JSON_BEGIN===%s===CI_METRICS_JSON_END===\n' "$job_metrics_json"
 
 # ---------- Step summary ----------
 summary_target="${GITHUB_STEP_SUMMARY:-/dev/null}"


### PR DESCRIPTION
## What

Sync the `ci-metrics/job-completed.sh` copy with the producer change in [github-runners-infra#422](https://github.com/SonarSource/github-runners-infra/pull/422): wrap the stdout metrics JSON in sentinels so `report-ci-insights` can recover it from the job log.

Ticket: [BUILD-11310](https://sonarsource.atlassian.net/browse/BUILD-11310)

## Change

```diff
-printf '%s\n' "$job_metrics_json"
+printf '===CI_METRICS_JSON_BEGIN===%s===CI_METRICS_JSON_END===\n' "$job_metrics_json"
```

This is the WarpBuild-deployed copy of the hook (downloaded at job start). Same one-line change as the infra PR; applied independently because the two copies legitimately diverge in their feature-gate section (infra sources `decide.sh`; this copy reads `CI_METRICS_ENABLED`). File-write untouched.

## Related
- Producer (ARC): SonarSource/github-runners-infra#422
- Consumer: the `report-ci-insights` action PR (separate, in this repo).

[BUILD-11310]: https://sonarsource.atlassian.net/browse/BUILD-11310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ