### PR TITLE
BUILD-11520 Migrate code-signing off deprecated digicert/ssm-code-signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1307,10 +1307,12 @@ No outputs are provided by this action.
 
 ## `code-signing`
 
-Install and configure DigiCert smctl and jsign tools for code signing with caching support.
+Install and configure DigiCert Software Trust Manager (smctl) and jsign tools for code signing with caching support.
 
-This action provides a complete setup for DigiCert's SigningManager tools (smctl) and jsign with intelligent caching
+This action provides a complete setup for DigiCert's Software Trust Manager tools (smctl) and jsign with intelligent caching
 to avoid re-downloading tools on every run. It handles all DigiCert authentication setup and environment configuration.
+It uses the maintained [DigiCert Binary Signing](https://github.com/marketplace/actions/digicert-binary-signing) action
+(`digicert/code-signing-software-trust-action`), which replaces the deprecated `digicert/ssm-code-signing`.
 
 ### Requirements
 
@@ -1363,7 +1365,7 @@ After running this action, the following environment variables are available:
 - `SM_CLIENT_CERT_FILE`: Path to the decoded client certificate file
 - `SM_CLIENT_CERT_PASSWORD`: Client certificate password
 - `SM_CODE_SIGNING_CERT_SHA1_HASH`: Certificate fingerprint for signing
-- `SMTOOLS_PATH`: Path where SMTools are installed, certificate and `.cfg` file is stored.
+- `SMTOOLS_PATH`: Directory containing the generated `pkcs11properties.cfg` PKCS#11 provider config used for signing.
 
 ---
 

--- a/code-signing/action.yml
+++ b/code-signing/action.yml
@@ -1,12 +1,12 @@
 ---
 name: Setup DigiCert Code Signing Tools
-description: Install and configure DigiCert smctl and jsign tools with caching support
+description: Install and configure DigiCert Software Trust Manager (smctl) and jsign tools with caching support
 inputs:
   jsign-version:
     description: Version of jsign to install
     default: 7.2
   force-download-tools:
-    description: Force download both DigiCert and jsign tools (disables caching)
+    description: Force a fresh download of the DigiCert and jsign tools (bypasses caching)
     default: false
 
 runs:
@@ -19,18 +19,14 @@ runs:
       run: |
         echo "JSIGN_VERSION=${JSIGN_VERSION}" >> "$GITHUB_ENV"
         echo "JSIGN_CACHE_KEY=jsign-${JSIGN_VERSION}-${{ runner.os }}" >> "$GITHUB_ENV"
-        echo "SMTOOLS_CACHE_KEY=smtools-linux-x64-${{ runner.os }}" >> "$GITHUB_ENV"
-        echo "SMTOOLS_PATH=/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64" >> "$GITHUB_ENV"
         echo "JSIGN_CACHE_PATH=/tmp/jsign-cache" >> "$GITHUB_ENV"
 
-    - name: Cache code signing tools
+    - name: Cache jsign
       uses: SonarSource/gh-action_cache@a7d13cdd1c9f097a5f8382ccec463be2831e3dbc # v1.6.0
-      id: tools-cache
+      id: jsign-cache
       with:
-        path: |
-          /tmp/DigiCert One Signing Manager Tools/smtools-linux-x64
-          /tmp/jsign-cache
-        key: tools-${{ env.SMTOOLS_CACHE_KEY }}-${{ env.JSIGN_CACHE_KEY }}
+        path: /tmp/jsign-cache
+        key: ${{ env.JSIGN_CACHE_KEY }}
 
     - name: Get DigiCert secrets from Vault
       id: secrets
@@ -43,18 +39,41 @@ runs:
           development/kv/data/sign/digicert client_cert_password | SM_CLIENT_CERT_PASSWORD;
           development/kv/data/sign/digicert host | SM_HOST;
 
-    - name: Setup DigiCert Client Tools
-      if: steps.tools-cache.outputs.cache-hit != 'true' || inputs.force-download-tools == 'true'
-      uses: digicert/ssm-code-signing@1d820463733701cf1484c7eb5d7d24a15ca2c454 # v1.2.1
-      with:
-        force-download-tools: ${{ inputs.force-download-tools }}
-
-    - name: Add smctl to PATH (when using cache)
-      if: steps.tools-cache.outputs.cache-hit == 'true' && inputs.force-download-tools != 'true'
+    - name: Setup certificate and environment variables
       shell: bash
       run: |
-        echo "Using cached smctl from ${SMTOOLS_PATH}"
-        echo "${SMTOOLS_PATH}" >> "$GITHUB_PATH"
+        rm -f Certificate_pkcs12.p12
+        echo '${{ fromJSON(steps.secrets.outputs.vault).SM_CLIENT_CERT_FILE_B64 }}' | base64 --decode > Certificate_pkcs12.p12
+        echo "SM_HOST=${{ fromJSON(steps.secrets.outputs.vault).SM_HOST }}" >> "$GITHUB_ENV"
+        echo "SM_API_KEY=${{ fromJSON(steps.secrets.outputs.vault).SM_API_KEY }}" >> "$GITHUB_ENV"
+        echo "SM_CLIENT_CERT_FILE=${PWD}/Certificate_pkcs12.p12" >> "$GITHUB_ENV"
+        echo "SM_CLIENT_CERT_PASSWORD=${{ fromJSON(steps.secrets.outputs.vault).SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
+        echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ fromJSON(steps.secrets.outputs.vault).SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
+
+    - name: Setup DigiCert Software Trust Manager tools
+      id: digicert-setup
+      uses: digicert/code-signing-software-trust-action@fae23a455ba4bde62b64fd7cb2f81ade788f5a95 # v1.2.1
+      with:
+        # force-download-tools disables the action's GitHub cache so the tools are re-downloaded
+        use-github-caching-service: ${{ inputs.force-download-tools != 'true' }}
+
+    - name: Expose Software Trust Manager tools path
+      shell: bash
+      env:
+        PKCS11_CONFIG: ${{ steps.digicert-setup.outputs.PKCS11_CONFIG }}
+      run: |
+        # Preserve the SMTOOLS_PATH contract used by downstream signing
+        # (e.g. sonarlint-eclipse pom.xml: ${env.SMTOOLS_PATH}/pkcs11properties.cfg).
+        if [[ -z "${PKCS11_CONFIG}" ]]; then
+          echo "::error::code-signing-software-trust-action did not expose a PKCS11_CONFIG output"
+          exit 1
+        fi
+        SMTOOLS_PATH="$(dirname "${PKCS11_CONFIG}")"
+        echo "SMTOOLS_PATH=${SMTOOLS_PATH}" >> "$GITHUB_ENV"
+        # Ensure the lowercase filename consumers expect resolves to the generated config.
+        if [[ ! -e "${SMTOOLS_PATH}/pkcs11properties.cfg" ]]; then
+          ln -sf "${PKCS11_CONFIG}" "${SMTOOLS_PATH}/pkcs11properties.cfg"
+        fi
 
     - name: Setup jsign
       shell: bash
@@ -68,7 +87,7 @@ runs:
         sudo apt-get update -q
         sudo apt-get install -y default-jre-headless
 
-        if [[ "${{ steps.tools-cache.outputs.cache-hit }}" == "true" && "${FORCE_DOWNLOAD_TOOLS}" != "true" &&
+        if [[ "${{ steps.jsign-cache.outputs.cache-hit }}" == "true" && "${FORCE_DOWNLOAD_TOOLS}" != "true" &&
         -f "${JSIGN_CACHE_PATH}/jsign_${JSIGN_VERSION}_all.deb" ]]; then
           echo "Installing jsign from cache..."
           sudo dpkg --install "${JSIGN_CACHE_PATH}/jsign_${JSIGN_VERSION}_all.deb"
@@ -79,18 +98,6 @@ runs:
           curl -L --fail --silent --show-error "${JSIGN_URL}" --output "${JSIGN_CACHE_PATH}/jsign_${JSIGN_VERSION}_all.deb"
           sudo dpkg --install "${JSIGN_CACHE_PATH}/jsign_${JSIGN_VERSION}_all.deb"
         fi
-
-    - name: Setup certificate and environment variables
-      shell: bash
-      run: |
-        rm -f Certificate_pkcs12.p12
-        echo '${{ fromJSON(steps.secrets.outputs.vault).SM_CLIENT_CERT_FILE_B64 }}' | base64 --decode > Certificate_pkcs12.p12
-        echo "SM_HOST=${{ fromJSON(steps.secrets.outputs.vault).SM_HOST }}" >> "$GITHUB_ENV"
-        echo "SM_API_KEY=${{ fromJSON(steps.secrets.outputs.vault).SM_API_KEY }}" >> "$GITHUB_ENV"
-        echo "SM_CLIENT_CERT_FILE=${PWD}/Certificate_pkcs12.p12" >> "$GITHUB_ENV"
-        echo "SM_CLIENT_CERT_PASSWORD=${{ fromJSON(steps.secrets.outputs.vault).SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
-        echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ fromJSON(steps.secrets.outputs.vault).SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
-
 
     - name: Verify tool installations
       shell: bash
@@ -112,6 +119,14 @@ runs:
           jsign --help
         else
           echo "❌ jsign not found"
+          exit 1
+        fi
+
+        # Check the PKCS#11 config used by downstream signing
+        if [[ -e "${SMTOOLS_PATH}/pkcs11properties.cfg" ]]; then
+          echo "✅ pkcs11properties.cfg available under SMTOOLS_PATH"
+        else
+          echo "❌ pkcs11properties.cfg not found under ${SMTOOLS_PATH}"
           exit 1
         fi
 


### PR DESCRIPTION
## Why

`code-signing/action.yml` pinned **`digicert/ssm-code-signing@v1.2.1`**, which DigiCert has **vendor-EOL'd**:

- End-of-service: **2026-03-01**
- End-of-life: **2026-05-01** (already past — this is overdue)

DigiCert steers users to **DigiCert Binary Signing** (`digicert/code-signing-software-trust-action`), which is maintained and runs on **Node 24**. Tracked as [BUILD-11520](https://sonarsource.atlassian.net/browse/BUILD-11520) (surfaced in the [BUILD-10781](https://sonarsource.atlassian.net/browse/BUILD-10781) audit).

## What changed (`code-signing/action.yml`)

Swapped the tool-setup step to `digicert/code-signing-software-trust-action@v1.2.1` (SHA-pinned) in its **default (full) mode**, which installs the Software Trust Manager client tools + `smctl` and generates the PKCS#11 provider config (`simple-signing-mode` would only install `smctl`, without the PKCS#11 module `jsign` needs, so it's intentionally left off).

Because the new action **manages its own download / caching / PATH**, the migration is more than a `uses:` swap:

| Area | Before | After |
|---|---|---|
| smctl tool cache | bespoke `gh-action_cache` of `/tmp/DigiCert One Signing Manager Tools/...` + manual "add smctl to PATH" step | handled by the action (`use-github-caching-service`) — both removed |
| jsign cache | shared cache step | kept (jsign-only cache) |
| `SM_*` env + client cert | set **after** the DigiCert step | moved **before** it (the action needs them to generate the PKCS#11 config) |
| `SMTOOLS_PATH` output | hardcoded to the legacy install dir | derived from the action's `PKCS11_CONFIG` output; a lowercase `pkcs11properties.cfg` symlink is ensured there |
| inputs | `jsign-version`, `force-download-tools` | unchanged; `force-download-tools` now maps to the action's `use-github-caching-service` |

### Why `SMTOOLS_PATH` matters (consumer contract)

`SonarSource/sonarlint-eclipse` (the only consumer) signs via its `pom.xml`:

```xml
<providerArg>${env.SMTOOLS_PATH}/pkcs11properties.cfg</providerArg>
```

So `SMTOOLS_PATH` + a `pkcs11properties.cfg` at that path is a **public output contract** of this action. It is preserved here, so `sonarlint-eclipse` needs **no change**. A fail-fast guard + a verify-step check make a broken contract obvious in CI logs rather than silently breaking signing.

## Acceptance criteria ([BUILD-11520](https://sonarsource.atlassian.net/browse/BUILD-11520))

- [x] Confirm the EOL date (EOS 2026-03-01, EOL 2026-05-01 per DigiCert docs)
- [x] Evaluate the maintained alternative for input/output compatibility (see table above)
- [x] Update `ci-github-actions/code-signing/action.yml` to the maintained action
- [ ] Smoke test against a downstream consumer that actually signs binaries (see Test plan)

## Test plan

> ⚠️ The one thing this PR cannot fully prove on its own is that **real Windows signing** still works end-to-end, because the install path / config filename produced by the new action is inferred from its `PKCS11_CONFIG` output. This needs a signing run on the consumer.

1. **CI on this PR:** `pre-commit` (yamllint --strict + actionlint), shell specs, etc. validate structure. There is no signing in this repo's CI.
2. **Real signing smoke test (required before merge):** on a branch of **`sonarlint-eclipse`**, point the signing jobs at this branch:
   ```yaml
   - uses: SonarSource/ci-github-actions/code-signing@feat/smarini/BUILD-11520-digicertBinarySigning
   ```
   Run the **Build** workflow on a job that signs Windows artifacts, then confirm:
   - the action's `Verify tool installations` step passes (`smctl`, `jsign`, and `pkcs11properties.cfg` under `SMTOOLS_PATH` all present),
   - the Maven `jsign` / `SunPKCS11` signing step produces signed binaries,
   - `smctl --version` and the signing step logs show **no Node 20 deprecation warning**.
3. Run twice to confirm caching behaves (second run hits the new action's cache + the jsign cache).
4. After merge, **move the `v1` tag** so `sonarlint-eclipse@v1` consumers pick it up.

## Risk / rollback

Low blast radius (single consumer). If signing regresses, revert this commit; the deprecated action still exists on the marketplace but is past EOL, so reverting is only a short-term measure.

[BUILD-11520]: https://sonarsource.atlassian.net/browse/BUILD-11520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-10781]: https://sonarsource.atlassian.net/browse/BUILD-10781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BUILD-11520]: https://sonarsource.atlassian.net/browse/BUILD-11520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