### PR TITLE
BUILD-11311 Add trend deltas (cache hit-rate, peak memory) to CI metrics report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1617,22 +1617,24 @@ Terraform resource; add the environment for your repo there alongside the existi
 
 ## `report-ci-metrics`
 
-Aggregate per-job CI resource metrics from the current workflow run and post a sticky pull-request comment summarising them.
+Aggregate per-job CI resource metrics from the current workflow run and post a sticky pull-request comment summarising them,
+with trend deltas against the latest default-branch run. On a default-branch push it writes the same summary (delta vs the
+previous default-branch run) to the job summary instead of a comment.
 
 ### Usage
 
-Add a dedicated reporting job that runs after all the jobs you want covered. It must run on every pull-request outcome
-(`if: always()`) so the comment is posted even when an earlier job fails:
+Add a dedicated reporting job that runs after all the jobs you want covered. It must run on every outcome (`if: always()`) so the
+report is produced even when an earlier job fails. To get trend lines, let it run on both pull requests and default-branch pushes:
 
 ```yaml
 jobs:
   report-ci-metrics:
     needs: [build, test, lint]  # list every job whose metrics you want reported
-    if: always() && github.event_name == 'pull_request'
+    if: always() && (github.event_name == 'pull_request' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
     runs-on: sonar-xs
     permissions:
       actions: read           # read sibling job logs via the Actions API
-      pull-requests: write    # post / update the sticky comment
+      pull-requests: write    # post / update the sticky comment (PR runs)
     steps:
       - uses: SonarSource/ci-github-actions/report-ci-metrics@v1
 ```
@@ -1643,15 +1645,22 @@ jobs:
 2. Recovers the metrics JSON that the runner-side CI-metrics hook emitted into the log (a sentinel-wrapped block), skipping the
    report job itself and any job without a metrics block.
 3. Renders a headline of run totals (CPU-seconds, peak memory, network, cache) plus foldable per-job and cache breakdown tables.
-4. Posts a sticky comment matched by a hidden marker — re-runs update the same comment instead of duplicating it. If no sibling
-   produced metrics, nothing is posted.
+4. Computes a **trend line** against a baseline run found via the Actions API (latest default-branch run for a PR; the previous
+   default-branch run for a default-branch push), showing the cache hit-rate delta and the worst-job peak-memory-vs-limit delta.
+   Shows `no baseline yet` on the first run or when the baseline's logs have aged out.
+5. On a pull request, posts a sticky comment matched by a hidden marker — re-runs update the same comment instead of duplicating
+   it. On a default-branch push, writes the headline + trend to the job summary. If no sibling produced metrics, nothing is posted.
 
 ### Scope and behaviour
 
 - Metrics are produced only on **Linux ARC and WarpBuild runners** where the CI Metrics runner hook runs; jobs on other runners
   simply contribute no data.
 - **Fail-open**: any error is logged as a warning and the step exits `0`, so this action never fails the workflow.
-- Runs only for `pull_request` events — there is no PR to comment on otherwise.
+- The trend deliberately covers only **cache hit-rate** and **peak memory vs limit** — the two signals attributable to a PR's
+  diff. Run duration and network bandwidth are dominated by infrastructure noise, so they are shown as current values only (in
+  the per-job table), not as trend deltas.
+- Baselines are recovered by re-reading the baseline run's job logs (same mechanism as the current run); there is no separate
+  persisted store, so trend availability is bounded by Actions log retention.
 
 ---
 

--- a/report-ci-metrics/action.yml
+++ b/report-ci-metrics/action.yml
@@ -1,5 +1,5 @@
 name: Report CI Metrics
-description: Aggregate per-job CI metrics from the run and post a sticky PR comment
+description: Aggregate per-job CI metrics, post a sticky PR comment with trends vs master (or a job summary on default-branch pushes)
 runs:
   using: composite
   steps:
@@ -11,4 +11,6 @@ runs:
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
         SELF_JOB: ${{ github.job }}
