### PR TITLE
BUILD-11718: reach 100% code coverage on config-poetry

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.projectName=ci-github-actions
 
 sonar.sourceEncoding=UTF-8
 
-sonar.sources=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-maven,config-npm,build-npm,build-yarn,shared,config-pip,cache,code-signing,config-gradle,config-maven,check-sca,update-release-channel,report-ci-metrics
+sonar.sources=build-poetry,get-build-number,pr_cleanup,promote,build-gradle,build-maven,config-npm,build-npm,build-yarn,shared,config-pip,config-poetry,cache,code-signing,config-gradle,config-maven,check-sca,update-release-channel,report-ci-metrics
 sonar.tests=spec
 
 sonar.coverageReportPaths=coverage/coverage_data/sonar_coverage.xml

--- a/spec/config-poetry_spec.sh
+++ b/spec/config-poetry_spec.sh
@@ -34,6 +34,29 @@ Describe 'configure_poetry_repox()'
     The line 3 should include "jf config use repox"
     The line 4 should include "jf poetry-config --global --server-id-resolve repox --repo-resolve sonarsource-pypi"
   End
+
+  It 'writes Poetry credentials to GITHUB_ENV'
+    GITHUB_ENV=$(mktemp)
+    export GITHUB_ENV
+    When call configure_poetry_repox
+    The status should be success
+    The line 1 should equal "$MESSAGE_CONFIGURING_POETRY"
+    The contents of file "$GITHUB_ENV" should include "POETRY_HTTP_BASIC_REPOX_USERNAME=test-user"
+    The contents of file "$GITHUB_ENV" should include "POETRY_HTTP_BASIC_REPOX_PASSWORD=test-token"
+  End
+
+  It 'ignores missing repox JFrog configuration when removing config'
+    Mock jf
+      if [[ "$1" == "config" && "$2" == "remove" ]]; then
+        return 1
+      fi
+      echo "jf $*"
+    End
+    When call configure_poetry_repox
+    The status should be success
+    The line 1 should equal "$MESSAGE_CONFIGURING_POETRY"
+    The line 2 should include "jf config add repox"
+  End
 End
 
 Describe 'main()'
@@ -60,9 +83,63 @@ End
 export BUILD_NUMBER="42"
 export GITHUB_OUTPUT=/dev/null
 
+Describe 'config-poetry/poetry_set_project_version.sh'
+  It 'does not run main when sourced'
+    When run source config-poetry/poetry_set_project_version.sh
+    The status should be success
+    The lines of output should equal 0
+    The lines of error should equal 0
+  End
+End
+
 Include config-poetry/poetry_set_project_version.sh
 
 Describe 'set_project_version()'
+  # shellcheck disable=SC2329,SC2317
+  common_setup() {
+    GITHUB_OUTPUT=$(mktemp)
+    GITHUB_ENV=$(mktemp)
+    return 0
+  }
+  # shellcheck disable=SC2329,SC2317
+  common_cleanup() {
+    [[ -f "$GITHUB_OUTPUT" ]] && rm "$GITHUB_OUTPUT"
+    [[ -f "$GITHUB_ENV" ]] && rm "$GITHUB_ENV"
+    return 0
+  }
+
+  BeforeEach 'common_setup'
+  AfterEach 'common_cleanup'
+
+  It 'uses provided CURRENT_VERSION and PROJECT_VERSION without changes'
+    export CURRENT_VERSION="1.2.3.dev"
+    export PROJECT_VERSION="1.2.3.42"
+    When call set_project_version
+    The status should be success
+    The line 1 should equal "Using provided CURRENT_VERSION 1.2.3.dev and PROJECT_VERSION 1.2.3.42 without changes."
+    The line 1 of contents of file "$GITHUB_OUTPUT" should equal "current-version=1.2.3.dev"
+    The line 2 of contents of file "$GITHUB_OUTPUT" should equal "project-version=1.2.3.42"
+  End
+
+  It 'writes version outputs to GITHUB_OUTPUT and GITHUB_ENV'
+    Mock poetry
+      if [[ "$*" == "version -s" ]]; then
+        echo "1.2.3"
+      else
+        echo "poetry $*"
+      fi
+    End
+    When call set_project_version
+    The status should be success
+    The line 1 of contents of file "$GITHUB_OUTPUT" should equal "current-version=1.2.3"
+    The line 2 of contents of file "$GITHUB_OUTPUT" should equal "project-version=1.2.3.42"
+    The line 1 of contents of file "$GITHUB_ENV" should equal "CURRENT_VERSION=1.2.3"
+    The line 2 of contents of file "$GITHUB_ENV" should equal "PROJECT_VERSION=1.2.3.42"
+    The line 1 should equal "Replacing version 1.2.3 with 1.2.3.42"
+    The line 2 should include "poetry version 1.2.3.42"
+    The line 3 should equal "PROJECT_VERSION=1.2.3.42"
+  End
+
   It 'appends .0 given version is 1.2 and append BUILD_NUMBER'
     Mock poetry
       if [[ "$*" == "version -s" ]]; then
