### PR TITLE
PREQ-6373: Store build-number cache in S3 via runs-on/cache split

### DIFF
--- a/.github/workflows/test-build-number.yml
+++ b/.github/workflows/test-build-number.yml
@@ -64,7 +64,7 @@ jobs:
             echo -e "::error title=test-build-number-reuse::Build number '${BUILD_NUMBER}' does not match the previous job build number" \
               "'${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run.\n" \
               "Prefer using the output from SonarSource/ci-github-actions/get-build-number instead of calling it from distinct jobs."
-            # exit 1 # flaky test
+            exit 1
           fi
 
   test-build-number-reuse-from-cache-windows:
@@ -86,7 +86,7 @@ jobs:
             echo -e "::error title=test-build-number-reuse-from-cache-windows::Build number '${BUILD_NUMBER}' does not match the previous" \
               "job build number '${{ needs.test-build-number-generation.outputs.BUILD_NUMBER }}' despite it is the same workflow run.\n" \
               "Prefer using the output from SonarSource/ci-github-actions/get-build-number instead of calling it from distinct jobs."
-            # exit 1 # flaky test
+            exit 1
           fi
 
   test-build-number-reuse-from-env:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ and set it as an environment variable named `BUILD_NUMBER`, and as a GitHub Acti
 The build number is unique per workflow run ID. It is not incremented on workflow reruns.
 
 During execution the action temporarily writes `.build_number.txt` at the repository root (for
-`actions/cache`); the file is removed before the action completes. Do not track a file named
+S3 cache via `runs-on/cache`); the file is removed before the action completes. Do not track a file named
 `.build_number.txt` in your repository.
 
 ### Requirements
@@ -110,7 +110,9 @@ jobs:
 
 ### Inputs
 
-No inputs are required for this action.
+| Input               | Description                                      | Default |
+|---------------------|--------------------------------------------------|---------|
+| `host-actions-root` | Path to the actions folder on the host (used when called from another local action) | (empty) |
 
 ### Outputs
 

--- a/get-build-number/action.yml
+++ b/get-build-number/action.yml
@@ -42,14 +42,28 @@ runs:
         echo "${BUILD_NUMBER}" > "$BUILD_NUMBER_FILE"
         echo "skip=true" >> $GITHUB_OUTPUT
 
+    - name: Setup S3 cache credentials
+      if: steps.from-env.outputs.skip != 'true'
+      id: aws-auth
+      uses: SonarSource/gh-action_cache/credential-setup@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
+
     # Reuse current build number in case of rerun
     - name: Get cached build number
       if: steps.from-env.outputs.skip != 'true'
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: runs-on/cache/restore@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
       id: current-build-number
+      env:
+        RUNS_ON_S3_BUCKET_CACHE: sonarsource-s3-cache-prod-bucket
+        AWS_DEFAULT_REGION: eu-central-1
+        AWS_REGION: eu-central-1
+        AWS_ACCESS_KEY_ID: ${{ steps.aws-auth.outputs.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ steps.aws-auth.outputs.AWS_SECRET_ACCESS_KEY }}
+        AWS_SESSION_TOKEN: ${{ steps.aws-auth.outputs.AWS_SESSION_TOKEN }}
+        AWS_PROFILE: ''
+        AWS_DEFAULT_PROFILE: ''
       with:
         path: ${{ env.BUILD_NUMBER_FILE }}
-        key: build-number-${{ github.run_id }}
+        key: ${{ format('{0}/build-number-{1}', github.head_ref || github.ref, github.run_id) }}
         enableCrossOsArchive: true
 
     # Otherwise, increment the build number
@@ -76,11 +90,20 @@ runs:
         echo "BUILD_NUMBER=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
 
     - name: Save build number to cache
-      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: runs-on/cache/save@88d90644011a3a9957fd141a106f5a94f9794203 # v5.0.7
       if: steps.from-env.outputs.skip != 'true' && steps.current-build-number.outputs.cache-hit != 'true'
+      env:
+        RUNS_ON_S3_BUCKET_CACHE: sonarsource-s3-cache-prod-bucket
+        AWS_DEFAULT_REGION: eu-central-1
+        AWS_REGION: eu-central-1
+        AWS_ACCESS_KEY_ID: ${{ steps.aws-auth.outputs.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ steps.aws-auth.outputs.AWS_SECRET_ACCESS_KEY }}
+        AWS_SESSION_TOKEN: ${{ steps.aws-auth.outputs.AWS_SESSION_TOKEN }}
+        AWS_PROFILE: ''
+        AWS_DEFAULT_PROFILE: ''
       with:
         path: ${{ env.BUILD_NUMBER_FILE }}
-        key: build-number-${{ github.run_id }}
+        key: ${{ format('{0}/build-number-{1}', github.head_ref || github.ref, github.run_id) }}
         enableCrossOsArchive: true
 
     - name: Remove build number file from workspace


### PR DESCRIPTION
## Summary

- Replace `actions/cache/restore` + `actions/cache/save` in `get-build-number` with `gh-action_cache/credential-setup` and `runs-on/cache/restore` + `runs-on/cache/save`, storing build numbers in SonarSource S3 (`sonarsource-s3-cache-prod-bucket`)
- Use branch-prefixed cache keys (`{github.head_ref || github.ref}/build-number-{run_id}`) aligned with `gh-action_cache` S3 layout
- Keep the split restore → increment → save → cleanup lifecycle so `.build_number.txt` is removed from the workspace after save
- Re-enable `exit 1` on cross-job reuse mismatches in `Test Build Number` (previously commented out as flaky under GitHub Actions cache)

## Test plan

- [ ] `Test Build Number` workflow passes (generation, same-job stability, cross-job Linux reuse, cross-OS Windows reuse, env bypass)
- [ ] Confirm build number is not re-incremented on workflow rerun (S3 cache hit)
- [ ] Verify consuming workflows still work with `id-token: write` permission