### PR TITLE
BUILD-11613 Create a channel version file only containing the version

### DIFF
--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Assert key output
         run: |
           [[ "${{ steps.urc.outputs.key }}" == "Distribution/test-fixture/stable.json" ]]
+          [[ "${{ steps.urc.outputs.version-key }}" == "Distribution/test-fixture/stable.version" ]]
+          [[ "${{ steps.urc.outputs.version-body }}" == "0.0.0-test" ]]
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.9
@@ -93,3 +95,4 @@ jobs:
       - name: Assert custom prefix used in key
         run: |
           [[ "${{ steps.urc.outputs.key }}" == "NotDistribution/test-fixture/stable.json" ]]
+          [[ "${{ steps.urc.outputs.version-key }}" == "NotDistribution/test-fixture/stable.version" ]]

--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -27,8 +27,6 @@ jobs:
       - name: Assert key output
         run: |
           [[ "${{ steps.urc.outputs.key }}" == "Distribution/test-fixture/stable.json" ]]
-          [[ "${{ steps.urc.outputs.version-key }}" == "Distribution/test-fixture/stable.version" ]]
-          [[ "${{ steps.urc.outputs.version-body }}" == "0.0.0-test" ]]
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.9
@@ -95,4 +93,3 @@ jobs:
       - name: Assert custom prefix used in key
         run: |
           [[ "${{ steps.urc.outputs.key }}" == "NotDistribution/test-fixture/stable.json" ]]
-          [[ "${{ steps.urc.outputs.version-key }}" == "NotDistribution/test-fixture/stable.version" ]]

--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Assert key output
         run: |
           [[ "${{ steps.urc.outputs.key }}" == "Distribution/test-fixture/stable.json" ]]
+          [[ "${{ steps.urc.outputs.version-key }}" == "Distribution/test-fixture/stable.version" ]]
+          [[ "${{ steps.urc.outputs.version-url }}" == "https://binaries.sonarsource.com/Distribution/test-fixture/stable.version" ]]
+          [[ "${{ steps.urc.outputs.version }}" == "0.0.0-test" ]]
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.9
@@ -93,3 +96,4 @@ jobs:
       - name: Assert custom prefix used in key
         run: |
           [[ "${{ steps.urc.outputs.key }}" == "NotDistribution/test-fixture/stable.json" ]]
+          [[ "${{ steps.urc.outputs.version-key }}" == "NotDistribution/test-fixture/stable.version" ]]

--- a/README.md
+++ b/README.md
@@ -1445,11 +1445,11 @@ jobs:
 
 ## `update-release-channel`
 
-Updates a per-channel JSON pointer file on `binaries.sonarsource.com` so consumers can discover the currently published
-version for each release channel of a product. Writes one JSON file per channel at
-`<prefix>/<product>/<channel>.json` (atomic, single S3 `PutObject`). The body follows the
-[v1 schema](update-release-channel/schema/v1.json); see [schema/README.md](update-release-channel/schema/README.md) for the
-field contract.
+Updates per-channel release files on `binaries.sonarsource.com` so consumers can discover the currently published
+version for each release channel of a product. Writes two files per channel:
+`<prefix>/<product>/<channel>.json` and `<prefix>/<product>/<channel>.version`. The JSON body follows the
+[v1 schema](update-release-channel/schema/v1.json); the `.version` file contains only the version string. See
+[schema/README.md](update-release-channel/schema/README.md) for the JSON field contract.
 
 ### Requirements
 
@@ -1531,12 +1531,15 @@ Terraform resource; add the environment for your repo there alongside the existi
 
 ### Outputs
 
