### PR TITLE
BUILD-11964: Harden config-uv dependency cache keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,14 +1280,6 @@ default = true
 
 > **Note:** This action automatically calls [`get-build-number`](#get-build-number) to manage the build number.
 
-The cache key is derived from `uv.lock` and `pyproject.toml` in `working-directory`.
-When the project is not at the repository root, always set `working-directory`
-to the directory that the job installs. The action disables caching with a
-warning instead of creating an empty, permanently stale cache key when neither
-dependency file exists there.
-For a job that intentionally installs several uv projects, set
-`cache-dependency-glob` to a glob that covers every lockfile it installs.
-
 ### Requirements
 
 #### Required GitHub Permissions
@@ -1316,25 +1308,6 @@ steps:
   - run: jf uv sync
 ```
 
-For a project in a monorepo:
-
-```yaml
-- uses: SonarSource/ci-github-actions/config-uv@v1
-  with:
-    working-directory: services/my-service
-- run: jf uv sync
-  working-directory: services/my-service
-```
-
-For a job that installs every uv project in a monorepo:
-
-```yaml
-- uses: SonarSource/ci-github-actions/config-uv@v1
-  with:
-    cache-dependency-glob: '**/uv.lock'
-- run: ./scripts/install-all-uv-projects.sh
-```
-
 For build-info collection, pass `--build-name` and `--build-number` to `jf uv` and publish with `jf rt build-publish`.
 
 ### Inputs
@@ -1346,7 +1319,6 @@ For build-info collection, pass `--build-name` and `--build-number` to `jf uv` a
 | `uv-index-name`           | Name of the uv index in `pyproject.toml` to authenticate                    | `repox`                                                              |
 | `repox-url`               | URL for Repox                                                               | `https://repox.jfrog.io`                                             |
 | `uv-cache-dir`            | Path to the uv cache directory, relative to GitHub workspace                | `.cache/uv`                                                          |
-| `cache-dependency-glob`   | Dependency-file glob for jobs that install multiple uv projects             | (optional)                                                           |
 | `disable-caching`         | Whether to disable uv caching entirely                                      | `false`                                                              |
 
 ### Outputs

--- a/README.md
+++ b/README.md
@@ -1280,6 +1280,14 @@ default = true
 
 > **Note:** This action automatically calls [`get-build-number`](#get-build-number) to manage the build number.
 
+The cache key is derived from `uv.lock` and `pyproject.toml` in `working-directory`.
+When the project is not at the repository root, always set `working-directory`
+to the directory that the job installs. The action disables caching with a
+warning instead of creating an empty, permanently stale cache key when neither
+dependency file exists there.
+For a job that intentionally installs several uv projects, set
+`cache-dependency-glob` to a glob that covers every lockfile it installs.
+
 ### Requirements
 
 #### Required GitHub Permissions
@@ -1308,6 +1316,25 @@ steps:
   - run: jf uv sync
 ```
 
+For a project in a monorepo:
+
+```yaml
+- uses: SonarSource/ci-github-actions/config-uv@v1
+  with:
+    working-directory: services/my-service
+- run: jf uv sync
+  working-directory: services/my-service
+```
+
+For a job that installs every uv project in a monorepo:
+
+```yaml
+- uses: SonarSource/ci-github-actions/config-uv@v1
+  with:
+    cache-dependency-glob: '**/uv.lock'
+- run: ./scripts/install-all-uv-projects.sh
+```
+
 For build-info collection, pass `--build-name` and `--build-number` to `jf uv` and publish with `jf rt build-publish`.
 
 ### Inputs
@@ -1319,6 +1346,7 @@ For build-info collection, pass `--build-name` and `--build-number` to `jf uv` a
 | `uv-index-name`           | Name of the uv index in `pyproject.toml` to authenticate                    | `repox`                                                              |
 | `repox-url`               | URL for Repox                                                               | `https://repox.jfrog.io`                                             |
 | `uv-cache-dir`            | Path to the uv cache directory, relative to GitHub workspace                | `.cache/uv`                                                          |
+| `cache-dependency-glob`   | Dependency-file glob for jobs that install multiple uv projects             | (optional)                                                           |
 | `disable-caching`         | Whether to disable uv caching entirely                                      | `false`                                                              |
 
 ### Outputs

--- a/config-uv/action.yml
+++ b/config-uv/action.yml
@@ -101,8 +101,8 @@ runs:
       if: steps.config-uv-completed.outputs.skip != 'true' && inputs.disable-caching != 'true'
       with:
         path: ${{ github.workspace }}/${{ inputs.uv-cache-dir }}
-        key: uv-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-${{ hashFiles(format('{0}/uv.lock', inputs.working-directory),
-          format('{0}/pyproject.toml', inputs.working-directory)) }}
+        key: uv-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-${{
+          hashFiles(format('{0}/uv.lock', inputs.working-directory), format('{0}/pyproject.toml', inputs.working-directory)) }}
         restore-keys: uv-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-
 
     - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0

--- a/config-uv/action.yml
+++ b/config-uv/action.yml
@@ -18,6 +18,9 @@ inputs:
   uv-cache-dir:
     description: Path to the uv cache directory, relative to GitHub workspace
     default: .cache/uv
+  cache-dependency-glob:
+    description: Glob of dependency files for jobs that install more than one uv project
+    default: ''
   disable-caching:
     description: Whether to disable uv caching entirely
     default: 'false'
@@ -88,22 +91,42 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
 
-    - name: Sanitize workflow name for cache key
-      id: sanitize_workflow
+    - name: Resolve uv cache key
+      id: uv-cache-key
       if: steps.config-uv-completed.outputs.skip != 'true' && inputs.disable-caching != 'true'
       shell: bash
       env:
-        WORKFLOW_NAME: ${{ github.workflow }}
-      run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
+        CACHE_DEPENDENCY_GLOB: ${{ inputs.cache-dependency-glob }}
+        DIRECTORY_DEPENDENCY_HASH:
+          ${{ hashFiles(format('{0}/uv.lock', inputs.working-directory),
+          format('{0}/pyproject.toml', inputs.working-directory)) }}
+        GLOB_DEPENDENCY_HASH: ${{ hashFiles(inputs.cache-dependency-glob) }}
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+      run: |
+        dependency_hash="$DIRECTORY_DEPENDENCY_HASH"
+        dependency_source="working-directory '${WORKING_DIRECTORY}'"
+        if [[ -n "$CACHE_DEPENDENCY_GLOB" ]]; then
+          dependency_hash="$GLOB_DEPENDENCY_HASH"
+          dependency_source="cache-dependency-glob '${CACHE_DEPENDENCY_GLOB}'"
+        fi
+        if [[ -z "$dependency_hash" ]]; then
+          message="No dependency files matched ${dependency_source}. "
+          message+="Point config-uv at the uv project or dependency files that the job installs."
+          echo "::warning title=uv caching disabled::$message"
+          echo "cache_enabled=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "cache_enabled=true" >> "$GITHUB_OUTPUT"
+        echo "dependency_hash=$dependency_hash" >> "$GITHUB_OUTPUT"
 
     - name: Cache uv dependencies
       uses: SonarSource/gh-action_cache@4e40632e780e11a8bbe9b721985ab22b42847cc4 # v1.7.2
-      if: steps.config-uv-completed.outputs.skip != 'true' && inputs.disable-caching != 'true'
+      if: steps.config-uv-completed.outputs.skip != 'true' && inputs.disable-caching != 'true' &&
+        steps.uv-cache-key.outputs.cache_enabled == 'true'
       with:
         path: ${{ github.workspace }}/${{ inputs.uv-cache-dir }}
-        key: uv-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-${{
-          hashFiles(format('{0}/uv.lock', inputs.working-directory), format('{0}/pyproject.toml', inputs.working-directory)) }}
-        restore-keys: uv-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-
+        key: uv-${{ runner.os }}-${{ steps.uv-cache-key.outputs.dependency_hash }}
+        restore-keys: uv-${{ runner.os }}-
 
     - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       if: steps.config-uv-completed.outputs.skip != 'true'

--- a/config-uv/action.yml
+++ b/config-uv/action.yml
@@ -88,14 +88,22 @@ runs:
       run: |
         echo "ARTIFACTORY_READER_ROLE=${ARTIFACTORY_READER_ROLE}" >> "$GITHUB_ENV"
 
+    - name: Sanitize workflow name for cache key
+      id: sanitize_workflow
+      if: steps.config-uv-completed.outputs.skip != 'true' && inputs.disable-caching != 'true'
+      shell: bash
+      env:
+        WORKFLOW_NAME: ${{ github.workflow }}
+      run: echo "workflow_name=${WORKFLOW_NAME// /-}" >> "$GITHUB_OUTPUT"
+
     - name: Cache uv dependencies
       uses: SonarSource/gh-action_cache@4e40632e780e11a8bbe9b721985ab22b42847cc4 # v1.7.2
       if: steps.config-uv-completed.outputs.skip != 'true' && inputs.disable-caching != 'true'
       with:
         path: ${{ github.workspace }}/${{ inputs.uv-cache-dir }}
-        key: uv-${{ runner.os }}-${{ hashFiles(format('{0}/uv.lock', inputs.working-directory),
+        key: uv-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-${{ hashFiles(format('{0}/uv.lock', inputs.working-directory),
           format('{0}/pyproject.toml', inputs.working-directory)) }}
-        restore-keys: uv-${{ runner.os }}-
+        restore-keys: uv-${{ runner.os }}-${{ steps.sanitize_workflow.outputs.workflow_name }}-
 
     - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       if: steps.config-uv-completed.outputs.skip != 'true'


### PR DESCRIPTION
## Summary
- derive uv cache keys from dependency content only, allowing reuse across workflows
- support an explicit dependency glob for jobs that install multiple uv projects
- warn and disable caching when no dependency files match instead of freezing `uv-Linux-`

## Predicted savings
**Approximately 0 TiB/month directly.** This is the shared prerequisite and safety guard for BUILD-11965 through BUILD-11969. The measurable savings occur when those consumers supply correct project or lockfile scope.

Removing workflow-name partitioning avoids duplicate caches and also avoids the Unicode workflow-name failure independently confirmed in Semsitter.

## Rollout and confirmation
1. Merge and release this change on the v1 tag.
2. Run each consumer PR twice.
3. Confirm the first run saves a non-empty dependency-hash key and the second restores the exact key.
4. After consumer rollout, compare 7-14 day pre/post repository uv bytes and repeated immutable wheel paths in [the uv caching notebook](https://app.datadoghq.eu/notebook/329447).

Success for this PR is no new empty keys and correct key invalidation when scoped lockfiles change. Savings are attributed and verified in each consumer PR.

## Test plan
- [x] Parse `config-uv/action.yml`
- [x] Run `git diff --check`
- [x] Run focused ShellSpec suite: 5 examples, 0 failures
- [ ] Canary a root uv project
- [ ] Canary a nested uv project with `working-directory`
- [ ] Canary a multi-project job with `cache-dependency-glob`

The full repository ShellSpec suite currently has two unrelated failures: one existing SCA mock expectation and one missing local `check-jsonschema` executable.