### PR TITLE
BUILD-11661: fix check-sca key discovery when sonar-project.properties lacks sonar.projectKey

### DIFF
--- a/check-sca/check-sca.sh
+++ b/check-sca/check-sca.sh
@@ -39,7 +39,7 @@ PLATFORMS=(
 # Parse a key=value property from a file. Returns the trimmed value or empty string.
 parse_property_value() {
   local file="$1" key="$2"
-  grep -E "^${key}=" "$file" | head -1 | cut -d= -f2- | tr -d '[:space:]'
+  grep -E "^${key}=" "$file" | head -1 | cut -d= -f2- | tr -d '[:space:]' || true
 }
 
 # Read a value from .github/repo-metadata.yaml under a given top-level section.

--- a/spec/check-sca_spec.sh
+++ b/spec/check-sca_spec.sh
@@ -231,6 +231,14 @@ Describe 'discover_project_keys()'
     The output should include "SonarSource_my-repo"
   End
 
+  It 'falls back to GITHUB_REPOSITORY when sonar-project.properties lacks sonar.projectKey'
+    export PROJECT_KEY_INPUT=""
+    export GITHUB_REPOSITORY="SonarSource/my-repo"
+    echo "sonar.python.version=3.13" > "$TEST_DIR/sonar-project.properties"
+    When call discover_project_keys
+    The output should include "SonarSource_my-repo"
+  End
+
   It 'deduplicates keys'
     export PROJECT_KEY_INPUT="SonarSource_test-repo"
     export GITHUB_REPOSITORY="SonarSource/test-repo"


### PR DESCRIPTION
## Summary

- `parse_property_value()` used a bare `grep` that exits 1 on no match; with `set -euo pipefail` active in the `discover_project_keys()` process substitution subshell, this caused the function to abort before reaching the `GITHUB_REPOSITORY` fallback (step 7)
- Repos with a `sonar-project.properties` that contains non-`sonar.projectKey` settings (e.g. `sonar.python.version=3.13` in `docker-images`) would always get "Could not discover any SonarQube project keys" instead of the derived key
- Fix: add `|| true` to the grep pipeline in `parse_property_value()`, matching the pattern already used for jq and perl calls in the same script
- Add a regression spec: sonar-project.properties present but without `sonar.projectKey` → GITHUB_REPOSITORY fallback still fires

## Test plan

- [x] `shellspec --shell bash spec/check-sca_spec.sh` passes (39 examples, 0 failures)
- [x] Merge PR
- [ ] Re-run the failing `verify-sca` check on `SonarSource/docker-images#166` to confirm it now passes