### PR TITLE
BUILD-11784 Route the Gradle buildscript classpath through Repox in config-gradle

### DIFF
--- a/config-gradle/resources/repoxAuth.init.gradle.kts
+++ b/config-gradle/resources/repoxAuth.init.gradle.kts
@@ -71,12 +71,19 @@ allprojects {
         repositories {
             configureRepoxRepositories(providers)
         }
+        // Configure the buildscript classpath repositories too. This must happen in
+        // beforeEvaluate: the buildscript {} block is resolved while the build script
+        // is evaluated, so adding Repox here (before evaluation) puts it ahead of any
+        // repository the script declares itself, keeping plugin/buildscript classpath
+        // dependencies (and their transitives) off the rate-limited public repos.
+        buildscript.repositories.configureRepoxRepositories(providers)
     }
     afterEvaluate {
         logger.debug("Applying Repox configuration init script after project '${project.name}' evaluation")
         repositories {
             configureRepoxRepositories(providers)
         }
+        buildscript.repositories.configureRepoxRepositories(providers)
     }
 }
 


### PR DESCRIPTION
## Problem

`config-gradle`'s Repox init script rewrites repositories to authenticated Repox for `pluginManagement`, `dependencyResolutionManagement`, and each project's dependency `repositories` — but **not** the `buildscript {}` classpath.

- A project with a `buildscript { dependencies { classpath(...) } }` block resolves that classpath (and transitives, e.g. the Kotlin DSL stdlib) from the Gradle Plugin Portal / Maven Central.
- Those are rate-limited and return HTTP 429 on shared CI runners. This already broke sonar-rust-enterprise CI (`org.tukaani:xz` → `kotlin-stdlib`).

## Change

- Inside the existing `allprojects { ... }` block, also configure the `buildscript` classpath repositories via the existing `configureRepoxRepositories` helper.
- One call added in both `beforeEvaluate` and `afterEvaluate`.
- The `buildscript {}` classpath is resolved during build-script evaluation, so injecting Repox in `beforeEvaluate` lands it ahead of any repo the script declares — keeping buildscript/plugin classpath deps off the rate-limited public repos. `afterEvaluate` is kept for parity with the existing project-repos handling.

## Impact

- Shared CI action: once merged and tagged (`@v1`), it affects every repo consuming `config-gradle` and makes any per-repo buildscript-Repox workaround redundant on CI.

Resolves BUILD-11784.