### PR TITLE
BUILD-11669 Fix config-npm in test-urc-happy-path

### DIFF
--- a/.github/workflows/test-update-release-channel.yml
+++ b/.github/workflows/test-update-release-channel.yml
@@ -13,6 +13,7 @@ jobs:
   test-urc-happy-path:
     runs-on: sonar-xs
     permissions:
+      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -30,6 +31,7 @@ jobs:
           [[ "${{ steps.urc.outputs.version-key }}" == "Distribution/test-fixture/stable.version" ]]
           [[ "${{ steps.urc.outputs.version-url }}" == "https://binaries.sonarsource.com/Distribution/test-fixture/stable.version" ]]
           [[ "${{ steps.urc.outputs.version }}" == "0.0.0-test" ]]
+      - uses: ./config-npm
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.5.9


### PR DESCRIPTION
## Summary

- Add `./config-npm` (+ `id-token: write`) before `jdx/mise-action` in the `test-urc-happy-path` job — the root `mise.toml` includes `npm:markdownlint-cli` which causes `UNABLE_TO_VERIFY_LEAF_SIGNATURE` on self-hosted runners without CA config

## Related

- https://github.com/SonarSource/ci-github-actions/pull/282
- https://github.com/SonarSource/renovate-config/pull/138
- https://sonarsource.atlassian.net/browse/BUILD-11669