### PR TITLE
PREQ-6823 Guard Develocity vault JSON parsing in config-gradle

### DIFF
--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -172,7 +172,7 @@ runs:
         develocity-injection-enabled: ${{ inputs.use-develocity == 'true' }}
         cache-disabled: true
         develocity-plugin-version: '4.0'
-        develocity-access-key: ${{ inputs.use-develocity == 'true' &&
+        develocity-access-key: ${{ inputs.use-develocity == 'true' && steps.secrets.outputs.vault &&
           fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN || '' }}
 
     - name: Generate Gradle Cache Key


### PR DESCRIPTION
## Summary
Guard `config-gradle`'s `develocity-access-key` expression so GitHub Actions does not call `fromJSON(...)` when the Vault output is empty during post-job evaluation.

## Context
`sonarcloud-analyzers-shared-services` PR 314 (`SC-51120`) is migrating the repository to uv and currently uses `build-gradle@v1` with Develocity enabled in several jobs.

The current `config-gradle` action evaluates:

```yaml
develocity-access-key: ${{ inputs.use-develocity == 'true' &&
  fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN || '' }}
```

During `Post job cleanup`, `steps.secrets.outputs.vault` can be empty/unavailable, which causes:

`Error reading JToken from JsonReader`

This change makes the expression consistent with the already-safe `DEVELOCITY_TOKEN` environment export earlier in the same action.

## Change
```yaml
develocity-access-key: ${{ inputs.use-develocity == 'true' && steps.secrets.outputs.vault &&
  fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN || '' }}
```

## Impact
This is the shared-action fix needed to unblock completion of `SC-51120` without keeping a repo-specific workaround in `sonarcloud-analyzers-shared-services`.

## Validation
- `git diff --check`
- `./run_shell_tests.sh` could not be run locally because `shellspec` is not installed in the current environment
