### PR TITLE
PREQ-7501: Bump jfrog-cli to 2.115.0 across remaining actions

### DIFF
--- a/build-npm/mise.local.toml
+++ b/build-npm/mise.local.toml
@@ -1,5 +1,5 @@
 [tools]
-jfrog-cli = "2.96.0"
+jfrog-cli = "2.115.0"
 jq = "1.8.1"
 
 [env]

--- a/build-poetry/mise.local.toml
+++ b/build-poetry/mise.local.toml
@@ -1,5 +1,5 @@
 [tools]
-jfrog-cli = "2.96.0"
+jfrog-cli = "2.115.0"
 
 [env]
 JFROG_CLI_AVOID_NEW_VERSION_WARNING = "true"

--- a/build-yarn/mise.local.toml
+++ b/build-yarn/mise.local.toml
@@ -1,5 +1,5 @@
 [tools]
-jfrog-cli = "2.96.0"
+jfrog-cli = "2.115.0"
 jq = "1.8.1"
 
 [env]

--- a/config-npm/mise.local.toml
+++ b/config-npm/mise.local.toml
@@ -1,5 +1,5 @@
 [tools]
-jfrog-cli = "2.96.0"
+jfrog-cli = "2.115.0"
 jq = "1.8.1"
 
 [env]

--- a/config-poetry/mise.local.toml
+++ b/config-poetry/mise.local.toml
@@ -1,5 +1,5 @@
 [tools]
-jfrog-cli = "2.96.0"
+jfrog-cli = "2.115.0"
 
 [env]
 JFROG_CLI_AVOID_NEW_VERSION_WARNING = "true"

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 pre-commit = "4.2.0"
 shellcheck = "0.11.0"
 shellspec = "0.28.1"
-jfrog-cli = "2.96.0"
+jfrog-cli = "2.115.0"
 node = "24.15.0"
 python = "3.14"
 "npm:markdownlint-cli" = "0.39.0"

--- a/promote/mise.local.toml
+++ b/promote/mise.local.toml
@@ -1,5 +1,5 @@
 [tools]
-jfrog-cli = "2.96.0"
+jfrog-cli = "2.115.0"
 
 [env]
 JFROG_CLI_AVOID_NEW_VERSION_WARNING = "true"


### PR DESCRIPTION
## Summary
- `config-npm` fails in consumers (e.g. sonarcloud-tooling) because mise cannot resolve `jfrog-cli@2.96.0` (`invalid package name 'mise-plugins/mise-jfrog-cli'`).
- [BUILD-12007](https://sonarsource.atlassian.net/browse/BUILD-12007) / [#325](https://github.com/SonarSource/ci-github-actions/pull/325) already bumped `config-uv` to `2.115.0`; this completes the same bump for the remaining pins (`config-npm`, `config-poetry`, `promote`, `build-*`, root `mise.toml`).
- Jira: [PREQ-7501](https://sonarsource.atlassian.net/browse/PREQ-7501)

## Test plan
- [ ] CI on this PR passes (shellspec / action tests)
- [ ] After merge/release, re-run failing consumer job: https://github.com/SonarSource/sonarcloud-tooling/actions/runs/29922569037/job/88932141583
- [ ] Confirm `config-npm` installs `jfrog-cli` 2.115.0 (same as `config-uv`)

[BUILD-12007]: https://sonarsource.atlassian.net/browse/BUILD-12007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PREQ-7501]: https://sonarsource.atlassian.net/browse/PREQ-7501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