### PR TITLE
BUILD-12007: Bump jfrog-cli in config-uv to 2.115.0

### DIFF
--- a/config-uv/mise.local.toml
+++ b/config-uv/mise.local.toml
@@ -1,5 +1,5 @@
 [tools]
-jfrog-cli = "2.96.0"
+jfrog-cli = "2.115.0"
 
 [env]
 JFROG_CLI_AVOID_NEW_VERSION_WARNING = "true"


### PR DESCRIPTION
BUILD-12007: Bump jfrog-cli in config-uv to 2.115.0

## Summary

- `config-uv` pinned `jfrog-cli` to `2.96.0`, which does not include the public `jf uv` command (added in [jfrog-cli v2.105.0](https://github.com/jfrog/jfrog-cli/releases#release-v2.105.0)).
- Bump to `2.115.0` so [documented](https://github.com/SonarSource/ci-github-actions#config-uv) `jf uv sync` works after `config-uv`.

## Concrete failure

After the GH_TOKEN fix path in `gitarcode/benchmark-martian`, setup failed at `jf uv sync`:

- Run: https://github.com/gitarcode/benchmark-martian/actions/runs/29730236355/job/88312750323
- `get-build-number` succeeded (`BUILD_NUMBER: 1`)
- Install failed with:

```text
'jf uv' is not a jf command. See --help
```

## Changes

- `config-uv/mise.local.toml`: bump `jfrog-cli` `2.96.0` → `2.115.0`

## Validation

- [x] CI on this PR passes
- [x] Tested with [gitarcode/benchmark-martian/actions/runs/29731266555/job/88316072434](https://github.com/gitarcode/benchmark-martian/actions/runs/29731266555/job/88316072434)
