### PR TITLE
PREQ-7525 Fail promote job when multi-repo promotion API call returns an error

### DIFF
--- a/promote/promote.sh
+++ b/promote/promote.sh
@@ -136,8 +136,14 @@ promote_multi() {
   local response
   response=$(jf rt curl "$promoteUrl")
   echo "$response"
-  if jq -e '.errors' <<< "$response" > /dev/null 2>&1; then
-    echo "::error title=Multi-repo promotion failed::$(jq -r '.errors' <<< "$response")" >&2
+  if ! jq -e 'type == "object"' <<< "$response" > /dev/null 2>&1; then
+    # ::error:: is a single-line workflow command: flatten the response in case it contains newlines (e.g. an HTML error page).
+    echo "::error title=Multi-repo promotion failed::Unexpected non-JSON response from the multiRepoPromote plugin: $(tr '\n' ' ' <<< "$response")" >&2
+    return 1
+  fi
+  if jq -e '(.errors // []) | length > 0' <<< "$response" > /dev/null 2>&1; then
+    # -c (compact) keeps the ::error:: workflow command on a single line.
+    echo "::error title=Multi-repo promotion failed::$(jq -c '.errors' <<< "$response")" >&2
     return 1
   fi
 }

--- a/promote/promote.sh
+++ b/promote/promote.sh
@@ -133,7 +133,13 @@ promote_multi() {
   promoteUrl+="params=buildName=$BUILD_NAME;buildNumber=$BUILD_NUMBER;status=$status"
   promoteUrl+=";src1=$MULTI_REPO_SRC_PRIVATE;target1=$targetRepo1"
   promoteUrl+=";src2=$MULTI_REPO_SRC_PUBLIC;target2=$targetRepo2"
-  jf rt curl "$promoteUrl"
+  local response
+  response=$(jf rt curl "$promoteUrl")
+  echo "$response"
+  if jq -e '.errors' <<< "$response" > /dev/null 2>&1; then
+    echo "::error title=Multi-repo promotion failed::$(jq -r '.errors' <<< "$response")" >&2
+    return 1
+  fi
 }
 
 promote_mono() {

--- a/spec/promote_spec.sh
+++ b/spec/promote_spec.sh
@@ -13,6 +13,11 @@ Mock jf
     }
 }
 EOF
+  elif [[ "$*" == rt\ curl\ api/plugins/execute/multiRepoPromote* ]]; then
+    # Echo the invocation to stderr (not captured by the caller's `response=$(...)`)
+    # so tests can still verify the exact URL that was requested.
+    echo "jf $*" >&2
+    echo '{"status":"success"}'
   else
     echo "jf $*"
   fi
@@ -31,10 +36,20 @@ Mock jq
     echo "1.2.3.42"
   elif [[ "$*" == *"buildInfo.env.NON_EXISTING_PROPERTY"* ]]; then
     echo "null"
