### PR TITLE
PREQ-7525: Accept plain-text success from multiRepoPromote

### DIFF
--- a/promote/promote.sh
+++ b/promote/promote.sh
@@ -136,16 +136,22 @@ promote_multi() {
   local response
   response=$(jf rt curl "$promoteUrl")
   echo "$response"
-  if ! jq -e 'type == "object"' <<< "$response" > /dev/null 2>&1; then
-    # ::error:: is a single-line workflow command: flatten the response in case it contains newlines (e.g. an HTML error page).
-    echo "::error title=Multi-repo promotion failed::Unexpected non-JSON response from the multiRepoPromote plugin: $(tr '\n' ' ' <<< "$response")" >&2
-    return 1
+  if jq -e 'type == "object"' <<< "$response" > /dev/null 2>&1; then
+    if jq -e '(.errors // []) | length > 0' <<< "$response" > /dev/null 2>&1; then
+      # -c (compact) keeps the ::error:: workflow command on a single line.
+      echo "::error title=Multi-repo promotion failed::$(jq -c '.errors' <<< "$response")" >&2
+      return 1
+    fi
+    return 0
   fi
-  if jq -e '(.errors // []) | length > 0' <<< "$response" > /dev/null 2>&1; then
-    # -c (compact) keeps the ::error:: workflow command on a single line.
-    echo "::error title=Multi-repo promotion failed::$(jq -c '.errors' <<< "$response")" >&2
-    return 1
+  # multiRepoPromote.groovy returns plain text on HTTP 200 success, e.g.
+  # "Promoted <build> <number> from … to … with status …"
+  if [[ "$response" == Promoted\ * ]]; then
+    return 0
   fi
+  # ::error:: is a single-line workflow command: flatten the response in case it contains newlines (e.g. an HTML error page).
+  echo "::error title=Multi-repo promotion failed::Unexpected non-JSON response from the multiRepoPromote plugin: $(tr '\n' ' ' <<< "$response")" >&2
+  return 1
 }
 
 promote_mono() {

--- a/spec/promote_spec.sh
+++ b/spec/promote_spec.sh
@@ -17,7 +17,8 @@ EOF
     # Echo the invocation to stderr (not captured by the caller's `response=$(...)`)
     # so tests can still verify the exact URL that was requested.
     echo "jf $*" >&2
-    echo '{"status":"success"}'
+    # Matches multiRepoPromote.groovy success body (plain text, not JSON).
+    echo "Promoted dummy-project 42 from sonarsource-private-qa and sonarsource-public-qa to sonarsource-private-builds and sonarsource-public-builds with status it-passed"
   else
     echo "jf $*"
   fi
@@ -254,8 +255,21 @@ Describe 'promote_multi()'
     The status should be success
     The line 1 should equal "Promoting build dummy-project/$BUILD_NUMBER (version: 1.2.3.42)"
     The line 2 should equal "Target repositories: sonarsource-private-builds and sonarsource-public-builds"
-    The line 3 should equal '{"status":"success"}'
+    The line 3 should equal "Promoted dummy-project 42 from sonarsource-private-qa and sonarsource-public-qa to sonarsource-private-builds and sonarsource-public-builds with status it-passed"
     The error should match pattern "jf rt curl */multiRepoPromote?*;src1=*;target1=*;src2=*;target2=*"
+  End
+
+  It 'succeeds when the multiRepoPromote plugin returns a plain-text Promoted response'
+    Mock jf
+      echo "Promoted dummy-project 42 from sonarsource-private-qa and sonarsource-public-qa to sonarsource-private-dev and sonarsource-public-dev with status it-passed-pr"
+    End
+    export GITHUB_REF_NAME="main"
+    status='it-passed'
+    export PROJECT_VERSION="1.2.3.42"
+    get_target_repos
+    When call promote_multi
+    The status should be success
+    The line 3 should equal "Promoted dummy-project 42 from sonarsource-private-qa and sonarsource-public-qa to sonarsource-private-dev and sonarsource-public-dev with status it-passed-pr"
   End
 
   It 'fails when the multiRepoPromote plugin returns a non-JSON response'
@@ -402,7 +416,7 @@ Describe 'jfrog_promote()'
     The variable PROJECT_VERSION should equal "1.2.3.42"
     The line 1 should equal "Promoting build dummy-project/$BUILD_NUMBER (version: 1.2.3.42)"
     The line 2 should equal "Target repositories: sonarsource-private-builds and sonarsource-public-builds"
-    The line 3 should equal '{"status":"success"}'
+    The line 3 should equal "Promoted dummy-project 42 from sonarsource-private-qa and sonarsource-public-qa to sonarsource-private-builds and sonarsource-public-builds with status it-passed"
     The error should match pattern "jf rt curl */multiRepoPromote?*;src1=*;target1=*;src2=*;target2=*"
   End
 


### PR DESCRIPTION
## Summary
- **Regression in 1.8.6** ([#329](https://github.com/SonarSource/ci-github-actions/pull/329)): `promote_multi()` required a JSON object response, but [`multiRepoPromote.groovy`](https://github.com/SonarSource/re-tooling/blob/main/artifactory-user-plugins/multiRepoPromote/multiRepoPromote.groovy) returns plain text on success (`Promoted <build> <number> from …`).
- Concrete failure: [sonarqube-unification promote](https://github.com/SonarSource/sonarqube-unification/actions/runs/30024094006/job/89269791835) — artifacts were promoted, then the job failed with `Unexpected non-JSON response`.
- Fix: treat responses starting with `Promoted ` as success; still fail on JSON `errors` and other non-JSON bodies (e.g. `Bad Gateway`).
- Jira: [PREQ-7525](https://sonarsource.atlassian.net/browse/PREQ-7525)

## Test plan
- [x] `shellspec spec/promote_spec.sh --shell bash` (35 examples, 0 failures)
- [x] `shellcheck promote/promote.sh`
- [ ] CI on this PR
- [ ] After release `1.8.7` + `v1` update, re-run multi-repo promote (e.g. sonarqube-unification)

[PREQ-7525]: https://sonarsource.atlassian.net/browse/PREQ-7525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