### PR TITLE
PREQ-7838 Add Artifactory Env Exports to config-pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,9 +1240,12 @@ steps:
 
 ### Output Environment Variables
 
-| Environment Variable | Description              |
-|----------------------|--------------------------|
-| `BUILD_NUMBER`       | The current build number |
+| Environment Variable          | Description                                                         |
+|-------------------------------|---------------------------------------------------------------------|
+| `BUILD_NUMBER`                | The current build number                                            |
+| `ARTIFACTORY_ACCESS_TOKEN`    | Access token for Artifactory authentication                         |
+| `ARTIFACTORY_USERNAME`        | Username for Artifactory authentication                             |
+| `ARTIFACTORY_URL`             | Artifactory (Repox) URL. E.x.: `https://repox.jfrog.io/artifactory` |
 
 See also [`get-build-number`](#get-build-number) output environment variables.
 

--- a/config-pip/action.yml
+++ b/config-pip/action.yml
@@ -78,13 +78,20 @@ runs:
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} username | ARTIFACTORY_USERNAME;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-${{ env.ARTIFACTORY_READER_ROLE }} access_token | ARTIFACTORY_ACCESS_TOKEN;
 
-    - name: Run pip configuration script
-      id: config
+    - name: Set environment variables for Artifactory authentication
       shell: bash
       env:
         ARTIFACTORY_URL: ${{ format('{0}/artifactory', inputs.repox-url) }}
-        ARTIFACTORY_USERNAME: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME }}
-        ARTIFACTORY_ACCESS_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
+        ARTIFACTORY_USERNAME: ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USERNAME || '' }}
+        ARTIFACTORY_ACCESS_TOKEN: ${{ steps.secrets.outputs.vault && fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN || '' }}
+      run: |
+        echo "ARTIFACTORY_URL=$ARTIFACTORY_URL" >> "$GITHUB_ENV"
+        echo "ARTIFACTORY_USERNAME=$ARTIFACTORY_USERNAME" >> "$GITHUB_ENV"
+        echo "ARTIFACTORY_ACCESS_TOKEN=$ARTIFACTORY_ACCESS_TOKEN" >> "$GITHUB_ENV"
+
+    - name: Run pip configuration script
+      id: config
+      shell: bash
       run: $ACTION_PATH_CONFIG_PIP/config.sh
 
     - name: Sanitize workflow name for cache key


### PR DESCRIPTION
Part of RC-16

When using pip, a repo can have a Pipfile which needs to be routed through repox via the env.

Without this change, everywhere we call config-pip we also have to retrieve our own artifactory tokens and export them to the env.

This solves the problem centrally.