### PR TITLE
PREQ-7805 Fix config-pip README usage example order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1196,10 +1196,10 @@ permissions:
   contents: read
 steps:
   - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+  - uses: SonarSource/ci-github-actions/config-pip@v1
   - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
     with:
       python-version: 3.12
-  - uses: SonarSource/ci-github-actions/config-pip@v1
   - run: pip install pipenv
 ```
 


### PR DESCRIPTION
## Summary
- The `config-pip` `### Usage` example in README.md showed `actions/setup-python` running **before** `config-pip`. That order defeats the fix's purpose: `setup-python`'s own internal `pip install --upgrade pip` step still hits public `pypi.org` directly, before pip has been routed through Repox — which is exactly the SSL/PyPI-brownout failure reported in PREQ-7805.
- Swapped the order so `config-pip` runs first, matching the pattern already fixed in `SonarSource/sonardata-tools#59` and `SonarSource/gh-action_releasability#150`.
- Confirmed via repo-wide search that this was the only `setup-python` reference in the repo (README, workflows, or other actions' docs) — no other examples needed the same fix. `config-pip/action.yml` and `get-build-number/action.yml` were also checked: neither invokes `pip`/`python` themselves, so reordering is safe.

Jira: PREQ-7805

## Test plan
- [x] Doc-only change — verified rendered example order against the corrected pattern used in sonardata-tools#59 / gh-action_releasability#150