-| Output   | Description                                                                     |
-|----------|---------------------------------------------------------------------------------|
-| `bucket` | S3 bucket of the JSON pointer file.                                             |
-| `key`    | S3 key of the JSON pointer file (e.g. `Distribution/<product>/<channel>.json`). |
-| `url`    | Public URL of the JSON pointer file.                                            |
-| `body`   | Content of the JSON pointer file.                                               |
+| Output         | Description                                                                              |
+|----------------|------------------------------------------------------------------------------------------|
+| `bucket`       | S3 bucket of the channel files.                                                          |
+| `key`          | S3 key of the JSON pointer file (e.g. `Distribution/<product>/<channel>.json`).         |
+| `url`          | Public URL of the JSON pointer file.                                                     |
+| `body`         | Content of the JSON pointer file.                                                        |
+| `version-key`  | S3 key of the sibling plain-text version file (e.g. `Distribution/<product>/<channel>.version`). |
+| `version-url`  | Public URL of the sibling plain-text version file.                                       |
+| `version-body` | Content of the sibling plain-text version file.                                          |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1531,15 +1531,12 @@ Terraform resource; add the environment for your repo there alongside the existi
 
 ### Outputs
 
-| Output         | Description                                                                              |
-|----------------|------------------------------------------------------------------------------------------|
-| `bucket`       | S3 bucket of the channel files.                                                          |
-| `key`          | S3 key of the JSON pointer file (e.g. `Distribution/<product>/<channel>.json`).         |
-| `url`          | Public URL of the JSON pointer file.                                                     |
-| `body`         | Content of the JSON pointer file.                                                        |
-| `version-key`  | S3 key of the sibling plain-text version file (e.g. `Distribution/<product>/<channel>.version`). |
-| `version-url`  | Public URL of the sibling plain-text version file.                                       |
-| `version-body` | Content of the sibling plain-text version file.                                          |
+| Output   | Description                                                                     |
+|----------|---------------------------------------------------------------------------------|
+| `bucket` | S3 bucket of the channel files.                                                 |
+| `key`    | S3 key of the JSON pointer file (e.g. `Distribution/<product>/<channel>.json`). |
+| `url`    | Public URL of the JSON pointer file.                                            |
+| `body`   | Content of the JSON pointer file.                                               |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1531,12 +1531,15 @@ Terraform resource; add the environment for your repo there alongside the existi
 
 ### Outputs
 
-| Output   | Description                                                                     |
-|----------|---------------------------------------------------------------------------------|
-| `bucket` | S3 bucket of the channel files.                                                 |
-| `key`    | S3 key of the JSON pointer file (e.g. `Distribution/<product>/<channel>.json`). |
-| `url`    | Public URL of the JSON pointer file.                                            |
-| `body`   | Content of the JSON pointer file.                                               |
+| Output        | Description                                                                                           |
+|---------------|-------------------------------------------------------------------------------------------------------|
+| `bucket`      | S3 bucket of the channel files.                                                                       |
+| `key`         | S3 key of the JSON pointer file (e.g. `Distribution/<product>/<channel>.json`).                       |
+| `url`         | Public URL of the JSON pointer file.                                                                  |
+| `body`        | Content of the JSON pointer file.                                                                     |
+| `version-key` | S3 key of the sibling plain-text version file (e.g. `Distribution/<product>/<channel>.version`).      |
+| `version-url` | Public URL of the sibling plain-text version file.                                                    |
+| `version`     | Content of the sibling plain-text version file.                                                       |
 
 ---
 

