### PR TITLE
PREQ-7260 Validate build number before export in get-build-number

### DIFF
--- a/get-build-number/action.yml
+++ b/get-build-number/action.yml
@@ -71,6 +71,10 @@ runs:
       shell: bash
       run: |
         BUILD_NUMBER=$(cat "$BUILD_NUMBER_FILE")
+        if ! [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
+          echo "::error title=Invalid build number::Build number '${BUILD_NUMBER}' (from ${BUILD_NUMBER_FILE}) is not a valid positive integer." >&2
+          exit 1
+        fi
         echo "BUILD_NUMBER: ${BUILD_NUMBER}"
         echo "BUILD_NUMBER=${BUILD_NUMBER}" >> "$GITHUB_ENV"
         echo "BUILD_NUMBER=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"

--- a/get-build-number/action.yml
+++ b/get-build-number/action.yml
@@ -72,7 +72,7 @@ runs:
       run: |
         BUILD_NUMBER=$(cat "$BUILD_NUMBER_FILE")
         if ! [[ "$BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
-          echo "::error title=Invalid build number::Build number '${BUILD_NUMBER}' (from ${BUILD_NUMBER_FILE}) is not a valid positive integer." >&2
+          echo "::error title=Invalid build number::Build number '${BUILD_NUMBER}' is not a valid positive integer." >&2
           exit 1
         fi
         echo "BUILD_NUMBER: ${BUILD_NUMBER}"


### PR DESCRIPTION
## What

Validates `BUILD_NUMBER` against `^[0-9]+$` in the "Export build number" step, right before exporting it - the same check `get_build_number.sh` already applies, just at the single point where all three code paths (env passthrough, cache hit, freshly generated) converge.

## Why

The "Export build number" step trusts `.build_number.txt`'s content unconditionally on all three paths. `get_build_number.sh` validates the value it fetches from the repo property, but only on the freshly-generated path - a cache hit (or an externally-provided `BUILD_NUMBER` env var) skips that check entirely. A corrupted or empty cache entry would flow straight through to `BUILD_NUMBER` unchecked.

Found this while migrating `sonar-scanner-msbuild`'s CI to GitHub Actions: an empty `BUILD_NUMBER` there causes `scripts/set-version.ps1` to treat the run as a release-version bump - checking out a branch, committing, and opening a PR unattended. Not something this action is responsible for, but the blast radius of a missing one-line check seemed worth closing here rather than only guarding defensively downstream.