@@ -135,5 +212,52 @@ Describe 'set_project_version()'
     The variable CURRENT_VERSION should be undefined
     The variable PROJECT_VERSION should be undefined
     The status should be failure
+  End
+End
+
+Describe 'poetry_set_project_version main()'
+  # shellcheck disable=SC2329,SC2317
+  common_setup() {
+    GITHUB_OUTPUT=$(mktemp)
+    GITHUB_ENV=$(mktemp)
+    return 0
+  }
+  # shellcheck disable=SC2329,SC2317
+  common_cleanup() {
+    [[ -f "$GITHUB_OUTPUT" ]] && rm "$GITHUB_OUTPUT"
+    [[ -f "$GITHUB_ENV" ]] && rm "$GITHUB_ENV"
+    return 0
+  }
+
+  BeforeEach 'common_setup'
+  AfterEach 'common_cleanup'
+
+  It 'runs set_project_version within a GitHub Actions group'
+    Mock poetry
+      if [[ "$*" == "version -s" ]]; then
+        echo "1.2.3"
+      else
+        echo "poetry $*"
+      fi
+    End
+    When run script config-poetry/poetry_set_project_version.sh
+    The status should be success
+    The line 1 should equal "::group::Set project version"
+    The line 2 should equal "Replacing version 1.2.3 with 1.2.3.42"
+    The line 3 should include "poetry version 1.2.3.42"
+    The line 4 should equal "PROJECT_VERSION=1.2.3.42"
+    The line 5 should equal "::endgroup::"
+  End
+
+  It 'uses provided CURRENT_VERSION and PROJECT_VERSION without changes'
+    export CURRENT_VERSION="1.2.3.dev"
+    export PROJECT_VERSION="1.2.3.42"
+    When run script config-poetry/poetry_set_project_version.sh
+    The status should be success
+    The line 1 should equal "::group::Set project version"
+    The line 2 should equal "Using provided CURRENT_VERSION 1.2.3.dev and PROJECT_VERSION 1.2.3.42 without changes."
+    The line 3 should equal "::endgroup::"
+    The line 1 of contents of file "$GITHUB_OUTPUT" should equal "current-version=1.2.3.dev"
+    The line 2 of contents of file "$GITHUB_OUTPUT" should equal "project-version=1.2.3.42"
   End
 End

--- a/spec/config-poetry_spec.sh
+++ b/spec/config-poetry_spec.sh
@@ -220,6 +220,7 @@ Describe 'poetry_set_project_version main()'
   common_setup() {
     GITHUB_OUTPUT=$(mktemp)
     GITHUB_ENV=$(mktemp)
+    export GITHUB_OUTPUT GITHUB_ENV
     return 0
   }
   # shellcheck disable=SC2329,SC2317


### PR DESCRIPTION
## Summary

- Add `config-poetry` to `sonar-project.properties` so SonarCloud tracks coverage for the extracted action scripts
- Extend `spec/config-poetry_spec.sh` to cover previously untested paths in `poetry_set_project_version.sh`:
  - sourcing guard and `main()` entrypoint
  - provided `CURRENT_VERSION` / `PROJECT_VERSION` shortcut
  - `GITHUB_OUTPUT` and `GITHUB_ENV` writes
  - missing JFrog config removal (`jf config remove`) and Poetry credential export in `configure_poetry_repox()`

JIRA: https://sonarsource.atlassian.net/browse/BUILD-11718

## Test plan

- [x] `shellspec spec/config-poetry_spec.sh` passes locally (15 examples)
- [ ] CI `Test Shell Scripts` workflow passes and SonarCloud reports 100% coverage on `config-poetry`