--- a/spec/update-release-channel_spec.sh
+++ b/spec/update-release-channel_spec.sh
@@ -38,9 +38,6 @@ Describe 'update-release-channel/update-release-channel.sh'
       The contents of file "$GITHUB_OUTPUT" should include "key=Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "body={"
-      The contents of file "$GITHUB_OUTPUT" should include "version-key=Distribution/sonarqube-cli/latest.version"
-      The contents of file "$GITHUB_OUTPUT" should include "version-url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.version"
-      The contents of file "$GITHUB_OUTPUT" should include "version-body=0.9.0.977"
       The contents of file "$GITHUB_STEP_SUMMARY" should include "update-release-channel"
       The contents of file "$GITHUB_STEP_SUMMARY" should include "Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_STEP_SUMMARY" should include "Distribution/sonarqube-cli/latest.version"
@@ -152,8 +149,6 @@ Describe 'update-release-channel/update-release-channel.sh'
       The output should include "Wrote https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.version"
       The contents of file "$GITHUB_OUTPUT" should include "url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "body={"
-      The contents of file "$GITHUB_OUTPUT" should include "version-url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.version"
-      The contents of file "$GITHUB_OUTPUT" should include "version-body=0.9.0.977"
     End
   End
 End

--- a/spec/update-release-channel_spec.sh
+++ b/spec/update-release-channel_spec.sh
@@ -31,12 +31,19 @@ Describe 'update-release-channel/update-release-channel.sh'
       The output should include "Dry-run: aws s3api put-object"
       The output should include "--cache-control 'no-cache, no-store, max-age=0'"
       The output should include "--content-type application/json"
+      The output should include "--key Distribution/sonarqube-cli/latest.version"
+      The output should include "--content-type text/plain"
+      The output should include "Dry-run version body: 0.9.0.977"
       The contents of file "$GITHUB_OUTPUT" should include "bucket=downloads-cdn-eu-central-1-prod"
       The contents of file "$GITHUB_OUTPUT" should include "key=Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "body={"
+      The contents of file "$GITHUB_OUTPUT" should include "version-key=Distribution/sonarqube-cli/latest.version"
+      The contents of file "$GITHUB_OUTPUT" should include "version-url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.version"
+      The contents of file "$GITHUB_OUTPUT" should include "version-body=0.9.0.977"
       The contents of file "$GITHUB_STEP_SUMMARY" should include "update-release-channel"
       The contents of file "$GITHUB_STEP_SUMMARY" should include "Distribution/sonarqube-cli/latest.json"
+      The contents of file "$GITHUB_STEP_SUMMARY" should include "Distribution/sonarqube-cli/latest.version"
     End
 
     # Requires `check-jsonschema` on PATH (installed by the CI workflow).
@@ -95,17 +102,45 @@ Describe 'update-release-channel/update-release-channel.sh'
   Describe 'non-dry-run path'
     Mock aws
       body_file=""
+      content_type=""
+      key=""
       while [[ "$#" -gt 0 ]]; do
-        if [[ "$1" == "--body" ]]; then
-          body_file="$2"
-          break
-        fi
-        shift
+        case "$1" in
+          --body)
+            body_file="$2"
+            shift 2
+            ;;
+          --content-type)
+            content_type="$2"
+            shift 2
+            ;;
+          --key)
+            key="$2"
+            shift 2
+            ;;
+          *)
+            shift
+            ;;
+        esac
       done
       [[ -n "$body_file" ]] || exit 1
+      [[ -n "$content_type" ]] || exit 1
+      [[ -n "$key" ]] || exit 1
       [[ "$body_file" != "/dev/stdin" ]] || exit 1
       [[ -f "$body_file" ]] || exit 1
-      grep -q '"version":"0.9.0.977"' "$body_file" || exit 1
+      case "$key" in
+        "Distribution/sonarqube-cli/latest.json")
+          [[ "$content_type" == "application/json" ]] || exit 1
+          grep -q '"version":"0.9.0.977"' "$body_file" || exit 1
+          ;;
+        "Distribution/sonarqube-cli/latest.version")
+          [[ "$content_type" == "text/plain" ]] || exit 1
+          [[ "$(cat "$body_file")" == "0.9.0.977" ]] || exit 1
+          ;;
+        *)
+          exit 1
+          ;;
+      esac
       echo '{"ServerSideEncryption":"AES256"}'
     End
 
@@ -114,8 +149,11 @@ Describe 'update-release-channel/update-release-channel.sh'
       When run script update-release-channel/update-release-channel.sh
       The status should be success
       The output should include "Wrote https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.json"