-  elif [[ "$*" == "-e .errors" ]]; then
-    grep -q '"errors"'
-  elif [[ "$*" == "-r .errors" ]]; then
-    cat
+  elif [[ "$*" == '-e type == "object"' ]]; then
+    input=$(tr -d '[:space:]')
+    [[ "$input" == '{'*'}' ]]
+  elif [[ "$*" == "-e (.errors // []) | length > 0" ]]; then
+    input=$(cat)
+    if [[ "$input" != *'"errors"'* ]]; then
+      false
+    elif [[ "$input" =~ \"errors\"[[:space:]]*:[[:space:]]*\[[[:space:]]*\] ]]; then
+      false
+    else
+      true
+    fi
+  elif [[ "$*" == "-c .errors" ]]; then
+    tr -d '\n'
   else
     echo "jq $*"
   fi
@@ -232,14 +247,42 @@ End
 Describe 'promote_multi()'
   It 'calls the multiRepoPromote plugin with version display'
     export GITHUB_REF_NAME="main"
-    export status='it-passed'
+    status='it-passed'
     export PROJECT_VERSION="1.2.3.42"
     get_target_repos
     When call promote_multi
     The status should be success
     The line 1 should equal "Promoting build dummy-project/$BUILD_NUMBER (version: 1.2.3.42)"
     The line 2 should equal "Target repositories: sonarsource-private-builds and sonarsource-public-builds"
-    The line 3 should match pattern "jf rt curl */multiRepoPromote?*;src1=*;target1=*;src2=*;target2=*"
+    The line 3 should equal '{"status":"success"}'
+    The error should match pattern "jf rt curl */multiRepoPromote?*;src1=*;target1=*;src2=*;target2=*"
+  End
+
+  It 'fails when the multiRepoPromote plugin returns a non-JSON response'
+    Mock jf
+      echo "Bad Gateway"
+    End
+    export GITHUB_REF_NAME="main"
+    status='it-passed'
+    export PROJECT_VERSION="1.2.3.42"
+    get_target_repos
+    When call promote_multi
+    The status should be failure
+    The line 3 should equal "Bad Gateway"
+    The error should include "::error title=Multi-repo promotion failed::Unexpected non-JSON response from the multiRepoPromote plugin: Bad Gateway"
+  End
+
+  It 'succeeds when the multiRepoPromote plugin returns an empty errors array'
+    Mock jf
+      echo '{"errors": []}'
+    End
+    export GITHUB_REF_NAME="main"
+    status='it-passed'
+    export PROJECT_VERSION="1.2.3.42"
+    get_target_repos
+    When call promote_multi
+    The status should be success
+    The line 3 should equal '{"errors": []}'
   End
 
   It 'fails when the multiRepoPromote plugin returns an error response'
@@ -254,7 +297,8 @@ Describe 'promote_multi()'
 EOF
     End
     export GITHUB_REF_NAME="main"
-    export status='it-passed'
+    # shellcheck disable=SC2034 # read as $status by promote_multi(), sourced via `Include promote/promote.sh`
+    status='it-passed'
     export PROJECT_VERSION="1.2.3.42"
     get_target_repos
     When call promote_multi
@@ -264,6 +308,8 @@ EOF
     The output should include "The execution name 'multiRepoPromote' could not be found."
     The error should include "::error title=Multi-repo promotion failed::"
     The error should include "The execution name 'multiRepoPromote' could not be found."
+    # The multi-line JSON response must not break the single-line ::error:: workflow command.
+    The lines of stderr should equal 1
   End
 End
 
@@ -356,7 +402,8 @@ Describe 'jfrog_promote()'
     The variable PROJECT_VERSION should equal "1.2.3.42"
     The line 1 should equal "Promoting build dummy-project/$BUILD_NUMBER (version: 1.2.3.42)"
     The line 2 should equal "Target repositories: sonarsource-private-builds and sonarsource-public-builds"
-    The line 3 should match pattern "jf rt curl */multiRepoPromote?*;src1=*;target1=*;src2=*;target2=*"
+    The line 3 should equal '{"status":"success"}'
+    The error should match pattern "jf rt curl */multiRepoPromote?*;src1=*;target1=*;src2=*;target2=*"
   End
 
   It 'uses PROJECT_VERSION from environment when set instead of fetching from JFrog'

--- a/spec/promote_spec.sh
+++ b/spec/promote_spec.sh
@@ -31,6 +31,10 @@ Mock jq
     echo "1.2.3.42"
   elif [[ "$*" == *"buildInfo.env.NON_EXISTING_PROPERTY"* ]]; then
     echo "null"
+  elif [[ "$*" == "-e .errors" ]]; then
+    grep -q '"errors"'
+  elif [[ "$*" == "-r .errors" ]]; then
+    cat
   else
     echo "jq $*"
   fi
@@ -232,9 +236,34 @@ Describe 'promote_multi()'
     export PROJECT_VERSION="1.2.3.42"
     get_target_repos
     When call promote_multi
+    The status should be success
     The line 1 should equal "Promoting build dummy-project/$BUILD_NUMBER (version: 1.2.3.42)"
     The line 2 should equal "Target repositories: sonarsource-private-builds and sonarsource-public-builds"
     The line 3 should match pattern "jf rt curl */multiRepoPromote?*;src1=*;target1=*;src2=*;target2=*"
+  End
+
+  It 'fails when the multiRepoPromote plugin returns an error response'
+    Mock jf
+      cat <<'EOF'
+{
+  "errors" : [ {
+    "status" : 404,
+    "message" : "The execution name 'multiRepoPromote' could not be found."
+  } ]
+}
+EOF
+    End
+    export GITHUB_REF_NAME="main"
+    export status='it-passed'
+    export PROJECT_VERSION="1.2.3.42"
+    get_target_repos
+    When call promote_multi
+    The status should be failure
+    The line 1 should equal "Promoting build dummy-project/$BUILD_NUMBER (version: 1.2.3.42)"
+    The line 2 should equal "Target repositories: sonarsource-private-builds and sonarsource-public-builds"
+    The output should include "The execution name 'multiRepoPromote' could not be found."
+    The error should include "::error title=Multi-repo promotion failed::"
+    The error should include "The execution name 'multiRepoPromote' could not be found."
   End
 End
 


### PR DESCRIPTION
## Summary
- We just hit a case on `sonar-scanner-engine` PR #525 where the `Promote` job (with `multi-repo: true`) reported success on GitHub, but the actual JFrog `multiRepoPromote` plugin call returned a 404 (`The execution name 'multiRepoPromote' could not be found.`). Because `promote_multi()` only printed the curl response without inspecting it, the failure was silently swallowed, the artifact was never promoted to `sonarsource-private-dev`, and the downstream deploy job failed later with a confusing "no artifact found" error.
- This makes `promote_multi()` check the JSON response for an `errors` field and fail the step (with a clear `::error::` annotation) when the Artifactory plugin call itself fails, instead of only failing much later in an unrelated deploy job.

## Test plan
- [x] `./run_shell_tests.sh` (via `mise exec -- shellspec spec/promote_spec.sh --shell bash`) — 32 examples, 0 failures, including a new case simulating the exact 404 response seen in the wild
- [x] `shellcheck promote/promote.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)