### PR TITLE
SC-51500 Skip Maven version update when pom.xml is absent

### DIFF
--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -193,8 +193,22 @@ runs:
         # yamllint enable rule:line-length
         restore-keys: maven-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-
 
+    - name: Check for pom.xml
+      id: check_pom_xml
+      if: steps.config-maven-completed.outputs.skip != 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        if [[ -f "pom.xml" ]]; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "No pom.xml file. Skipping project version update."
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Update project version and set current-version and project-version variables
       id: set-version
+      if: steps.config-maven-completed.outputs.skip == 'true' || steps.check_pom_xml.outputs.exists == 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:

--- a/config-maven/action.yml
+++ b/config-maven/action.yml
@@ -208,7 +208,7 @@ runs:
 
     - name: Update project version and set current-version and project-version variables
       id: set-version
-      if: steps.config-maven-completed.outputs.skip == 'true' || steps.check_pom_xml.outputs.exists == 'true'
+      if: steps.config-maven-completed.outputs.skip != 'true' && steps.check_pom_xml.outputs.exists == 'true'
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:


### PR DESCRIPTION
## Summary

- Add a `Check for pom.xml` step to `config-maven` before the version update step
- Only invoke `set_maven_project_version.sh` when `pom.xml` exists (or when the action is re-entered with `skip=true`)
- Aligns behavior with the existing `config-npm` guard for `package.json`

## Test plan

- [ ] Run `config-maven` in a repo with a root `pom.xml` — version update should still run
- [ ] Run `config-maven` in a repo without a root `pom.xml` — should log skip message and not fail