### PR TITLE
PREQ-7293 Fix config-uv mise restore with working-directory

### DIFF
--- a/config-uv/action.yml
+++ b/config-uv/action.yml
@@ -121,13 +121,16 @@ runs:
         ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
         UV_INDEX_NAME: ${{ inputs.uv-index-name }}
         UV_CACHE_DIR: ${{ github.workspace }}/${{ inputs.uv-cache-dir }}
-      run: |
-        $ACTION_PATH_CONFIG_UV/uv_config.sh
+      run: $ACTION_PATH_CONFIG_UV/uv_config.sh
 
+    - name: Restore mise files
+      if: always() && steps.config-uv-completed.outputs.skip != 'true'
+      shell: bash
+      run: |
         echo "::group::Restore mise files"
-        rm mise.local.toml
+        rm -f mise.local.toml
         mv "${{ steps.set-path.outputs.MISE_BACKUP }}"/* "${{ steps.set-path.outputs.MISE_BACKUP }}"/.* ./ 2>/dev/null || true
-        rmdir "${{ steps.set-path.outputs.MISE_BACKUP }}"
+        rmdir "${{ steps.set-path.outputs.MISE_BACKUP }}" 2>/dev/null || true
         echo "::endgroup::"
 
     - name: Set Config uv completed


### PR DESCRIPTION
PREQ-7293 Fix config-uv mise restore when callers pass a non-default working-directory.

## Summary

- Move mise backup restore out of the `Configure uv authentication` step into a dedicated step at the workspace root
- Aligns with the existing `config-poetry` pattern
- Use `rm -f` and tolerant `rmdir` so cleanup does not fail if files are already gone

## Behavioral change

When `working-directory` is set, `mise.local.toml` is still created at the workspace root during setup, but cleanup now also runs at the workspace root instead of inside the working directory.

## Test plan

- [x] Verify CI passes on this PR
- [ ] Confirm `sonarcloud-doptranslation` workflow succeeds with a non-default `working-directory` after release

## Related

- Failing job: https://github.com/SonarSource/sonarcloud-doptranslation/actions/runs/29279832338/job/86918679273