+        EVENT_NAME: ${{ github.event_name }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       run: ${GITHUB_ACTION_PATH}/report-ci-metrics.sh

--- a/report-ci-metrics/action.yml
+++ b/report-ci-metrics/action.yml
@@ -1,5 +1,7 @@
 name: Report CI Metrics
-description: Aggregate per-job CI metrics, post a sticky PR comment with trends vs master (or a job summary on default-branch pushes)
+description: >
+  Aggregate per-job CI metrics, post a sticky PR comment with trends vs the default branch
+  (or a job summary on default-branch pushes)
 runs:
   using: composite
   steps:

--- a/report-ci-metrics/lib.sh
+++ b/report-ci-metrics/lib.sh
@@ -79,19 +79,8 @@ _rci_sum() {
   printf '%s' "$total"
 }
 
-# True when at least one record has a non-null jq path. Used before _rci_sum when
-# an absent metric must stay distinguishable from a real zero.
-_rci_has_metric() {
-  local records=$1 path=$2 name json
-  while IFS=$'\t' read -r name json; do
-    [[ -z "$json" ]] && continue
-    jq -e "($path) != null" <<< "$json" >/dev/null 2>&1 && return 0
-  done <<< "$records"
-  return 1
-}
-
 # --- Trend metrics ---------------------------------------------------------------------
-# All three operate on the "<name>\t<json>" record stream so they're testable without gh.
+# These operate on the "<name>\t<json>" record stream so they're testable without gh.
 
 # _rci_cache_hit_rate <records> — integer hit-rate percent across every job's cache entries.
 # An entry counts as a hit when it restored data: either an exact-key hit (cache_hit == true) or
@@ -109,6 +98,51 @@ _rci_cache_hit_rate() {
   done <<< "$records"
   (( total == 0 )) && return 0
   awk -v h="$hits" -v t="$total" 'BEGIN{printf "%.0f", (h/t)*100}'
+}
+
+# _rci_cpu_util <json> — the CPU utilisation ratio shown by _rci_cpu_cell, or empty when no
+# percentage denominator is available. Mirrors denominator preference: limit avg_utilization,
+# then request cores, then online cores.
+_rci_cpu_util() {
+  local json=$1
+  jq -r '.cgroup.cpu as $c | .duration_seconds as $d |
+    if ($c.usage_seconds != null and $d != null and $d > 0) then
+      (($c.usage_seconds / $d) * 100 | round / 100) as $cores |
+      if ($c.limit_cores != null and $c.avg_utilization != null) then $c.avg_utilization
+      elif ($c.request_cores != null and $c.request_cores > 0) then ($cores / $c.request_cores)
+      elif ($c.online_count != null and $c.online_count > 0) then ($cores / $c.online_count)
+      else empty end
+    else empty end' <<< "$json" 2>/dev/null
+}
+
+# _rci_worst_cpu_util <records> — "<util_ratio>\t<job_name>" for the job with the highest
+# CPU average utilisation, using the same percentage denominator as the per-job table.
+_rci_worst_cpu_util() {
+  local records=$1 name json worst="-1" worst_name=""
+  while IFS=$'\t' read -r name json; do
+    [[ -z "$json" ]] && continue
+    local u
+    u=$(_rci_cpu_util "$json")
+    [[ -n "$u" ]] || continue
+    if awk -v a="$u" -v b="$worst" 'BEGIN{exit !(a+0>b+0)}'; then worst=$u; worst_name=$name; fi
+  done <<< "$records"
+  [[ -n "$worst_name" ]] || return 0
+  printf '%s\t%s' "$worst" "$worst_name"
+}
+
+# _rci_cpu_util_for_job <records> <job_name> — CPU utilisation ratio of the named job, or empty
+# when that job is absent or has no percentage denominator.
+_rci_cpu_util_for_job() {
+  local records=$1 target=$2 name json
+  while IFS=$'\t' read -r name json; do
+    [[ "$name" == "$target" ]] || continue
+    local u
+    u=$(_rci_cpu_util "$json")
+    [[ -n "$u" ]] || return 0
+    printf '%s' "$u"
+    return 0
+  done <<< "$records"
+  return 0
 }
 
 # _rci_worst_mem_util <records> — "<util_ratio>\t<job_name>" for the job with the highest
@@ -226,11 +260,11 @@ render_headline() {
   fi
 }
 
-# render_trend <records> <baseline_records> [branch] — one "Trend vs <branch>:" line comparing the two
-# PR-attributable signals against a baseline run: cache hit-rate, total CPU-seconds, and
-# worst-job peak memory utilisation. Emits "no baseline yet" when baseline_records is empty
-# (first run / retention gap). Metrics with no current data are omitted; the line is skipped
-# entirely if none are present. Percentages: cache rate is already 0-100; mem util is 0-1 → ×100.
+# render_trend <records> <baseline_records> [branch] — one "Trend vs <branch>:" line comparing
+# PR-attributable signals against a baseline run: cache hit-rate, worst-job CPU average
+# utilisation, and worst-job peak memory utilisation. Emits "no baseline yet" when
+# baseline_records is empty (first run / retention gap). Metrics with no current data are
+# omitted; the line is skipped entirely if none are present.
 render_trend() {
   local records=$1 baseline=$2 branch=${3:-${DEFAULT_BRANCH:-master}}
   local label="Trend vs ${branch}:"
@@ -248,15 +282,17 @@ render_trend() {
     segs="${segs:+$segs · }cache hit ${cur_hr}% ($(_rci_fmt_delta "$cur_hr" "$base_hr" pp))"
   fi
 
-  # CPU-seconds: total work across the run. PR-attributable (more tests/compute → more CPU-s).
-  # Display to 1dp to match the headline's CPU-s formatting.
-  local cur_cpu base_cpu
-  cur_cpu=$(_rci_sum "$records" '.cgroup.cpu.usage_seconds')
-  base_cpu=""
-  _rci_has_metric "$baseline" '.cgroup.cpu.usage_seconds' && base_cpu=$(_rci_sum "$baseline" '.cgroup.cpu.usage_seconds')
-  if awk -v c="$cur_cpu" 'BEGIN{exit !(c+0>0)}'; then
-    local cur_cpu1; cur_cpu1=$(awk -v u="$cur_cpu" 'BEGIN{printf "%.1f", u}')
-    segs="${segs:+$segs · }CPU ${cur_cpu1} CPU-s ($(_rci_fmt_delta "$cur_cpu" "$base_cpu" ''))"
+  # CPU average: the current run's highest CPU-utilisation job, compared to that same job in
+  # the baseline. This matches the percentage shown in the per-job table.
+  local cur_cpu cpu_pct base_cpu_util base_cpu_pct cpu_job
+  cur_cpu=$(_rci_worst_cpu_util "$records")
+  if [[ -n "$cur_cpu" ]]; then
+    cpu_job=${cur_cpu#*$'\t'}
+    cpu_pct=$(awk -v u="${cur_cpu%%$'\t'*}" 'BEGIN{printf "%.0f", u*100}')
+    base_cpu_util=$(_rci_cpu_util_for_job "$baseline" "$cpu_job")
+    base_cpu_pct=""
+    [[ -n "$base_cpu_util" ]] && base_cpu_pct=$(awk -v u="$base_cpu_util" 'BEGIN{printf "%.0f", u*100}')
+    segs="${segs:+$segs · }CPU avg $(_rci_md_cell "$cpu_job") ${cpu_pct}% ($(_rci_fmt_delta "$cpu_pct" "$base_cpu_pct" pp))"
   fi
 
   # Peak memory: the current run's worst-memory (OOM-risk) job. The baseline must be that SAME

--- a/report-ci-metrics/lib.sh
+++ b/report-ci-metrics/lib.sh
@@ -10,12 +10,7 @@ extract_metrics_json() {
     | sed -e 's/.*===CI_METRICS_JSON_BEGIN===//' -e 's/===CI_METRICS_JSON_END===.*//'
 }
 
-# List a run's jobs and emit "<name>\t<json>" for each completed sibling whose log
-# carries a metrics block. Skips: non-completed jobs, the report job itself (exact or
-# matrix "id (val)" prefix match on SELF_JOB), log-download failures, and jobs with no
-# metrics block. Record format relies on job names having no tab/newline.
-# $1: run id to collect (defaults to the current $RUN_ID). The arg form is used to
-# collect a baseline run for trend comparison.
+# Emit "<name>\t<json>" for completed jobs with metrics. $1 defaults to RUN_ID.
 collect_job_metrics() {
   local run_id=${1:-$RUN_ID}
   local jobs id name status log metrics
@@ -33,9 +28,7 @@ collect_job_metrics() {
   done <<< "$jobs"
 }
 
-# Sanitize an author-influenced value for safe inclusion in a markdown table cell:
-# escape pipes (column injection), collapse CR/LF (row/line injection), and neutralize
-# angle brackets (HTML/details injection) since the comment is posted with write scope.
+# Sanitize author-influenced markdown table cells.
 _rci_md_cell() {
   local s=$1
   s=${s//|/\\|}
@@ -47,8 +40,7 @@ _rci_md_cell() {
   printf '%s' "$s"
 }
 
-# Bytes → human-readable, matching the producer hook's fmt_bytes (2dp, IEC units).
-# A blank/non-numeric arg renders as "n/a" so callers can pass jq nulls directly.
+# Bytes → human-readable IEC units. Blank/non-numeric renders as "n/a".
 _rci_fmt_bytes() {
   local b=${1:-}
   [[ "$b" =~ ^[0-9]+$ ]] || { printf 'n/a'; return; }
@@ -59,15 +51,13 @@ _rci_fmt_bytes() {
   fi
 }
 
-# CPU-avg display cell for one job's JSON, mirroring the hook's step-summary logic.
-# Denominator preference: limit_cores -> request_cores ("requested", ARC burstable) ->
-# online_count ("available", WarpBuild VM) -> bare cores -> "n/a".
+# CPU-avg display cell. Denominator: limit -> request -> online cores.
 _rci_cpu_cell() {
   local json=$1
   jq -r '.cgroup.cpu as $c | .duration_seconds as $d | if ($c.usage_seconds != null and $d != null and $d > 0) then (($c.usage_seconds / $d) * 100 | round / 100) as $cores | if ($c.limit_cores != null and $c.avg_utilization != null) then "\($cores) / \(($c.limit_cores*100|round)/100) cores (\(($c.avg_utilization*100)|round)%)" elif ($c.request_cores != null and $c.request_cores > 0) then "\($cores) / \(($c.request_cores*100|round)/100) cores requested (\((($cores/$c.request_cores)*100)|round)%)" elif ($c.online_count != null and $c.online_count > 0) then "\($cores) / \($c.online_count) cores available (\((($cores/$c.online_count)*100)|round)%)" else "\($cores) cores" end else "n/a" end' <<< "$json"
 }
 
-# Sum a numeric jq path across all record JSONs; nulls count as 0. Echoes an integer-ish sum.
+# Sum a numeric jq path across all record JSONs; nulls count as 0.
 _rci_sum() {
   local records=$1 path=$2 total=0 name json
   while IFS=$'\t' read -r name json; do
@@ -80,13 +70,8 @@ _rci_sum() {
 }
 
 # --- Trend metrics ---------------------------------------------------------------------
-# These operate on the "<name>\t<json>" record stream so they're testable without gh.
 
-# _rci_cache_hit_rate <records> — integer hit-rate percent across every job's cache entries.
-# An entry counts as a hit when it restored data: either an exact-key hit (cache_hit == true) or
-# a prefix restore-key match (restore_key_hit != null) — the latter has cache_hit == false but
-# still restored a cache, so counting only cache_hit would undercount. Mirrors the three-state
-# logic in render_cache_fold. Empty when there are no cache entries at all (nothing to rate).
+# Integer cache hit-rate percent. Restore-key matches count as hits.
 _rci_cache_hit_rate() {
   local records=$1 total=0 hits=0 name json
   while IFS=$'\t' read -r name json; do
@@ -100,9 +85,7 @@ _rci_cache_hit_rate() {
   awk -v h="$hits" -v t="$total" 'BEGIN{printf "%.0f", (h/t)*100}'
 }
 
-# _rci_cpu_util <json> — the CPU utilisation ratio shown by _rci_cpu_cell, or empty when no
-# percentage denominator is available. Mirrors denominator preference: limit avg_utilization,
-# then request cores, then online cores.
+# CPU utilisation ratio shown by _rci_cpu_cell, or empty without a percentage denominator.
 _rci_cpu_util() {
   local json=$1
   jq -r '.cgroup.cpu as $c | .duration_seconds as $d |
@@ -115,72 +98,55 @@ _rci_cpu_util() {
     else empty end' <<< "$json" 2>/dev/null
 }
 
-# _rci_worst_cpu_util <records> — "<util_ratio>\t<job_name>" for the job with the highest
-# CPU average utilisation, using the same percentage denominator as the per-job table.
+# Memory peak utilisation ratio, or empty when unavailable.
+_rci_mem_util() {
+  local json=$1
+  jq -r '.cgroup.memory.peak_utilization // empty' <<< "$json" 2>/dev/null
+}
+
+_rci_worst_by_metric() {
+  local records=$1 metric_fn=$2 name json worst="-1" worst_name=""
+  while IFS=$'\t' read -r name json; do
+    [[ -z "$json" ]] && continue
+    local u
+    u=$("$metric_fn" "$json")
+    [[ -n "$u" ]] || continue
+    if awk -v a="$u" -v b="$worst" 'BEGIN{exit !(a+0>b+0)}'; then worst=$u; worst_name=$name; fi
+  done <<< "$records"
+  [[ -n "$worst_name" ]] || return 0
+  printf '%s\t%s' "$worst" "$worst_name"
+}
+
+_rci_metric_for_job() {
+  local records=$1 target=$2 metric_fn=$3 name json
+  while IFS=$'\t' read -r name json; do
+    [[ "$name" == "$target" ]] || continue
+    local u
+    u=$("$metric_fn" "$json")
+    [[ -n "$u" ]] || return 0
+    printf '%s' "$u"
+    return 0
+  done <<< "$records"
+  return 0
+}
+
 _rci_worst_cpu_util() {
-  local records=$1 name json worst="-1" worst_name=""
-  while IFS=$'\t' read -r name json; do
-    [[ -z "$json" ]] && continue
-    local u
-    u=$(_rci_cpu_util "$json")
-    [[ -n "$u" ]] || continue
-    if awk -v a="$u" -v b="$worst" 'BEGIN{exit !(a+0>b+0)}'; then worst=$u; worst_name=$name; fi
-  done <<< "$records"
-  [[ -n "$worst_name" ]] || return 0
-  printf '%s\t%s' "$worst" "$worst_name"
+  _rci_worst_by_metric "$1" _rci_cpu_util
 }
 
-# _rci_cpu_util_for_job <records> <job_name> — CPU utilisation ratio of the named job, or empty
-# when that job is absent or has no percentage denominator.
 _rci_cpu_util_for_job() {
-  local records=$1 target=$2 name json
-  while IFS=$'\t' read -r name json; do
-    [[ "$name" == "$target" ]] || continue
-    local u
-    u=$(_rci_cpu_util "$json")
-    [[ -n "$u" ]] || return 0
-    printf '%s' "$u"
-    return 0
-  done <<< "$records"
-  return 0
+  _rci_metric_for_job "$1" "$2" _rci_cpu_util
 }
 
-# _rci_worst_mem_util <records> — "<util_ratio>\t<job_name>" for the job with the highest
-# memory.peak_utilization (the OOM-risk job). Empty when no job reports peak_utilization.
-# Mirrors the worst-peak scan in render_headline but keys on utilisation, not raw bytes.
 _rci_worst_mem_util() {
-  local records=$1 name json worst="-1" worst_name=""
-  while IFS=$'\t' read -r name json; do
-    [[ -z "$json" ]] && continue
-    local u
-    u=$(jq -r '.cgroup.memory.peak_utilization // empty' <<< "$json" 2>/dev/null)
-    [[ -n "$u" ]] || continue
-    if awk -v a="$u" -v b="$worst" 'BEGIN{exit !(a+0>b+0)}'; then worst=$u; worst_name=$name; fi
-  done <<< "$records"
-  [[ -n "$worst_name" ]] || return 0
-  printf '%s\t%s' "$worst" "$worst_name"
+  _rci_worst_by_metric "$1" _rci_mem_util
 }
 
-# _rci_mem_util_for_job <records> <job_name> — the peak_utilization of the named job, or empty
-# when that job is absent or has no peak_utilization. Used to compare the baseline against the
-# SAME job as the current worst-memory job, so the trend delta is like-for-like (not current
-# worst job vs a possibly-different baseline worst job).
 _rci_mem_util_for_job() {
-  local records=$1 target=$2 name json
-  while IFS=$'\t' read -r name json; do
-    [[ "$name" == "$target" ]] || continue
-    local u
-    u=$(jq -r '.cgroup.memory.peak_utilization // empty' <<< "$json" 2>/dev/null)
-    [[ -n "$u" ]] || return 0
-    printf '%s' "$u"
-    return 0
-  done <<< "$records"
-  return 0
+  _rci_metric_for_job "$1" "$2" _rci_mem_util
 }
 
-# _rci_fmt_delta <current> <baseline> [unit] — neutral arrow + signed delta vs a baseline.
-# "→ ±0<unit>" within epsilon, "↑/↓ +N<unit>" otherwise, "n/a" when baseline is empty.
-# Direction is presented without good/bad coloring; the reader judges significance.
+# Neutral signed delta; empty baseline renders as n/a.
 _rci_fmt_delta() {
   local cur=$1 base=$2 unit=${3:-}
   [[ -n "$base" ]] || { printf 'n/a'; return; }
@@ -260,11 +226,7 @@ render_headline() {
   fi
 }
 
-# render_trend <records> <baseline_records> [branch] — one "Trend vs <branch>:" line comparing
-# PR-attributable signals against a baseline run: cache hit-rate, worst-job CPU average
-# utilisation, and worst-job peak memory utilisation. Emits "no baseline yet" when
-# baseline_records is empty (first run / retention gap). Metrics with no current data are
-# omitted; the line is skipped entirely if none are present.
+# Render one default-branch trend line from cache, worst CPU avg, and worst memory utilisation.
 render_trend() {
   local records=$1 baseline=$2 branch=${3:-${DEFAULT_BRANCH:-master}}
   local label="Trend vs ${branch}:"
@@ -282,8 +244,6 @@ render_trend() {
     segs="${segs:+$segs · }cache hit ${cur_hr}% ($(_rci_fmt_delta "$cur_hr" "$base_hr" pp))"
   fi
 
-  # CPU average: the current run's highest CPU-utilisation job, compared to that same job in
-  # the baseline. This matches the percentage shown in the per-job table.
   local cur_cpu cpu_pct base_cpu_util base_cpu_pct cpu_job
   cur_cpu=$(_rci_worst_cpu_util "$records")
   if [[ -n "$cur_cpu" ]]; then
@@ -295,9 +255,6 @@ render_trend() {
     segs="${segs:+$segs · }CPU avg $(_rci_md_cell "$cpu_job") ${cpu_pct}% ($(_rci_fmt_delta "$cpu_pct" "$base_cpu_pct" pp))"
   fi
 
-  # Peak memory: the current run's worst-memory (OOM-risk) job. The baseline must be that SAME
-  # job's utilisation — not the baseline's own worst job, which could be a different job and would
-  # make the delta a cross-job comparison. Shows n/a when that job is absent from the baseline.
   local cur_mem cur_pct base_util base_pct mem_job
   cur_mem=$(_rci_worst_mem_util "$records")
   if [[ -n "$cur_mem" ]]; then
@@ -422,11 +379,7 @@ render_cache_fold() {
   printf '\n</details>\n'
 }
 
-# find_baseline_run — echo the default-branch run id to compare against, or
-# empty when none exists (first run / log-retention gap). Resolves this run's workflow id from
-# the run object (no fragile workflow-name matching), then lists that workflow's completed runs
-# on the default branch. PR context → newest such run; default-branch push → newest run that is
-# not the current one (the previous default-branch run). Fail-open: any gh error echoes empty.
+# Echo the default-branch baseline run id, or empty on first run/API failure.
 find_baseline_run() {
   local wf_id
   wf_id=$(gh api "repos/$REPO/actions/runs/$RUN_ID" -q '.workflow_id' 2>/dev/null) || return 0
@@ -437,8 +390,7 @@ find_baseline_run() {
   local id
   while read -r id; do
     [[ -n "$id" ]] || continue
-    # On a default-branch push the current run is itself in this list — skip it so we compare
-    # against the previous default-branch run. In PR context the current run is on a PR ref, not here.
+    # On default-branch pushes, skip the current run and use the previous one.
     [[ "$id" == "$RUN_ID" ]] && continue
     printf '%s' "$id"
     return 0
@@ -458,10 +410,7 @@ upsert_comment() {
   fi
 }
 
-# Entry point: collect this run's sibling metrics, fetch a master baseline for trend deltas,
-# render, and surface the report. On pull_request it upserts the sticky PR comment; on a
-# default-branch push it writes to the job summary (no PR to comment on). Returns early when
-# there's no usable context or no metrics. Marker must lead the comment body.
+# Entry point: collect metrics, compare to the default branch, then comment or summarize.
 main() {
   local event=${EVENT_NAME:-pull_request}
   if [[ "$event" == "pull_request" && -z "${PR_NUMBER:-}" ]]; then

--- a/report-ci-metrics/lib.sh
+++ b/report-ci-metrics/lib.sh
@@ -79,6 +79,17 @@ _rci_sum() {
   printf '%s' "$total"
 }
 
+# True when at least one record has a non-null jq path. Used before _rci_sum when
+# an absent metric must stay distinguishable from a real zero.
+_rci_has_metric() {
+  local records=$1 path=$2 name json
+  while IFS=$'\t' read -r name json; do
+    [[ -z "$json" ]] && continue
+    jq -e "($path) != null" <<< "$json" >/dev/null 2>&1 && return 0
+  done <<< "$records"
+  return 1
+}
+
 # --- Trend metrics ---------------------------------------------------------------------
 # All three operate on the "<name>\t<json>" record stream so they're testable without gh.
 
@@ -241,7 +252,8 @@ render_trend() {
   # Display to 1dp to match the headline's CPU-s formatting.
   local cur_cpu base_cpu
   cur_cpu=$(_rci_sum "$records" '.cgroup.cpu.usage_seconds')
-  base_cpu=$(_rci_sum "$baseline" '.cgroup.cpu.usage_seconds')
+  base_cpu=""
+  _rci_has_metric "$baseline" '.cgroup.cpu.usage_seconds' && base_cpu=$(_rci_sum "$baseline" '.cgroup.cpu.usage_seconds')
   if awk -v c="$cur_cpu" 'BEGIN{exit !(c+0>0)}'; then
     local cur_cpu1; cur_cpu1=$(awk -v u="$cur_cpu" 'BEGIN{printf "%.1f", u}')
     segs="${segs:+$segs · }CPU ${cur_cpu1} CPU-s ($(_rci_fmt_delta "$cur_cpu" "$base_cpu" ''))"
@@ -353,7 +365,7 @@ render_cache_fold() {
     for (( i = 0; i < n; i++ )); do
       local key hit backend restored_b saved_flag end_b
       key=$(jq -r ".cache[$i].key // \"\"" <<< "$json")
-      hit=$(jq -r ".cache[$i].cache_hit // false | if . then \"yes\" else \"no\" end" <<< "$json")
+      hit=$(jq -r ".cache[$i] | if .cache_hit == true then \"yes\" elif ((.restore_key_hit // \"\") != \"\") then \"partial\" else \"no\" end" <<< "$json")
       backend=$(jq -r ".cache[$i].backend // \"\"" <<< "$json")
       restored_b=$(jq -r ".cache[$i].size_bytes_restored // empty" <<< "$json")
       saved_flag=$(jq -r ".cache[$i].saved // false | if . then \"yes\" else \"no\" end" <<< "$json")

--- a/report-ci-metrics/lib.sh
+++ b/report-ci-metrics/lib.sh
@@ -82,15 +82,18 @@ _rci_sum() {
 # --- Trend metrics ---------------------------------------------------------------------
 # All three operate on the "<name>\t<json>" record stream so they're testable without gh.
 
-# _rci_cache_hit_rate <records> — integer hit-rate percent across every job's cache entries
-# (.cache[].cache_hit). Empty when there are no cache entries at all (nothing to rate).
+# _rci_cache_hit_rate <records> — integer hit-rate percent across every job's cache entries.
+# An entry counts as a hit when it restored data: either an exact-key hit (cache_hit == true) or
+# a prefix restore-key match (restore_key_hit != null) — the latter has cache_hit == false but
+# still restored a cache, so counting only cache_hit would undercount. Mirrors the three-state
+# logic in render_cache_fold. Empty when there are no cache entries at all (nothing to rate).
 _rci_cache_hit_rate() {
   local records=$1 total=0 hits=0 name json
   while IFS=$'\t' read -r name json; do
     [[ -z "$json" ]] && continue
     local n h
     n=$(jq -r '(.cache // []) | length' <<< "$json" 2>/dev/null); [[ "$n" =~ ^[0-9]+$ ]] || n=0
-    h=$(jq -r '[.cache[]? | select(.cache_hit == true)] | length' <<< "$json" 2>/dev/null); [[ "$h" =~ ^[0-9]+$ ]] || h=0
+    h=$(jq -r '[.cache[]? | select(.cache_hit == true or .restore_key_hit != null)] | length' <<< "$json" 2>/dev/null); [[ "$h" =~ ^[0-9]+$ ]] || h=0
     total=$((total + n)); hits=$((hits + h))
   done <<< "$records"
   (( total == 0 )) && return 0
@@ -111,6 +114,23 @@ _rci_worst_mem_util() {
   done <<< "$records"
   [[ -n "$worst_name" ]] || return 0
   printf '%s\t%s' "$worst" "$worst_name"
+}
+
+# _rci_mem_util_for_job <records> <job_name> — the peak_utilization of the named job, or empty
+# when that job is absent or has no peak_utilization. Used to compare the baseline against the
+# SAME job as the current worst-memory job, so the trend delta is like-for-like (not current
+# worst job vs a possibly-different baseline worst job).
+_rci_mem_util_for_job() {
+  local records=$1 target=$2 name json
+  while IFS=$'\t' read -r name json; do
+    [[ "$name" == "$target" ]] || continue
+    local u
+    u=$(jq -r '.cgroup.memory.peak_utilization // empty' <<< "$json" 2>/dev/null)
+    [[ -n "$u" ]] || return 0
+    printf '%s' "$u"
+    return 0
+  done <<< "$records"
+  return 0
 }
 
 # _rci_fmt_delta <current> <baseline> [unit] — neutral arrow + signed delta vs a baseline.
@@ -195,15 +215,16 @@ render_headline() {
   fi
 }
 
-# render_trend <records> <baseline_records> — one "Trend vs master:" line comparing the two
-# PR-attributable signals against a baseline run: cache hit-rate and worst-job peak memory
-# utilisation. Emits "no baseline yet" when baseline_records is empty (first run / retention
-# gap). Metrics with no current data are omitted; the line is skipped entirely if neither
-# metric is present. Percentages: cache rate is already 0-100; mem util is a 0-1 ratio → ×100.
+# render_trend <records> <baseline_records> [branch] — one "Trend vs <branch>:" line comparing the two
+# PR-attributable signals against a baseline run: cache hit-rate, total CPU-seconds, and
+# worst-job peak memory utilisation. Emits "no baseline yet" when baseline_records is empty
+# (first run / retention gap). Metrics with no current data are omitted; the line is skipped
+# entirely if none are present. Percentages: cache rate is already 0-100; mem util is 0-1 → ×100.
 render_trend() {
-  local records=$1 baseline=$2
+  local records=$1 baseline=$2 branch=${3:-${DEFAULT_BRANCH:-master}}
+  local label="Trend vs ${branch}:"
   if [[ -z "$baseline" ]]; then
-    printf 'Trend vs master: no baseline yet\n'
+    printf '%s no baseline yet\n' "$label"
     return 0
   fi
 
@@ -216,18 +237,31 @@ render_trend() {
     segs="${segs:+$segs · }cache hit ${cur_hr}% ($(_rci_fmt_delta "$cur_hr" "$base_hr" pp))"
   fi
 
-  local cur_mem base_mem cur_pct base_pct mem_job
+  # CPU-seconds: total work across the run. PR-attributable (more tests/compute → more CPU-s).
+  # Display to 1dp to match the headline's CPU-s formatting.
+  local cur_cpu base_cpu
+  cur_cpu=$(_rci_sum "$records" '.cgroup.cpu.usage_seconds')
+  base_cpu=$(_rci_sum "$baseline" '.cgroup.cpu.usage_seconds')
+  if awk -v c="$cur_cpu" 'BEGIN{exit !(c+0>0)}'; then
+    local cur_cpu1; cur_cpu1=$(awk -v u="$cur_cpu" 'BEGIN{printf "%.1f", u}')
+    segs="${segs:+$segs · }CPU ${cur_cpu1} CPU-s ($(_rci_fmt_delta "$cur_cpu" "$base_cpu" ''))"
+  fi
+
+  # Peak memory: the current run's worst-memory (OOM-risk) job. The baseline must be that SAME
+  # job's utilisation — not the baseline's own worst job, which could be a different job and would
+  # make the delta a cross-job comparison. Shows n/a when that job is absent from the baseline.
+  local cur_mem cur_pct base_util base_pct mem_job
   cur_mem=$(_rci_worst_mem_util "$records")
-  base_mem=$(_rci_worst_mem_util "$baseline")
   if [[ -n "$cur_mem" ]]; then
     mem_job=${cur_mem#*$'\t'}
     cur_pct=$(awk -v u="${cur_mem%%$'\t'*}" 'BEGIN{printf "%.0f", u*100}')
+    base_util=$(_rci_mem_util_for_job "$baseline" "$mem_job")
     base_pct=""
-    [[ -n "$base_mem" ]] && base_pct=$(awk -v u="${base_mem%%$'\t'*}" 'BEGIN{printf "%.0f", u*100}')
+    [[ -n "$base_util" ]] && base_pct=$(awk -v u="$base_util" 'BEGIN{printf "%.0f", u*100}')
     segs="${segs:+$segs · }peak mem $(_rci_md_cell "$mem_job") ${cur_pct}% ($(_rci_fmt_delta "$cur_pct" "$base_pct" pp))"
   fi
 
-  [[ -n "$segs" ]] && printf 'Trend vs master: %s\n' "$segs"
+  [[ -n "$segs" ]] && printf '%s %s\n' "$label" "$segs"
   return 0
 }
 
@@ -340,11 +374,11 @@ render_cache_fold() {
   printf '\n</details>\n'
 }
 
-# find_baseline_run — echo the run id of the master run to compare against, or
+# find_baseline_run — echo the default-branch run id to compare against, or
 # empty when none exists (first run / log-retention gap). Resolves this run's workflow id from
 # the run object (no fragile workflow-name matching), then lists that workflow's completed runs
 # on the default branch. PR context → newest such run; default-branch push → newest run that is
-# not the current one (the previous master). Fail-open: any gh error echoes empty.
+# not the current one (the previous default-branch run). Fail-open: any gh error echoes empty.
 find_baseline_run() {
   local wf_id
   wf_id=$(gh api "repos/$REPO/actions/runs/$RUN_ID" -q '.workflow_id' 2>/dev/null) || return 0
@@ -356,7 +390,7 @@ find_baseline_run() {
   while read -r id; do
     [[ -n "$id" ]] || continue
     # On a default-branch push the current run is itself in this list — skip it so we compare
-    # against the *previous* master. In PR context the current run is on a PR ref, not here.
+    # against the previous default-branch run. In PR context the current run is on a PR ref, not here.
     [[ "$id" == "$RUN_ID" ]] && continue
     printf '%s' "$id"
     return 0
@@ -403,7 +437,7 @@ main() {
 
 $(render_headline "$records")
 
-$(render_trend "$records" "$baseline")
+$(render_trend "$records" "$baseline" "${DEFAULT_BRANCH:-master}")
 
 $(render_table "$records")
 $(render_cache_fold "$records")"
@@ -414,7 +448,7 @@ $(render_cache_fold "$records")"
       printf '## 📊 CI Metrics\n\n'
       render_headline "$records"
       printf '\n'
-      render_trend "$records" "$baseline"
+      render_trend "$records" "$baseline" "${DEFAULT_BRANCH:-master}"
     } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" 2>/dev/null || true
   fi
 }

--- a/report-ci-metrics/lib.sh
+++ b/report-ci-metrics/lib.sh
@@ -10,13 +10,16 @@ extract_metrics_json() {
     | sed -e 's/.*===CI_METRICS_JSON_BEGIN===//' -e 's/===CI_METRICS_JSON_END===.*//'
 }
 
-# List the run's jobs and emit "<name>\t<json>" for each completed sibling whose log
+# List a run's jobs and emit "<name>\t<json>" for each completed sibling whose log
 # carries a metrics block. Skips: non-completed jobs, the report job itself (exact or
 # matrix "id (val)" prefix match on SELF_JOB), log-download failures, and jobs with no
 # metrics block. Record format relies on job names having no tab/newline.
+# $1: run id to collect (defaults to the current $RUN_ID). The arg form is used to
+# collect a baseline run for trend comparison.
 collect_job_metrics() {
+  local run_id=${1:-$RUN_ID}
   local jobs id name status log metrics
-  jobs=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" --paginate -q '.jobs[] | "\(.id)\t\(.name)\t\(.status)"') || return 0
+  jobs=$(gh api "repos/$REPO/actions/runs/$run_id/jobs" --paginate -q '.jobs[] | "\(.id)\t\(.name)\t\(.status)"') || return 0
   while IFS=$'\t' read -r id name status; do
     [[ -z "$id" ]] && continue
     [[ "$status" == "completed" ]] || continue
@@ -74,6 +77,55 @@ _rci_sum() {
     total=$(awk -v a="$total" -v b="$v" 'BEGIN{printf "%.0f", a+b}')
   done <<< "$records"
   printf '%s' "$total"
+}
+
+# --- Trend metrics ---------------------------------------------------------------------
+# All three operate on the "<name>\t<json>" record stream so they're testable without gh.
+
+# _rci_cache_hit_rate <records> — integer hit-rate percent across every job's cache entries
+# (.cache[].cache_hit). Empty when there are no cache entries at all (nothing to rate).
+_rci_cache_hit_rate() {
+  local records=$1 total=0 hits=0 name json
+  while IFS=$'\t' read -r name json; do
+    [[ -z "$json" ]] && continue
+    local n h
+    n=$(jq -r '(.cache // []) | length' <<< "$json" 2>/dev/null); [[ "$n" =~ ^[0-9]+$ ]] || n=0
+    h=$(jq -r '[.cache[]? | select(.cache_hit == true)] | length' <<< "$json" 2>/dev/null); [[ "$h" =~ ^[0-9]+$ ]] || h=0
+    total=$((total + n)); hits=$((hits + h))
+  done <<< "$records"
+  (( total == 0 )) && return 0
+  awk -v h="$hits" -v t="$total" 'BEGIN{printf "%.0f", (h/t)*100}'
+}
+
+# _rci_worst_mem_util <records> — "<util_ratio>\t<job_name>" for the job with the highest
+# memory.peak_utilization (the OOM-risk job). Empty when no job reports peak_utilization.
+# Mirrors the worst-peak scan in render_headline but keys on utilisation, not raw bytes.
+_rci_worst_mem_util() {
+  local records=$1 name json worst="-1" worst_name=""
+  while IFS=$'\t' read -r name json; do
+    [[ -z "$json" ]] && continue
+    local u
+    u=$(jq -r '.cgroup.memory.peak_utilization // empty' <<< "$json" 2>/dev/null)
+    [[ -n "$u" ]] || continue
+    if awk -v a="$u" -v b="$worst" 'BEGIN{exit !(a+0>b+0)}'; then worst=$u; worst_name=$name; fi
+  done <<< "$records"
+  [[ -n "$worst_name" ]] || return 0
+  printf '%s\t%s' "$worst" "$worst_name"
+}
+
+# _rci_fmt_delta <current> <baseline> [unit] — neutral arrow + signed delta vs a baseline.
+# "→ ±0<unit>" within epsilon, "↑/↓ +N<unit>" otherwise, "n/a" when baseline is empty.
+# Direction is presented without good/bad coloring; the reader judges significance.
+_rci_fmt_delta() {
+  local cur=$1 base=$2 unit=${3:-}
+  [[ -n "$base" ]] || { printf 'n/a'; return; }
+  awk -v c="$cur" -v b="$base" -v u="$unit" 'BEGIN{
+    d = c - b
+    a = (d < 0) ? -d : d
+    if (a < 0.5) { printf "→ ±0%s", u }
+    else if (d > 0) { printf "↑ +%.0f%s", d, u }
+    else { printf "↓ %.0f%s", d, u }
+  }'
 }
 
 # render_headline <records> — a totals line, then a flags line if any job OOM'd/throttled.
@@ -141,6 +193,42 @@ render_headline() {
     fi
     printf '> ⚠️ %s\n' "$flags"
   fi
+}
+
+# render_trend <records> <baseline_records> — one "Trend vs master:" line comparing the two
+# PR-attributable signals against a baseline run: cache hit-rate and worst-job peak memory
+# utilisation. Emits "no baseline yet" when baseline_records is empty (first run / retention
+# gap). Metrics with no current data are omitted; the line is skipped entirely if neither
+# metric is present. Percentages: cache rate is already 0-100; mem util is a 0-1 ratio → ×100.
+render_trend() {
+  local records=$1 baseline=$2
+  if [[ -z "$baseline" ]]; then
+    printf 'Trend vs master: no baseline yet\n'
+    return 0
+  fi
+
+  local segs=""
+
+  local cur_hr base_hr
+  cur_hr=$(_rci_cache_hit_rate "$records")
+  base_hr=$(_rci_cache_hit_rate "$baseline")
+  if [[ -n "$cur_hr" ]]; then
+    segs="${segs:+$segs · }cache hit ${cur_hr}% ($(_rci_fmt_delta "$cur_hr" "$base_hr" pp))"
+  fi
+
+  local cur_mem base_mem cur_pct base_pct mem_job
+  cur_mem=$(_rci_worst_mem_util "$records")
+  base_mem=$(_rci_worst_mem_util "$baseline")
+  if [[ -n "$cur_mem" ]]; then
+    mem_job=${cur_mem#*$'\t'}
+    cur_pct=$(awk -v u="${cur_mem%%$'\t'*}" 'BEGIN{printf "%.0f", u*100}')
+    base_pct=""
+    [[ -n "$base_mem" ]] && base_pct=$(awk -v u="${base_mem%%$'\t'*}" 'BEGIN{printf "%.0f", u*100}')
+    segs="${segs:+$segs · }peak mem $(_rci_md_cell "$mem_job") ${cur_pct}% ($(_rci_fmt_delta "$cur_pct" "$base_pct" pp))"
+  fi
+
+  [[ -n "$segs" ]] && printf 'Trend vs master: %s\n' "$segs"
+  return 0
 }
 
 # render_table <records> — foldable per-job table. Columns with no data in any job are
@@ -252,6 +340,30 @@ render_cache_fold() {
   printf '\n</details>\n'
 }
 
+# find_baseline_run — echo the run id of the master run to compare against, or
+# empty when none exists (first run / log-retention gap). Resolves this run's workflow id from
+# the run object (no fragile workflow-name matching), then lists that workflow's completed runs
+# on the default branch. PR context → newest such run; default-branch push → newest run that is
+# not the current one (the previous master). Fail-open: any gh error echoes empty.
+find_baseline_run() {
+  local wf_id
+  wf_id=$(gh api "repos/$REPO/actions/runs/$RUN_ID" -q '.workflow_id' 2>/dev/null) || return 0
+  [[ -n "$wf_id" ]] || return 0
+  local ids
+  ids=$(gh api "repos/$REPO/actions/workflows/$wf_id/runs?branch=${DEFAULT_BRANCH}&status=completed&per_page=20" \
+        -q '.workflow_runs[].id' 2>/dev/null) || return 0
+  local id
+  while read -r id; do
+    [[ -n "$id" ]] || continue
+    # On a default-branch push the current run is itself in this list — skip it so we compare
+    # against the *previous* master. In PR context the current run is on a PR ref, not here.
+    [[ "$id" == "$RUN_ID" ]] && continue
+    printf '%s' "$id"
+    return 0
+  done <<< "$ids"
+  return 0
+}
+
 # Post or update the sticky comment, matched by the marker in <body>'s first line:
 # PATCH the first comment containing the marker, else POST a new one (idempotent on re-run).
 upsert_comment() {
@@ -264,21 +376,45 @@ upsert_comment() {
   fi
 }
 
-# Entry point: collect sibling metrics, render, upsert the sticky comment. Returns early
-# (no comment) when there's no PR context or no metrics. Marker must lead the body.
+# Entry point: collect this run's sibling metrics, fetch a master baseline for trend deltas,
+# render, and surface the report. On pull_request it upserts the sticky PR comment; on a
+# default-branch push it writes to the job summary (no PR to comment on). Returns early when
+# there's no usable context or no metrics. Marker must lead the comment body.
 main() {
-  [[ -n "${PR_NUMBER:-}" ]] || { echo "::notice::report-ci-metrics: no PR context, skipping"; return 0; }
+  local event=${EVENT_NAME:-pull_request}
+  if [[ "$event" == "pull_request" && -z "${PR_NUMBER:-}" ]]; then
+    echo "::notice::report-ci-metrics: no PR context, skipping"; return 0
+  fi
+
   local records
   records=$(collect_job_metrics)
-  [[ -n "$records" ]] || { echo "::notice::report-ci-metrics: no CI metrics found, skipping comment"; return 0; }
-  local marker='<!-- ci-metrics-report -->'
-  local body
-  body="$marker
+  [[ -n "$records" ]] || { echo "::notice::report-ci-metrics: no CI metrics found, skipping"; return 0; }
+
+  # Baseline for trends. Fail-open: a fetch/collect failure leaves baseline empty → "no baseline yet".
+  local baseline_run baseline=""
+  baseline_run=$(find_baseline_run)
+  [[ -n "$baseline_run" ]] && baseline=$(collect_job_metrics "$baseline_run")
+
+  if [[ "$event" == "pull_request" ]]; then
+    local marker='<!-- ci-metrics-report -->'
+    local body
+    body="$marker
 ## 📊 CI Metrics
 
 $(render_headline "$records")
 
+$(render_trend "$records" "$baseline")
+
 $(render_table "$records")
 $(render_cache_fold "$records")"
-  upsert_comment "$body"
+    upsert_comment "$body"
+  else
+    # Default-branch push: no PR comment — emit the headline + trend to the job summary.
+    {
+      printf '## 📊 CI Metrics\n\n'
+      render_headline "$records"
+      printf '\n'
+      render_trend "$records" "$baseline"
+    } >> "${GITHUB_STEP_SUMMARY:-/dev/null}" 2>/dev/null || true
+  fi
 }

--- a/spec/report-ci-metrics_spec.sh
+++ b/spec/report-ci-metrics_spec.sh
@@ -344,9 +344,7 @@ Describe 'report-ci-metrics/lib.sh'
 
     Describe 'render_trend()'
       It 'renders cache, CPU average, and memory deltas against a baseline'
-        # current: build cache hit (1/1=100), CPU avg build 32%, worst mem build 0.80.
         cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
-        # baseline: a miss (0%), lower CPU avg (20%), lower mem util (0.60).
         base_json='{"duration_seconds":62.0,"cache":[{"cache_hit":false,"restore_key_hit":null}],"cgroup":{"cpu":{"usage_seconds":25.0,"limit_cores":2.0,"avg_utilization":0.20},"memory":{"peak_utilization":0.60}}}'
         base=$(printf '%s\t%s\n' 'build' "$base_json")
         When call render_trend "$cur" "$base"
@@ -375,8 +373,6 @@ Describe 'report-ci-metrics/lib.sh'
       End
 
       It 'compares peak memory like-for-like and shows n/a when the worst job is absent from the baseline'
-        # current worst-mem job is build (0.80). Baseline has only a DIFFERENT job (test, 0.60).
-        # The delta must NOT be build(0.80) vs test(0.60) — it must be n/a (build not in baseline).
         cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
         base_json='{"cgroup":{"memory":{"peak_utilization":0.60}}}'
         base=$(printf '%s\t%s\n' 'test' "$base_json")
@@ -386,12 +382,10 @@ Describe 'report-ci-metrics/lib.sh'
       End
 
       It 'compares peak memory against the same job in the baseline'
-        # build is the worst in both runs: current 0.80 vs baseline 0.70 = +10pp, like-for-like.
         cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
         base=$(printf '%s\t%s\n' \
           'build' '{"cgroup":{"memory":{"peak_utilization":0.70}}}' \
           'test'  '{"cgroup":{"memory":{"peak_utilization":0.90}}}')
-        # Note: baseline's OWN worst job is test (0.90); the delta must still use build (0.70).
         When call render_trend "$cur" "$base"
         The output should include 'peak mem build 80% (↑ +10pp)'
       End

--- a/spec/report-ci-metrics_spec.sh
+++ b/spec/report-ci-metrics_spec.sh
@@ -272,6 +272,40 @@ Describe 'report-ci-metrics/lib.sh'
       End
     End
 
+    Describe '_rci_worst_cpu_util()'
+      It 'returns the highest CPU utilisation with its job name'
+        records=$(printf '%s\t%s\n' 'build' "$J_BUILD" 'test' "$J_TEST" 'lint' "$J_LINT")
+        When call _rci_worst_cpu_util "$records"
+        The output should equal "$(printf '0.32\tbuild')"
+      End
+
+      It 'uses CPU request as the denominator when limit utilisation is absent'
+        req='{"duration_seconds":10,"cgroup":{"cpu":{"usage_seconds":5,"limit_cores":null,"avg_utilization":null,"request_cores":1,"online_count":8}}}'
+        When call _rci_worst_cpu_util "$(printf '%s\t%s\n' 'test' "$req")"
+        The output should equal "$(printf '0.5\ttest')"
+      End
+
+      It 'is empty when no job has a CPU percentage denominator'
+        bare='{"duration_seconds":10,"cgroup":{"cpu":{"usage_seconds":5,"limit_cores":null,"avg_utilization":null,"request_cores":null,"online_count":null}}}'
+        When call _rci_worst_cpu_util "$(printf '%s\t%s\n' 'bare' "$bare")"
+        The output should equal ''
+      End
+    End
+
+    Describe '_rci_cpu_util_for_job()'
+      It 'returns the named jobs CPU utilisation'
+        records=$(printf '%s\t%s\n' 'build' "$J_BUILD" 'test' "$J_TEST")
+        When call _rci_cpu_util_for_job "$records" 'build'
+        The output should equal '0.32'
+      End
+
+      It 'is empty when the named job is absent'
+        records=$(printf '%s\t%s\n' 'build' "$J_BUILD")
+        When call _rci_cpu_util_for_job "$records" 'nonexistent'
+        The output should equal ''
+      End
+    End
+
     Describe '_rci_mem_util_for_job()'
       It 'returns the named jobs peak_utilization'
         records=$(printf '%s\t%s\n' 'build' "$J_BUILD" 'test' "$J_TEST")
@@ -309,17 +343,35 @@ Describe 'report-ci-metrics/lib.sh'
     End
 
     Describe 'render_trend()'
-      It 'renders cache, CPU-seconds, and memory deltas against a baseline'
-        # current: build cache hit (1/1=100), 40 CPU-s, worst mem build 0.80.
+      It 'renders cache, CPU average, and memory deltas against a baseline'
+        # current: build cache hit (1/1=100), CPU avg build 32%, worst mem build 0.80.
         cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
-        # baseline: a miss (0%), 30 CPU-s, lower mem util (0.60).
-        base_json='{"cache":[{"cache_hit":false,"restore_key_hit":null}],"cgroup":{"cpu":{"usage_seconds":30.0},"memory":{"peak_utilization":0.60}}}'
+        # baseline: a miss (0%), lower CPU avg (20%), lower mem util (0.60).
+        base_json='{"duration_seconds":62.0,"cache":[{"cache_hit":false,"restore_key_hit":null}],"cgroup":{"cpu":{"usage_seconds":25.0,"limit_cores":2.0,"avg_utilization":0.20},"memory":{"peak_utilization":0.60}}}'
         base=$(printf '%s\t%s\n' 'build' "$base_json")
         When call render_trend "$cur" "$base"
         The output should include 'Trend vs master:'
         The output should include 'cache hit 100% (↑ +100pp)'
-        The output should include 'CPU 40.0 CPU-s (↑ +10)'
+        The output should include 'CPU avg build 32% (↑ +12pp)'
         The output should include 'peak mem build 80% (↑ +20pp)'
+      End
+
+      It 'compares CPU average like-for-like and shows n/a when the worst job is absent from the baseline'
+        cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
+        base_json='{"duration_seconds":62.0,"cgroup":{"cpu":{"usage_seconds":25.0,"limit_cores":2.0,"avg_utilization":0.20}}}'
+        base=$(printf '%s\t%s\n' 'test' "$base_json")
+        When call render_trend "$cur" "$base"
+        The output should include 'CPU avg build 32% (n/a)'
+        The output should not include '+12pp'
+      End
+
+      It 'compares CPU average against the same job in the baseline'
+        cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
+        base=$(printf '%s\t%s\n' \
+          'build' '{"duration_seconds":62.0,"cgroup":{"cpu":{"usage_seconds":25.0,"limit_cores":2.0,"avg_utilization":0.20}}}' \
+          'test'  '{"duration_seconds":62.0,"cgroup":{"cpu":{"usage_seconds":50.0,"limit_cores":2.0,"avg_utilization":0.70}}}')
+        When call render_trend "$cur" "$base"
+        The output should include 'CPU avg build 32% (↑ +12pp)'
       End
 
       It 'compares peak memory like-for-like and shows n/a when the worst job is absent from the baseline'
@@ -344,23 +396,6 @@ Describe 'report-ci-metrics/lib.sh'
         The output should include 'peak mem build 80% (↑ +10pp)'
       End
 
-      It 'shows n/a for CPU delta when the baseline has no CPU metric'
-        cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
-        base_json='{"cache":[{"cache_hit":false,"restore_key_hit":null}],"cgroup":{"memory":{"peak_utilization":0.60}}}'
-        base=$(printf '%s\t%s\n' 'build' "$base_json")
-        When call render_trend "$cur" "$base"
-        The output should include 'CPU 40.0 CPU-s (n/a)'
-        The output should not include 'CPU 40.0 CPU-s (↑ +40)'
-      End
-
-      It 'keeps a real zero CPU baseline comparable'
-        cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
-        base_json='{"cache":[{"cache_hit":false,"restore_key_hit":null}],"cgroup":{"cpu":{"usage_seconds":0},"memory":{"peak_utilization":0.60}}}'
-        base=$(printf '%s\t%s\n' 'build' "$base_json")
-        When call render_trend "$cur" "$base"
-        The output should include 'CPU 40.0 CPU-s (↑ +40)'
-      End
-
       It 'says no baseline yet when the baseline is empty'
         cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
         When call render_trend "$cur" ''
@@ -369,7 +404,7 @@ Describe 'report-ci-metrics/lib.sh'
 
       It 'uses the provided default branch in the trend label'
         cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
-        base_json='{"cache":[{"cache_hit":false,"restore_key_hit":null}],"cgroup":{"cpu":{"usage_seconds":30.0},"memory":{"peak_utilization":0.60}}}'
+        base_json='{"cache":[{"cache_hit":false,"restore_key_hit":null}],"cgroup":{"memory":{"peak_utilization":0.60}}}'
         base=$(printf '%s\t%s\n' 'build' "$base_json")
         When call render_trend "$cur" "$base" 'main'
         The output should include 'Trend vs main:'

--- a/spec/report-ci-metrics_spec.sh
+++ b/spec/report-ci-metrics_spec.sh
@@ -344,6 +344,23 @@ Describe 'report-ci-metrics/lib.sh'
         The output should include 'peak mem build 80% (↑ +10pp)'
       End
 
+      It 'shows n/a for CPU delta when the baseline has no CPU metric'
+        cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
+        base_json='{"cache":[{"cache_hit":false,"restore_key_hit":null}],"cgroup":{"memory":{"peak_utilization":0.60}}}'
+        base=$(printf '%s\t%s\n' 'build' "$base_json")
+        When call render_trend "$cur" "$base"
+        The output should include 'CPU 40.0 CPU-s (n/a)'
+        The output should not include 'CPU 40.0 CPU-s (↑ +40)'
+      End
+
+      It 'keeps a real zero CPU baseline comparable'
+        cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
+        base_json='{"cache":[{"cache_hit":false,"restore_key_hit":null}],"cgroup":{"cpu":{"usage_seconds":0},"memory":{"peak_utilization":0.60}}}'
+        base=$(printf '%s\t%s\n' 'build' "$base_json")
+        When call render_trend "$cur" "$base"
+        The output should include 'CPU 40.0 CPU-s (↑ +40)'
+      End
+
       It 'says no baseline yet when the baseline is empty'
         cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
         When call render_trend "$cur" ''
@@ -529,6 +546,14 @@ Describe 'report-ci-metrics/lib.sh'
       The status should be success
       The output should include 'deps\|v2'
       The output should include '| deps\|v2 | yes | s3 |'
+    End
+
+    It 'shows prefix restore-key matches as partial hits'
+      partial='{"schema_version":3,"duration_seconds":62.0,"cgroup":{"cpu":{"usage_seconds":1.0,"throttled_seconds":0.0},"memory":{"peak_bytes":1024,"oom_kill":0}},"net":{"rx_bytes":0,"tx_bytes":0},"disk":{"total_bytes":null,"used_bytes":null},"cache":[{"key":"deps","cache_hit":false,"restore_key_hit":"deps-Linux-","backend":"s3","size_bytes_restored":1024,"saved":false,"size_bytes_at_end":null}]}'
+      records=$(printf '%s\t%s\n' 'build' "$partial")
+      When call render_cache_fold "$records"
+      The status should be success
+      The output should include '| deps | partial | s3 |'
     End
 
     It 'collapses newlines and neutralizes angle brackets in author-controlled cache cells'

--- a/spec/report-ci-metrics_spec.sh
+++ b/spec/report-ci-metrics_spec.sh
@@ -221,6 +221,142 @@ Describe 'report-ci-metrics/lib.sh'
     End
   End
 
+  Describe 'trend metrics'
+    Describe '_rci_cache_hit_rate()'
+      It 'computes the integer hit-rate percent across all jobs cache entries'
+        # build hit + test hit = 2/2 = 100; add a synthetic miss to get a mixed rate.
+        miss='{"cache":[{"cache_hit":false}]}'
+        records=$(printf '%s\t%s\n' 'build' "$J_BUILD" 'test' "$J_TEST" 'm' "$miss")
+        When call _rci_cache_hit_rate "$records"
+        The output should equal '67'
+      End
+
+      It 'is 100 when every cache entry is a hit'
+        records=$(printf '%s\t%s\n' 'build' "$J_BUILD" 'test' "$J_TEST")
+        When call _rci_cache_hit_rate "$records"
+        The output should equal '100'
+      End
+
+      It 'is 0 when every cache entry is a miss'
+        miss='{"cache":[{"cache_hit":false},{"cache_hit":false}]}'
+        When call _rci_cache_hit_rate "$(printf '%s\t%s\n' 'm' "$miss")"
+        The output should equal '0'
+      End
+
+      It 'is empty when no job has any cache entry (nothing to rate)'
+        # lint has no cache array.
+        When call _rci_cache_hit_rate "$(printf '%s\t%s\n' 'lint' "$J_LINT")"
+        The output should equal ''
+      End
+    End
+
+    Describe '_rci_worst_mem_util()'
+      It 'returns the highest peak_utilization with its job name'
+        # build=0.80, test=0.02, lint=0.01 → build wins.
+        records=$(printf '%s\t%s\n' 'build' "$J_BUILD" 'test' "$J_TEST" 'lint' "$J_LINT")
+        When call _rci_worst_mem_util "$records"
+        The output should equal "$(printf '0.80\tbuild')"
+      End
+
+      It 'is empty when no job reports peak_utilization'
+        nomem='{"cgroup":{"memory":{}}}'
+        When call _rci_worst_mem_util "$(printf '%s\t%s\n' 'j' "$nomem")"
+        The output should equal ''
+      End
+    End
+
+    Describe '_rci_fmt_delta()'
+      It 'shows an up arrow with a signed positive delta'
+        When call _rci_fmt_delta 95 80 pp
+        The output should equal '↑ +15pp'
+      End
+
+      It 'shows a down arrow with a signed negative delta'
+        When call _rci_fmt_delta 86 92 pp
+        The output should equal '↓ -6pp'
+      End
+
+      It 'shows a flat arrow within the epsilon'
+        When call _rci_fmt_delta 92 92 pp
+        The output should equal '→ ±0pp'
+      End
+
+      It 'is n/a when the baseline is empty'
+        When call _rci_fmt_delta 92 '' pp
+        The output should equal 'n/a'
+      End
+    End
+
+    Describe 'render_trend()'
+      It 'renders both deltas against a baseline'
+        # current: build cache hit (1/1=100), worst mem build 0.80.
+        cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
+        # baseline: a miss (0%) and lower mem util (0.60).
+        base_json='{"cache":[{"cache_hit":false}],"cgroup":{"memory":{"peak_utilization":0.60}}}'
+        base=$(printf '%s\t%s\n' 'build' "$base_json")
+        When call render_trend "$cur" "$base"
+        The output should include 'Trend vs master:'
+        The output should include 'cache hit 100% (↑ +100pp)'
+        The output should include 'peak mem build 80% (↑ +20pp)'
+      End
+
+      It 'says no baseline yet when the baseline is empty'
+        cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
+        When call render_trend "$cur" ''
+        The output should equal 'Trend vs master: no baseline yet'
+      End
+    End
+  End
+
+  Describe 'find_baseline_run()'
+    export REPO=o/r RUN_ID=100
+
+    It 'returns the newest completed default-branch run in PR context'
+      # In PR context the current run (id 100, on a PR ref) is not in the master list.
+      Mock gh
+        case "$*" in
+          *runs/100\ *|*runs/100) echo 7 ;;            # .workflow_id lookup
+          *workflows/7/runs*) printf '%s\n' 55 54 53 ;;
+          *) return 1 ;;
+        esac
+      End
+      When call find_baseline_run
+      The output should equal '55'
+    End
+
+    It 'skips the current run id on a default-branch push (previous master)'
+      Mock gh
+        case "$*" in
+          *runs/100\ *|*runs/100) echo 7 ;;
+          *workflows/7/runs*) printf '%s\n' 100 99 98 ;;  # current run is in the list
+          *) return 1 ;;
+        esac
+      End
+      When call find_baseline_run
+      The output should equal '99'
+    End
+
+    It 'is empty when there is no prior run'
+      Mock gh
+        case "$*" in
+          *runs/100\ *|*runs/100) echo 7 ;;
+          *workflows/7/runs*) : ;;
+          *) return 1 ;;
+        esac
+      End
+      When call find_baseline_run
+      The output should equal ''
+    End
+
+    It 'is empty (fail-open) when the workflow-id lookup fails'
+      Mock gh
+        false  # every gh call fails → find_baseline_run must fail-open to empty
+      End
+      When call find_baseline_run
+      The output should equal ''
+    End
+  End
+
   Describe 'render_table()'
     It 'renders one row per job inside a details/summary block'
       records=$(printf '%s\t%s\n' 'build' "$J_BUILD" 'test' "$J_TEST" 'lint' "$J_LINT")
@@ -421,6 +557,8 @@ body'
       render_headline()    { echo "HEADLINE"; return 0; }
       render_table()       { echo "TABLE"; return 0; }
       render_cache_fold()  { echo "CACHE"; return 0; }
+      render_trend()       { echo "TREND"; return 0; }
+      find_baseline_run()  { return 0; }
       upsert_comment()     { local body=$1; echo "UPSERT:$body"; return 0; }
       return 0
     }
@@ -461,6 +599,32 @@ body'
       The line 1 of output should equal 'UPSERT:<!-- ci-metrics-report -->'
       The output should include 'HEADLINE'
       The output should include 'TABLE'
+    End
+
+    It 'includes the trend line in the comment body when records are present'
+      export REPO=o/r RUN_ID=1 SELF_JOB=report-ci-metrics PR_NUMBER=7 EVENT_NAME=pull_request
+      # shellcheck disable=SC2329  # Invoked indirectly by main()
+      collect_job_metrics() { printf 'build\t{"job":"build"}\n'; return 0; }
+      stub_renderers
+      When call main
+      The status should be success
+      The output should include 'TREND'
+    End
+
+    It 'on a default-branch push writes the job summary and never upserts a comment'
+      export REPO=o/r RUN_ID=1 SELF_JOB=report-ci-metrics EVENT_NAME=push
+      unset PR_NUMBER
+      summary=$(mktemp)
+      export GITHUB_STEP_SUMMARY="$summary"
+      # shellcheck disable=SC2329  # Invoked indirectly by main()
+      collect_job_metrics() { printf 'build\t{"job":"build"}\n'; return 0; }
+      stub_renderers
+      When call main
+      The status should be success
+      The output should not include 'UPSERT:'
+      The contents of file "$summary" should include 'HEADLINE'
+      The contents of file "$summary" should include 'TREND'
+      rm -f "$summary"
     End
   End
 End

--- a/spec/report-ci-metrics_spec.sh
+++ b/spec/report-ci-metrics_spec.sh
@@ -238,9 +238,16 @@ Describe 'report-ci-metrics/lib.sh'
       End
 
       It 'is 0 when every cache entry is a miss'
-        miss='{"cache":[{"cache_hit":false},{"cache_hit":false}]}'
+        miss='{"cache":[{"cache_hit":false,"restore_key_hit":null},{"cache_hit":false,"restore_key_hit":null}]}'
         When call _rci_cache_hit_rate "$(printf '%s\t%s\n' 'm' "$miss")"
         The output should equal '0'
+      End
+
+      It 'counts a prefix restore-key match as a hit (cache_hit false but data restored)'
+        # cache_hit=false + restore_key_hit set = partial hit; must count as a hit, not a miss.
+        partial='{"cache":[{"cache_hit":false,"restore_key_hit":"maven-Linux-"},{"cache_hit":false,"restore_key_hit":null}]}'
+        When call _rci_cache_hit_rate "$(printf '%s\t%s\n' 'p' "$partial")"
+        The output should equal '50'
       End
 
       It 'is empty when no job has any cache entry (nothing to rate)'
@@ -261,6 +268,20 @@ Describe 'report-ci-metrics/lib.sh'
       It 'is empty when no job reports peak_utilization'
         nomem='{"cgroup":{"memory":{}}}'
         When call _rci_worst_mem_util "$(printf '%s\t%s\n' 'j' "$nomem")"
+        The output should equal ''
+      End
+    End
+
+    Describe '_rci_mem_util_for_job()'
+      It 'returns the named jobs peak_utilization'
+        records=$(printf '%s\t%s\n' 'build' "$J_BUILD" 'test' "$J_TEST")
+        When call _rci_mem_util_for_job "$records" 'build'
+        The output should equal '0.80'
+      End
+
+      It 'is empty when the named job is absent'
+        records=$(printf '%s\t%s\n' 'build' "$J_BUILD")
+        When call _rci_mem_util_for_job "$records" 'nonexistent'
         The output should equal ''
       End
     End
@@ -288,22 +309,54 @@ Describe 'report-ci-metrics/lib.sh'
     End
 
     Describe 'render_trend()'
-      It 'renders both deltas against a baseline'
-        # current: build cache hit (1/1=100), worst mem build 0.80.
+      It 'renders cache, CPU-seconds, and memory deltas against a baseline'
+        # current: build cache hit (1/1=100), 40 CPU-s, worst mem build 0.80.
         cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
-        # baseline: a miss (0%) and lower mem util (0.60).
-        base_json='{"cache":[{"cache_hit":false}],"cgroup":{"memory":{"peak_utilization":0.60}}}'
+        # baseline: a miss (0%), 30 CPU-s, lower mem util (0.60).
+        base_json='{"cache":[{"cache_hit":false,"restore_key_hit":null}],"cgroup":{"cpu":{"usage_seconds":30.0},"memory":{"peak_utilization":0.60}}}'
         base=$(printf '%s\t%s\n' 'build' "$base_json")
         When call render_trend "$cur" "$base"
         The output should include 'Trend vs master:'
         The output should include 'cache hit 100% (↑ +100pp)'
+        The output should include 'CPU 40.0 CPU-s (↑ +10)'
         The output should include 'peak mem build 80% (↑ +20pp)'
+      End
+
+      It 'compares peak memory like-for-like and shows n/a when the worst job is absent from the baseline'
+        # current worst-mem job is build (0.80). Baseline has only a DIFFERENT job (test, 0.60).
+        # The delta must NOT be build(0.80) vs test(0.60) — it must be n/a (build not in baseline).
+        cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
+        base_json='{"cgroup":{"memory":{"peak_utilization":0.60}}}'
+        base=$(printf '%s\t%s\n' 'test' "$base_json")
+        When call render_trend "$cur" "$base"
+        The output should include 'peak mem build 80% (n/a)'
+        The output should not include '+20pp'
+      End
+
+      It 'compares peak memory against the same job in the baseline'
+        # build is the worst in both runs: current 0.80 vs baseline 0.70 = +10pp, like-for-like.
+        cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
+        base=$(printf '%s\t%s\n' \
+          'build' '{"cgroup":{"memory":{"peak_utilization":0.70}}}' \
+          'test'  '{"cgroup":{"memory":{"peak_utilization":0.90}}}')
+        # Note: baseline's OWN worst job is test (0.90); the delta must still use build (0.70).
+        When call render_trend "$cur" "$base"
+        The output should include 'peak mem build 80% (↑ +10pp)'
       End
 
       It 'says no baseline yet when the baseline is empty'
         cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
         When call render_trend "$cur" ''
         The output should equal 'Trend vs master: no baseline yet'
+      End
+
+      It 'uses the provided default branch in the trend label'
+        cur=$(printf '%s\t%s\n' 'build' "$J_BUILD")
+        base_json='{"cache":[{"cache_hit":false,"restore_key_hit":null}],"cgroup":{"cpu":{"usage_seconds":30.0},"memory":{"peak_utilization":0.60}}}'
+        base=$(printf '%s\t%s\n' 'build' "$base_json")
+        When call render_trend "$cur" "$base" 'main'
+        The output should include 'Trend vs main:'
+        The output should not include 'Trend vs master:'
       End
     End
   End
@@ -324,7 +377,7 @@ Describe 'report-ci-metrics/lib.sh'
       The output should equal '55'
     End
 
-    It 'skips the current run id on a default-branch push (previous master)'
+    It 'skips the current run id on a default-branch push (previous default-branch run)'
       Mock gh
         case "$*" in
           *runs/100\ *|*runs/100) echo 7 ;;
@@ -557,7 +610,7 @@ body'
       render_headline()    { echo "HEADLINE"; return 0; }
       render_table()       { echo "TABLE"; return 0; }
       render_cache_fold()  { echo "CACHE"; return 0; }
-      render_trend()       { echo "TREND"; return 0; }
+      render_trend()       { echo "TREND:${3:-}"; return 0; }
       find_baseline_run()  { return 0; }
       upsert_comment()     { local body=$1; echo "UPSERT:$body"; return 0; }
       return 0
@@ -609,6 +662,16 @@ body'
       When call main
       The status should be success
       The output should include 'TREND'
+    End
+
+    It 'passes the default branch to the trend renderer'
+      export REPO=o/r RUN_ID=1 SELF_JOB=report-ci-metrics PR_NUMBER=7 EVENT_NAME=pull_request DEFAULT_BRANCH=main
+      # shellcheck disable=SC2329  # Invoked indirectly by main()
+      collect_job_metrics() { printf 'build\t{"job":"build"}\n'; return 0; }
+      stub_renderers
+      When call main
+      The status should be success
+      The output should include 'TREND:main'
     End
 
     It 'on a default-branch push writes the job summary and never upserts a comment'


### PR DESCRIPTION
## What

Add **trend deltas** to the `report-ci-metrics` report (M4.4): compare the current run against a default-branch baseline so a developer sees what their PR changed.

- **Pull request:** a `Trend vs master:` line is added under the headline in the sticky comment.
- **Default-branch push:** the headline + trend are written to the **job summary** (there is no PR to comment on).

```
## 📊 CI Metrics
2 jobs · CPU 50.0 CPU-s · peak mem 3.20 GiB (build) · net 1.49 GiB ↓ / 300 MiB ↑ · cache 450 MiB restored / 470 MiB saved

Trend vs master: cache hit 50% (↑ +50pp) · peak mem build 80% (↑ +20pp)
```

Ticket: [BUILD-11311](https://sonarsource.atlassian.net/browse/BUILD-11311) (M4.4, part of BUILD-11068).

## Scope decisions (deviate from the ticket text)

1. **Metric set.** The ticket named cache hit rate, run duration, and per-destination bandwidth. Only **cache hit rate** is reliably attributable to a PR's diff; duration (queue/contention noise) and bandwidth (dependency-driven) make misleading per-PR arrows, so they stay as current values in the per-job table — not trended. The schema also carries a stronger PR-attributable signal the ticket omitted: **peak memory vs limit** (an OOM-risk early warning), which is included. So the trend = **cache hit-rate Δ + peak-memory-vs-limit Δ**.
2. **Master-vs-previous-master.** No PR exists on a default-branch push, so that half writes to `$GITHUB_STEP_SUMMARY` instead of a comment.

## How baselines are sourced

The ticket assumed "the same artifacts uploaded in M4.2" — but M4.2's hook-side artifact upload was never built (it's not possible from a runner hook; see the M4.2 investigation), and M4.3 instead scrapes sibling job **logs**. This PR stays consistent with that: `find_baseline_run` resolves the workflow id from the run object, lists completed default-branch runs, and the existing collector re-reads that baseline run's logs. No new infra; trend availability is bounded by Actions log retention (shows `no baseline yet` on the first run / past retention).

[BUILD-11311]: https://sonarsource.atlassian.net/browse/BUILD-11311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