### PR TITLE
BUILD-12123 Route Develocity plugin resolution through Repox

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./config-npm
+      - uses: ./config-pip
       - uses: SonarSource/gh-action_pre-commit@2ddc0c7fdabce0adfaaa4075a17690972ed9961a # 1.2.0
         with:
           extra-args: >

--- a/config-gradle/action.yml
+++ b/config-gradle/action.yml
@@ -174,6 +174,11 @@ runs:
         develocity-plugin-version: '4.0'
         develocity-access-key: ${{ inputs.use-develocity == 'true' &&
           fromJSON(steps.secrets.outputs.vault).DEVELOCITY_TOKEN || '' }}
+        # Resolve Develocity plugin via Repox — plugins.gradle.org is blocked during registry brownouts.
+        gradle-plugin-repository-url: ${{ inputs.use-develocity == 'true' &&
+          format('{0}/artifactory/plugins.gradle.org/', inputs.repox-url) || '' }}
+        gradle-plugin-repository-username: ${{ inputs.use-develocity == 'true' && env.ARTIFACTORY_USERNAME || '' }}
+        gradle-plugin-repository-password: ${{ inputs.use-develocity == 'true' && env.ARTIFACTORY_ACCESS_TOKEN || '' }}
 
     - name: Generate Gradle Cache Key
       if: steps.config-gradle-completed.outputs.skip != 'true' && inputs.disable-caching != 'true'


### PR DESCRIPTION
BUILD-12123 Route Develocity plugin resolution through Repox

## Summary

- When `use-develocity: true`, `config-gradle` now passes `gradle-plugin-repository-url/username/password` to `setup-gradle`, pointing at `${repox-url}/artifactory/plugins.gradle.org/` with the Artifactory reader credentials.
- Fixes Develocity injection failing on `plugins.gradle.org` during the BUILD-10865 registry brownout (SSL/`PKIX`), as seen on sonarlint-intellij CI.
- Pre-commit workflow now runs `config-pip` before `gh-action_pre-commit` so pip upgrades resolve via Repox instead of `pypi.org`.

Related: [Slack thread](https://sonarsource.slack.com/archives/C04CVEU7734/p1785852448651779), [PREQ-7795](https://sonarsource.atlassian.net/browse/PREQ-7795)

## Test plan

- [ ] Confirm `config-gradle` with `use-develocity: true` resolves `develocity-gradle-plugin` from Repox (no request to `plugins.gradle.org`)
- [ ] Re-run / dogfood on a consumer such as sonarlint-intellij build that enables Develocity
- [ ] Confirm builds with `use-develocity: false` are unchanged
- [ ] Confirm pre-commit CI passes (pip upgrade via Repox)

[PREQ-7795]: https://sonarsource.atlassian.net/browse/PREQ-7795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