### PR TITLE
BUILD-11571: Pin check-sca version with better vault-error-output

### DIFF
--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -23,4 +23,4 @@ jobs:
     environment: sca-checking
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: SonarSource/ci-github-actions/check-sca@fdeb37e59320b102baec4c58662355e715b1c092 # master
+      - uses: SonarSource/ci-github-actions/check-sca@440aa1c41e5d7fb10f3354faeebb7a648ddc29ac # master


### PR DESCRIPTION
Follow up to https://github.com/SonarSource/ci-github-actions/pull/300 so that this newly committed to `master` version of `check-sca` gets used in this repo as well as all of the other repos via the org ruleset.

## Test Plan
- After merging this PR, make another test commit to https://github.com/SonarSource/dbd-ir-interpreter/pull/10 and ensure this newer version of the `check-sca` action gets picked up