### PR TITLE
PREQ-6490: check-sca workflow should not create temporary deployments

### DIFF
--- a/.github/workflows/check-sca.yml
+++ b/.github/workflows/check-sca.yml
@@ -20,7 +20,11 @@ jobs:
     # it: "OIDC error: the claim 'environment' cannot be null or empty".
     # `sca-checking` is appropriate here as it is a unique value and
     # will not be triggered on dev deploys.
-    environment: sca-checking
+    environment:
+      name: sca-checking
+      # Suppress the temporary deployment record/notification (GA 2026-03)
+      # while keeping the OIDC `environment` claim that Vault requires.
+      deployment: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: SonarSource/ci-github-actions/check-sca@440aa1c41e5d7fb10f3354faeebb7a648ddc29ac # master

--- a/.github/workflows/test-pr-cleanup.yml
+++ b/.github/workflows/test-pr-cleanup.yml
@@ -33,6 +33,7 @@ jobs:
     needs: test-resources
     permissions:
       actions: write  # Required for cache/artifact operations
+      contents: read  # Required for checkout
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run PR cleanup

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,8 @@ repos:
     rev: 96ee1570b119e6337aafcc2f299bb0d902b68328  # 0.28.6
     hooks:
       - id: check-github-workflows
+        # TEMP: bundled schema predates `environment.deployment` (GA 2026-03)
+        exclude: ^\.github/workflows/check-sca\.yml$
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: f295829140d25717bc79368d3f966fc1f67a824f  # v0.41.0
     hooks:
@@ -37,3 +39,7 @@ repos:
     rev: 62dc61a45fc95efe8c800af7a557ab0b9165d63b  # v1.7.1
     hooks:
       - id: actionlint
+        # TEMP: actionlint v1.7.1 schema predates `environment.deployment`
+        args:
+          - -ignore
+          - unexpected key "deployment" for "environment" section


### PR DESCRIPTION
----
## Summary by Gitar

- **Workflow configuration:**
  - Modified `check-sca.yml` to set `deployment: false` for the `sca-checking` environment.
- **Permissions:**
  - Added `contents: read` permission to the `test-cleanup` job in `test-pr-cleanup.yml` to enable checkout.
- **Linting bypass:**
  - Updated `.pre-commit-config.yaml` to exclude `check-sca.yml` from `check-github-workflows` and ignore the `deployment` key in `actionlint` due to schema limitations.

<sub>This will update automatically on new commits.</sub>