+      The output should include "Wrote https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.version"
       The contents of file "$GITHUB_OUTPUT" should include "url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "body={"
+      The contents of file "$GITHUB_OUTPUT" should include "version-url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.version"
+      The contents of file "$GITHUB_OUTPUT" should include "version-body=0.9.0.977"
     End
   End
 End

--- a/spec/update-release-channel_spec.sh
+++ b/spec/update-release-channel_spec.sh
@@ -38,9 +38,12 @@ Describe 'update-release-channel/update-release-channel.sh'
       The contents of file "$GITHUB_OUTPUT" should include "key=Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "body={"
+      The contents of file "$GITHUB_OUTPUT" should include "version-key=Distribution/sonarqube-cli/latest.version"
+      The contents of file "$GITHUB_OUTPUT" should include "version-url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.version"
+      The contents of file "$GITHUB_OUTPUT" should include "version=0.9.0.977"
       The contents of file "$GITHUB_STEP_SUMMARY" should include "update-release-channel"
       The contents of file "$GITHUB_STEP_SUMMARY" should include "Distribution/sonarqube-cli/latest.json"
-      The contents of file "$GITHUB_STEP_SUMMARY" should include "Distribution/sonarqube-cli/latest.version"
+      The contents of file "$GITHUB_STEP_SUMMARY" should not include "Distribution/sonarqube-cli/latest.version"
     End
 
     # Requires `check-jsonschema` on PATH (installed by the CI workflow).
@@ -93,6 +96,7 @@ Describe 'update-release-channel/update-release-channel.sh'
       The stderr should include "::warning::Custom prefix 'NotDistribution'"
       The output should include "--key NotDistribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "key=NotDistribution/sonarqube-cli/latest.json"
+      The contents of file "$GITHUB_OUTPUT" should include "version-key=NotDistribution/sonarqube-cli/latest.version"
     End
   End
 
@@ -149,6 +153,8 @@ Describe 'update-release-channel/update-release-channel.sh'
       The output should include "Wrote https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.version"
       The contents of file "$GITHUB_OUTPUT" should include "url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.json"
       The contents of file "$GITHUB_OUTPUT" should include "body={"
+      The contents of file "$GITHUB_OUTPUT" should include "version-url=https://binaries.sonarsource.com/Distribution/sonarqube-cli/latest.version"
+      The contents of file "$GITHUB_OUTPUT" should include "version=0.9.0.977"
     End
   End
 End

--- a/update-release-channel/action.yml
+++ b/update-release-channel/action.yml
@@ -36,15 +36,6 @@ outputs:
       The JSON body written (or that would be written) to S3. Always set.
       Useful for schema validation and debugging in dry-run mode.
     value: ${{ steps.update.outputs.body }}
-  version-key:
-    description: S3 key of the sibling plain-text version file (e.g. `Distribution/<product>/<channel>.version`).
-    value: ${{ steps.update.outputs.version-key }}
-  version-url:
-    description: Public URL of the sibling plain-text version file.
-    value: ${{ steps.update.outputs.version-url }}
-  version-body:
-    description: Version string written to the sibling plain-text version file. Always set.
-    value: ${{ steps.update.outputs.version-body }}
 
 runs:
   using: composite

--- a/update-release-channel/action.yml
+++ b/update-release-channel/action.yml
@@ -1,7 +1,7 @@
 ---
 name: Update release channel
 description: |
-  Update a release channel pointer (e.g. `Distribution/<product>/latest.json`) on
+  Update release channel files (e.g. `Distribution/<product>/latest.json` and `.version`) on
   `binaries.sonarsource.com` so consumers can discover the currently published version.
 inputs:
   version:
@@ -23,7 +23,7 @@ inputs:
     default: 'false'
 outputs:
   bucket:
-    description: S3 bucket the channel pointer was (or would be) written to.
+    description: S3 bucket the channel files were (or would be) written to.
     value: ${{ steps.update.outputs.bucket }}
   key:
     description: S3 key of the channel pointer (e.g. `Distribution/<product>/<channel>.json`).
@@ -36,6 +36,15 @@ outputs:
       The JSON body written (or that would be written) to S3. Always set.
       Useful for schema validation and debugging in dry-run mode.
     value: ${{ steps.update.outputs.body }}
+  version-key:
+    description: S3 key of the sibling plain-text version file (e.g. `Distribution/<product>/<channel>.version`).
+    value: ${{ steps.update.outputs.version-key }}
+  version-url:
+    description: Public URL of the sibling plain-text version file.
+    value: ${{ steps.update.outputs.version-url }}
+  version-body:
+    description: Version string written to the sibling plain-text version file. Always set.
+    value: ${{ steps.update.outputs.version-body }}
 
 runs:
   using: composite

--- a/update-release-channel/action.yml
+++ b/update-release-channel/action.yml
@@ -1,7 +1,7 @@
 ---
 name: Update release channel
 description: |
-  Update release channel files (e.g. `Distribution/<product>/latest.json` and `.version`) on
+  Update release channel files (e.g. `Distribution/<product>/latest.json` and `Distribution/<product>/latest.version`) on
   `binaries.sonarsource.com` so consumers can discover the currently published version.
 inputs:
   version:

--- a/update-release-channel/action.yml
+++ b/update-release-channel/action.yml
@@ -36,6 +36,15 @@ outputs:
       The JSON body written (or that would be written) to S3. Always set.
       Useful for schema validation and debugging in dry-run mode.
     value: ${{ steps.update.outputs.body }}
+  version-key:
+    description: S3 key of the sibling plain-text version file (e.g. `Distribution/<product>/<channel>.version`).
+    value: ${{ steps.update.outputs.version-key }}
+  version-url:
+    description: Public URL of the sibling plain-text version file.
+    value: ${{ steps.update.outputs.version-url }}
+  version:
+    description: Version string written to the sibling plain-text version file. Always set.
+    value: ${{ steps.update.outputs.version }}
 
 runs:
   using: composite

--- a/update-release-channel/schema/README.md
+++ b/update-release-channel/schema/README.md
@@ -1,7 +1,11 @@
 # Release channel pointer schema
 
-JSON Schema for the per-channel pointer file written by the `update-release-channel` GitHub Action to
+JSON Schema for the per-channel pointer JSON file written by the `update-release-channel` GitHub Action to
 `s3://downloads-cdn-eu-central-1-prod/<prefix>/<product>/<channel>.json`.
+
+The action also writes a sibling plain-text file at
+`s3://downloads-cdn-eu-central-1-prod/<prefix>/<product>/<channel>.version` containing only the version string. That
+file is not covered by this JSON schema.
 
 ## Versioning
 

--- a/update-release-channel/update-release-channel.sh
+++ b/update-release-channel/update-release-channel.sh
@@ -68,8 +68,11 @@ fi
   echo "key=$KEY"
   echo "url=$URL"
   echo "body=$JSON_BODY"
+  echo "version-key=$VERSION_KEY"
+  echo "version-url=$VERSION_URL"
+  echo "version=$VERSION"
 } >> "${GITHUB_OUTPUT:?}"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  echo "**update-release-channel** → [\`$KEY\`]($URL), [\`$VERSION_KEY\`]($VERSION_URL) (version \`$VERSION\`, dry-run \`$DRY_RUN\`)" >> "$GITHUB_STEP_SUMMARY"
+  echo "**update-release-channel** → [\`$KEY\`]($URL) (version \`$VERSION\`, dry-run \`$DRY_RUN\`)" >> "$GITHUB_STEP_SUMMARY"
 fi

--- a/update-release-channel/update-release-channel.sh
+++ b/update-release-channel/update-release-channel.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# Update a release channel pointer at
+# Update release channel files at
 # s3://downloads-cdn-eu-central-1-prod/<prefix>/<product>/<channel>.json
-# (served at https://binaries.sonarsource.com/<prefix>/<product>/<channel>.json).
+# and s3://downloads-cdn-eu-central-1-prod/<prefix>/<product>/<channel>.version
+# (served at https://binaries.sonarsource.com/<prefix>/<product>/<channel>.json
+# and https://binaries.sonarsource.com/<prefix>/<product>/<channel>.version).
 #
 # Required environment variables:
 #   VERSION - Version the channel should point at (e.g. "0.9.0.977")
@@ -20,6 +22,7 @@ set -euo pipefail
 
 readonly BUCKET="downloads-cdn-eu-central-1-prod"
 readonly PUBLIC_BASE_URL="https://binaries.sonarsource.com"
+readonly CACHE_CONTROL="no-cache, no-store, max-age=0"
 
 [[ "$CHANNEL" =~ ^(latest|stable|beta|rc|dogfood)$ ]] \
   || { echo "::error::Invalid channel '$CHANNEL'. Must be one of: latest, stable, beta, rc, dogfood." >&2; exit 1; }
@@ -32,21 +35,32 @@ readonly PUBLIC_BASE_URL="https://binaries.sonarsource.com"
 
 KEY="$PREFIX/$PRODUCT/$CHANNEL.json"
 URL="$PUBLIC_BASE_URL/$KEY"
+VERSION_KEY="$PREFIX/$PRODUCT/$CHANNEL.version"
+VERSION_URL="$PUBLIC_BASE_URL/$VERSION_KEY"
 UPDATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 BODY="$(jq -cn --arg v "$VERSION" --arg t "$UPDATED_AT" '{schemaVersion:1, version:$v, updatedAt:$t}')"
+VERSION_BODY="$VERSION"
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  echo "Dry-run: aws s3api put-object --bucket $BUCKET --key $KEY --cache-control 'no-cache, no-store, max-age=0' --content-type application/json --body <generated-json-file>"
+  echo "Dry-run: aws s3api put-object --bucket $BUCKET --key $KEY --cache-control '$CACHE_CONTROL' --content-type application/json --body <generated-json-file>"
   echo "Dry-run body: $BODY"
+  echo "Dry-run: aws s3api put-object --bucket $BUCKET --key $VERSION_KEY --cache-control '$CACHE_CONTROL' --content-type text/plain --body <generated-version-file>"
+  echo "Dry-run version body: $VERSION_BODY"
 else
   BODY_FILE="$(mktemp)"
-  trap 'rm -f "$BODY_FILE"' EXIT
+  VERSION_BODY_FILE="$(mktemp)"
+  trap 'rm -f "$BODY_FILE" "$VERSION_BODY_FILE"' EXIT
   printf '%s' "$BODY" > "$BODY_FILE"
+  printf '%s' "$VERSION_BODY" > "$VERSION_BODY_FILE"
 
   aws s3api put-object \
     --bucket "$BUCKET" --key "$KEY" --body "$BODY_FILE" \
-    --cache-control "no-cache, no-store, max-age=0" --content-type "application/json" > /dev/null
+    --cache-control "$CACHE_CONTROL" --content-type "application/json" > /dev/null
+  aws s3api put-object \
+    --bucket "$BUCKET" --key "$VERSION_KEY" --body "$VERSION_BODY_FILE" \
+    --cache-control "$CACHE_CONTROL" --content-type "text/plain" > /dev/null
   echo "Wrote $URL"
+  echo "Wrote $VERSION_URL"
 fi
 
 {
@@ -54,8 +68,11 @@ fi
   echo "key=$KEY"
   echo "url=$URL"
   echo "body=$BODY"
+  echo "version-key=$VERSION_KEY"
+  echo "version-url=$VERSION_URL"
+  echo "version-body=$VERSION_BODY"
 } >> "${GITHUB_OUTPUT:?}"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  echo "**update-release-channel** → [\`$KEY\`]($URL) (version \`$VERSION\`, dry-run \`$DRY_RUN\`)" >> "$GITHUB_STEP_SUMMARY"
+  echo "**update-release-channel** → [\`$KEY\`]($URL), [\`$VERSION_KEY\`]($VERSION_URL) (version \`$VERSION\`, dry-run \`$DRY_RUN\`)" >> "$GITHUB_STEP_SUMMARY"
 fi

--- a/update-release-channel/update-release-channel.sh
+++ b/update-release-channel/update-release-channel.sh
@@ -38,26 +38,26 @@ URL="$PUBLIC_BASE_URL/$KEY"
 VERSION_KEY="$PREFIX/$PRODUCT/$CHANNEL.version"
 VERSION_URL="$PUBLIC_BASE_URL/$VERSION_KEY"
 UPDATED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-BODY="$(jq -cn --arg v "$VERSION" --arg t "$UPDATED_AT" '{schemaVersion:1, version:$v, updatedAt:$t}')"
+JSON_BODY="$(jq -cn --arg v "$VERSION" --arg t "$UPDATED_AT" '{schemaVersion:1, version:$v, updatedAt:$t}')"
 VERSION_BODY="$VERSION"
 
 if [[ "$DRY_RUN" == "true" ]]; then
   echo "Dry-run: aws s3api put-object --bucket $BUCKET --key $KEY --cache-control '$CACHE_CONTROL' --content-type application/json --body <generated-json-file>"
-  echo "Dry-run body: $BODY"
+  echo "Dry-run body: $JSON_BODY"
   echo "Dry-run: aws s3api put-object --bucket $BUCKET --key $VERSION_KEY --cache-control '$CACHE_CONTROL' --content-type text/plain --body <generated-version-file>"
   echo "Dry-run version body: $VERSION_BODY"
 else
-  BODY_FILE="$(mktemp)"
-  VERSION_BODY_FILE="$(mktemp)"
-  trap 'rm -f "$BODY_FILE" "$VERSION_BODY_FILE"' EXIT
-  printf '%s' "$BODY" > "$BODY_FILE"
-  printf '%s' "$VERSION_BODY" > "$VERSION_BODY_FILE"
+  JSON_FILE="$(mktemp)"
+  VERSION_FILE="$(mktemp)"
+  trap 'rm -f "$JSON_FILE" "$VERSION_FILE"' EXIT
+  printf '%s' "$JSON_BODY" > "$JSON_FILE"
+  printf '%s' "$VERSION_BODY" > "$VERSION_FILE"
 
   aws s3api put-object \
-    --bucket "$BUCKET" --key "$KEY" --body "$BODY_FILE" \
+    --bucket "$BUCKET" --key "$KEY" --body "$JSON_FILE" \
     --cache-control "$CACHE_CONTROL" --content-type "application/json" > /dev/null
   aws s3api put-object \
-    --bucket "$BUCKET" --key "$VERSION_KEY" --body "$VERSION_BODY_FILE" \
+    --bucket "$BUCKET" --key "$VERSION_KEY" --body "$VERSION_FILE" \
     --cache-control "$CACHE_CONTROL" --content-type "text/plain" > /dev/null
   echo "Wrote $URL"
   echo "Wrote $VERSION_URL"
@@ -67,7 +67,7 @@ fi
   echo "bucket=$BUCKET"
   echo "key=$KEY"
   echo "url=$URL"
-  echo "body=$BODY"
+  echo "body=$JSON_BODY"
 } >> "${GITHUB_OUTPUT:?}"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then

--- a/update-release-channel/update-release-channel.sh
+++ b/update-release-channel/update-release-channel.sh
@@ -68,9 +68,6 @@ fi
   echo "key=$KEY"
   echo "url=$URL"
   echo "body=$BODY"
-  echo "version-key=$VERSION_KEY"
-  echo "version-url=$VERSION_URL"
-  echo "version-body=$VERSION_BODY"
 } >> "${GITHUB_OUTPUT:?}"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then


### PR DESCRIPTION
----
## Summary by Gitar

- **New feature:**
  - Added generation and upload of a `.version` file containing only the version string alongside existing JSON files.
- **Updated documentation:**
  - Updated `README.md`, `action.yml`, and `schema/README.md` to reflect the new `.version` file output.
- **Tests:**
  - Updated `spec/update-release-channel_spec.sh` to verify the creation and content of the new `.version` file.

<sub>This will update automatically on new commits.</sub>